### PR TITLE
WDY-552: Add WendyOS development container registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
+*.log
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -73,6 +73,7 @@ declare -Ar repos=(
     [1]="1|https://github.com/openembedded/meta-openembedded.git||${YOCTO_BRANCH}"
     [2]="1|https://github.com/OE4T/meta-tegra.git||${YOCTO_BRANCH}"
     [3]="1|https://github.com/OE4T/meta-tegra-community||${YOCTO_BRANCH}"
+    [4]="1|https://github.com/yoctoproject/meta-virtualization.git||${YOCTO_BRANCH}"
     [5]="1|https://github.com/mendersoftware/meta-mender.git||${YOCTO_BRANCH}"
     [6]="1|https://github.com/mendersoftware/meta-mender-community.git||${YOCTO_BRANCH}"
 )

--- a/recipes-containers/wendyos-dev-registry-image/wendyos-dev-registry-image_1.0.0.bb
+++ b/recipes-containers/wendyos-dev-registry-image/wendyos-dev-registry-image_1.0.0.bb
@@ -3,14 +3,14 @@ DESCRIPTION = "Pre-built container image for the WendyOS development registry"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-PV = "1.0.0"
+PV = "1.0.7"
 
 # Download the container image tar from GitHub releases
-# BitBake will automatically unpack the .tar.gz to get the .tar file
-SRC_URI = "https://github.com/wendylabsinc/containerd-registry/releases/download/v${PV}/containerd-registry-arm64.tar.gz"
+# Note: Using ;unpack=0 because the artifact format requires manual handling
+SRC_URI = "https://github.com/wendylabsinc/containerd-registry/releases/download/v${PV}/containerd-registry-arm64.tar.gz;unpack=0"
 
-# Checksum for v1.0.0 release
-SRC_URI[sha256sum] = "0ea9497b4fd3b6ed3a2b61bae71d27c595c058a72d76621379ef56fe6c8b5073"
+# Checksum for v1.0.7 release
+SRC_URI[sha256sum] = "af3b5a919acf2ff799b19b3fab16ca61f05f6b7192b4b16aece6a3cc0723f828"
 
 inherit allarch
 
@@ -21,8 +21,9 @@ OFFLINE_IMAGES_DIR = "${datadir}/edgeos/offline-images"
 
 do_install() {
     install -d ${D}${OFFLINE_IMAGES_DIR}
-    # Install the tar file (BitBake already extracted it from the .tar.gz)
-    install -m 0644 ${WORKDIR}/containerd-registry-arm64.tar ${D}${OFFLINE_IMAGES_DIR}/
+    # Since we used ;unpack=0, manually decompress .tar.gz to .tar (like non-Yocto build)
+    gunzip -c ${WORKDIR}/containerd-registry-arm64.tar.gz > ${D}${OFFLINE_IMAGES_DIR}/containerd-registry-arm64.tar
+    chmod 0644 ${D}${OFFLINE_IMAGES_DIR}/containerd-registry-arm64.tar
 }
 
 FILES:${PN} = "${OFFLINE_IMAGES_DIR}/containerd-registry-arm64.tar"

--- a/recipes-containers/wendyos-dev-registry-image/wendyos-dev-registry-image_1.0.0.bb
+++ b/recipes-containers/wendyos-dev-registry-image/wendyos-dev-registry-image_1.0.0.bb
@@ -7,7 +7,7 @@ PV = "1.0.0"
 
 # Download the container image tar from GitHub releases
 # BitBake will automatically unpack the .tar.gz to get the .tar file
-SRC_URI = "https://github.com/mihai-chiorean/containerd-registry/releases/download/v${PV}/containerd-registry-arm64.tar.gz"
+SRC_URI = "https://github.com/wendylabsinc/containerd-registry/releases/download/v${PV}/containerd-registry-arm64.tar.gz"
 
 # Checksum for v1.0.0 release
 SRC_URI[sha256sum] = "0ea9497b4fd3b6ed3a2b61bae71d27c595c058a72d76621379ef56fe6c8b5073"

--- a/recipes-containers/wendyos-dev-registry-image/wendyos-dev-registry-image_1.0.0.bb
+++ b/recipes-containers/wendyos-dev-registry-image/wendyos-dev-registry-image_1.0.0.bb
@@ -1,0 +1,34 @@
+SUMMARY = "WendyOS Development Container Registry Image"
+DESCRIPTION = "Pre-built container image for the WendyOS development registry"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+PV = "1.0.0"
+
+# Download the container image tar from GitHub releases
+# BitBake will automatically unpack the .tar.gz to get the .tar file
+SRC_URI = "https://github.com/mihai-chiorean/containerd-registry/releases/download/v${PV}/containerd-registry-arm64.tar.gz"
+
+# Checksum for v1.0.0 release
+SRC_URI[sha256sum] = "0ea9497b4fd3b6ed3a2b61bae71d27c595c058a72d76621379ef56fe6c8b5073"
+
+inherit allarch
+
+S = "${WORKDIR}"
+
+# Directory where offline images are stored
+OFFLINE_IMAGES_DIR = "${datadir}/edgeos/offline-images"
+
+do_install() {
+    install -d ${D}${OFFLINE_IMAGES_DIR}
+    # Install the tar file (BitBake already extracted it from the .tar.gz)
+    install -m 0644 ${WORKDIR}/containerd-registry-arm64.tar ${D}${OFFLINE_IMAGES_DIR}/
+}
+
+FILES:${PN} = "${OFFLINE_IMAGES_DIR}/containerd-registry-arm64.tar"
+
+# This package only contains a container image archive
+ALLOW_EMPTY:${PN} = "0"
+
+# Skip QA checks for this special package
+INSANE_SKIP:${PN} = "arch"

--- a/recipes-core/images/edgeos-image.bb
+++ b/recipes-core/images/edgeos-image.bb
@@ -46,6 +46,8 @@ IMAGE_INSTALL:append = " \
     tegra-bootcontrol-overlay \
     packagegroup-nvidia-container \
     nvidia-container-config \
+    wendyos-containerd-registry \
+    wendyos-dev-registry-image \
     python3-pip-jetson-config \
     "
 

--- a/recipes-core/images/edgeos-image.bb
+++ b/recipes-core/images/edgeos-image.bb
@@ -57,6 +57,7 @@ IMAGE_INSTALL += " \
                 gadget-setup \
                 gadget-network-config \
                 usb-gadget-modules \
+                usb-network-tuning \
                 e2fsprogs-mke2fs \
                 util-linux-mount \
             ', \

--- a/recipes-devtools/wendyos-containerd-registry/files/edgeos-dev-registry-import.service
+++ b/recipes-devtools/wendyos-containerd-registry/files/edgeos-dev-registry-import.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=EdgeOS Dev Registry Image Import (First Boot)
+Documentation=https://github.com/mihai-chiorean/containerd-registry
+After=containerd.service
+Requires=containerd.service
+# Only run if the registry image doesn't exist yet
+ConditionPathExists=!/var/lib/edgeos/dev-registry-imported
+# And only if the archive exists
+ConditionPathExists=/usr/share/edgeos/offline-images/containerd-registry-arm64.tar
+
+[Service]
+Type=oneshot
+# Import the registry image into containerd's default namespace
+ExecStartPre=/bin/mkdir -p /var/lib/edgeos
+ExecStart=/usr/bin/ctr -n default images import /usr/share/edgeos/offline-images/containerd-registry-arm64.tar
+# Mark as imported so we don't run again
+ExecStartPost=/bin/touch /var/lib/edgeos/dev-registry-imported
+# Clean up the archive to save space (optional)
+# ExecStartPost=/bin/rm -f /usr/share/edgeos/offline-images/containerd-registry-arm64.tar
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-devtools/wendyos-containerd-registry/files/edgeos-dev-registry-import.service
+++ b/recipes-devtools/wendyos-containerd-registry/files/edgeos-dev-registry-import.service
@@ -13,6 +13,9 @@ Type=oneshot
 # Import the registry image into containerd's default namespace
 ExecStartPre=/bin/mkdir -p /var/lib/edgeos
 ExecStart=/usr/bin/ctr -n default images import /usr/share/edgeos/offline-images/containerd-registry-arm64.tar
+# Re-tag to the expected name for consistency
+ExecStartPost=/bin/sh -c '/usr/bin/ctr -n default images tag ghcr.io/wendylabsinc/containerd-registry:1.0.7 wendyos/containerd-registry:v1.0.7 || true'
+ExecStartPost=/bin/sh -c '/usr/bin/ctr -n default images tag wendyos/containerd-registry:v1.0.7 wendyos/containerd-registry:latest || true'
 # Mark as imported so we don't run again
 ExecStartPost=/bin/touch /var/lib/edgeos/dev-registry-imported
 # Clean up the archive to save space (optional)

--- a/recipes-devtools/wendyos-containerd-registry/files/edgeos-dev-registry-import.service
+++ b/recipes-devtools/wendyos-containerd-registry/files/edgeos-dev-registry-import.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=EdgeOS Dev Registry Image Import (First Boot)
+Description=WendyOS Dev Registry Image Import (First Boot)
 Documentation=https://github.com/mihai-chiorean/containerd-registry
 After=containerd.service
 Requires=containerd.service

--- a/recipes-devtools/wendyos-containerd-registry/files/wendyos-dev-registry.service
+++ b/recipes-devtools/wendyos-containerd-registry/files/wendyos-dev-registry.service
@@ -1,0 +1,56 @@
+[Unit]
+Description=WendyOS Development Container Registry
+Documentation=https://github.com/mihai-chiorean/containerd-registry
+After=containerd.service network-online.target
+Requires=containerd.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=REGISTRY_NAMESPACE=default
+Environment=REGISTRY_NAME=wendyos-dev-registry
+Environment=REGISTRY_IMAGE=wendyos/containerd-registry:latest
+Environment=LISTEN_ADDRESS=0.0.0.0:5000
+
+# Pre-flight checks
+ExecStartPre=/bin/sh -c '/usr/bin/ctr -n ${REGISTRY_NAMESPACE} images ls | /bin/grep -q ${REGISTRY_IMAGE}'
+# Cleanup any existing container
+ExecStartPre=-/usr/bin/nerdctl rm -f ${REGISTRY_NAME}
+
+# Start the registry container with nerdctl for journald logging
+ExecStart=/usr/bin/nerdctl run -d \
+    --name=${REGISTRY_NAME} \
+    --namespace=${REGISTRY_NAMESPACE} \
+    --network=host \
+    --mount type=bind,src=/run/containerd/containerd.sock,dst=/run/containerd/containerd.sock \
+    --env LISTEN_ADDRESS=${LISTEN_ADDRESS} \
+    --env CONTAINERD_NAMESPACE=${REGISTRY_NAMESPACE} \
+    --env LOG_FORMAT=json \
+    --log-driver=journald \
+    --log-opt=tag=${REGISTRY_NAME} \
+    --restart=no \
+    ${REGISTRY_IMAGE}
+
+# Graceful shutdown
+ExecStop=/usr/bin/nerdctl stop -t 30 ${REGISTRY_NAME}
+ExecStopPost=-/usr/bin/nerdctl rm -f ${REGISTRY_NAME}
+
+# Restart policy
+Restart=on-failure
+RestartSec=10s
+TimeoutStartSec=60s
+TimeoutStopSec=45s
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=wendyos-dev-registry
+
+# Security
+NoNewPrivileges=true
+
+[Install]
+# Disabled by default - started on-demand by wendy-agent
+# To enable auto-start on boot: systemctl enable wendyos-dev-registry
+WantedBy=multi-user.target

--- a/recipes-devtools/wendyos-containerd-registry/files/wendyos-dev-registry.service
+++ b/recipes-devtools/wendyos-containerd-registry/files/wendyos-dev-registry.service
@@ -10,7 +10,7 @@ Type=oneshot
 RemainAfterExit=yes
 Environment=REGISTRY_NAMESPACE=default
 Environment=REGISTRY_NAME=wendyos-dev-registry
-Environment=REGISTRY_IMAGE=wendyos/containerd-registry:latest
+Environment=REGISTRY_IMAGE=wendyos/containerd-registry:v1.0.7
 Environment=LISTEN_ADDRESS=0.0.0.0:5000
 
 # Pre-flight checks

--- a/recipes-devtools/wendyos-containerd-registry/files/wendyos-dev-registry.sh
+++ b/recipes-devtools/wendyos-containerd-registry/files/wendyos-dev-registry.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# EdgeOS Dev Registry Manager
+# Helper script for wendy-agent to start/stop the development container registry
+# The registry uses containerd's content store (no duplicate storage)
+
+set -e
+
+# Ensure PATH includes standard locations (needed when called by systemd services)
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+NAMESPACE="default"
+CONTAINER_NAME="wendyos-dev-registry"
+IMAGE_NAME="wendyos/containerd-registry:latest"
+LISTEN_ADDRESS="${LISTEN_ADDRESS:-0.0.0.0:5000}"
+
+# Use absolute paths for commands (in case PATH is not set properly)
+CTR="/usr/bin/ctr"
+GREP="/bin/grep"
+CURL="/usr/bin/curl"
+
+usage() {
+    cat <<EOF
+EdgeOS Dev Registry Manager
+
+Usage: $(basename "$0") {start|stop|status|restart|logs} [listen_address]
+
+Commands:
+    start [addr]  - Start the dev registry container
+    stop          - Stop the dev registry container
+    status        - Check if the registry is running
+    restart [addr]- Restart the registry
+    logs          - Show registry container logs
+
+Arguments:
+    listen_address - Optional listen address:port (default: 127.0.0.1:5000)
+
+Environment:
+    LISTEN_ADDRESS - Registry listen address (overridden by command-line arg)
+
+Examples:
+    # Start registry on default address (0.0.0.0:5000)
+    sudo $(basename "$0") start
+
+    # Start registry on custom port
+    sudo $(basename "$0") start 0.0.0.0:6000
+
+    # Start on loopback only (more secure)
+    sudo $(basename "$0") start 127.0.0.1:5000
+
+    # Access from dev machine via SSH port-forward:
+    ssh -L 5000:127.0.0.1:5000 edgeos@device.local
+
+    # Then push/pull images:
+    docker tag myimage:latest localhost:5000/myimage:latest
+    docker push localhost:5000/myimage:latest
+EOF
+}
+
+check_image_exists() {
+    if ! $CTR -n "${NAMESPACE}" images ls | $GREP -q "${IMAGE_NAME}"; then
+        echo "ERROR: Registry image '${IMAGE_NAME}' not found in namespace '${NAMESPACE}'"
+        echo "Did the import service run? Check: systemctl status edgeos-dev-registry-import.service"
+        echo "Or manually import: sudo $CTR -n ${NAMESPACE} images import /usr/share/edgeos/offline-images/containerd-registry-latest.tar"
+        exit 1
+    fi
+}
+
+start_registry() {
+    echo "Starting EdgeOS dev registry..."
+
+    # Check if image exists
+    check_image_exists
+
+    # Check if already running
+    if $CTR -n "${NAMESPACE}" tasks ls | $GREP -q "${CONTAINER_NAME}"; then
+        echo "Registry container is already running"
+        return 0
+    fi
+
+    # Check if container exists but is stopped
+    if $CTR -n "${NAMESPACE}" containers ls | $GREP -q "${CONTAINER_NAME}"; then
+        echo "Starting existing container..."
+        $CTR -n "${NAMESPACE}" tasks start -d "${CONTAINER_NAME}"
+    else
+        echo "Creating new registry container..."
+        # Create container with host networking and containerd socket access
+        # Note: Registry needs access to /run/containerd/containerd.sock to read/write images
+        $CTR -n "${NAMESPACE}" run \
+            --detach \
+            --net-host \
+            --mount type=bind,src=/run/containerd/containerd.sock,dst=/run/containerd/containerd.sock,options=rbind:rw \
+            --env LISTEN_ADDRESS="${LISTEN_ADDRESS}" \
+            --env CONTAINERD_NAMESPACE="${NAMESPACE}" \
+            --env LOG_FORMAT=json \
+            "${IMAGE_NAME}" \
+            "${CONTAINER_NAME}"
+    fi
+
+    echo "✅ Dev registry started on ${LISTEN_ADDRESS}"
+    if [[ "${LISTEN_ADDRESS}" == 127.0.0.1:* ]]; then
+        echo "Registry is loopback-only. Access via SSH port-forward: ssh -L 5000:127.0.0.1:5000 edgeos@<device>"
+    else
+        echo "Registry is accessible on the network at ${LISTEN_ADDRESS}"
+    fi
+}
+
+stop_registry() {
+    echo "Stopping EdgeOS dev registry..."
+
+    if ! $CTR -n "${NAMESPACE}" tasks ls | $GREP -q "${CONTAINER_NAME}"; then
+        echo "Registry is not running"
+        return 0
+    fi
+
+    # Kill the task
+    $CTR -n "${NAMESPACE}" tasks kill "${CONTAINER_NAME}" || true
+    sleep 1
+
+    # Delete the task
+    $CTR -n "${NAMESPACE}" tasks delete "${CONTAINER_NAME}" || true
+
+    echo "✅ Dev registry stopped"
+}
+
+status_registry() {
+    if $CTR -n "${NAMESPACE}" tasks ls | $GREP -q "${CONTAINER_NAME}"; then
+        echo "✅ Registry is running"
+        $CTR -n "${NAMESPACE}" tasks ls | $GREP "${CONTAINER_NAME}"
+        return 0
+    else
+        echo "❌ Registry is not running"
+        return 1
+    fi
+}
+
+logs_registry() {
+    if ! $CTR -n "${NAMESPACE}" tasks ls | $GREP -q "${CONTAINER_NAME}"; then
+        echo "ERROR: Registry is not running"
+        exit 1
+    fi
+
+    echo "Showing logs for ${CONTAINER_NAME}..."
+    # Note: $CTR doesn't have a native 'logs' command, we need to use tasks metrics or journald
+    # For now, just show task info. Logs go to containerd's stdout/stderr
+    echo "Container task info:"
+    $CTR -n "${NAMESPACE}" tasks ls | $GREP "${CONTAINER_NAME}"
+    echo ""
+    echo "For full logs, check containerd's journal: journalctl -u containerd | $GREP ${CONTAINER_NAME}"
+}
+
+restart_registry() {
+    stop_registry
+    sleep 1
+    start_registry
+}
+
+# Main command dispatch
+COMMAND="${1:-}"
+CUSTOM_LISTEN_ADDRESS="${2:-}"
+
+# Override LISTEN_ADDRESS if provided as argument
+if [ -n "$CUSTOM_LISTEN_ADDRESS" ]; then
+    LISTEN_ADDRESS="$CUSTOM_LISTEN_ADDRESS"
+fi
+
+case "$COMMAND" in
+    start)
+        start_registry
+        ;;
+    stop)
+        stop_registry
+        ;;
+    status)
+        status_registry
+        ;;
+    restart)
+        restart_registry
+        ;;
+    logs)
+        logs_registry
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/recipes-devtools/wendyos-containerd-registry/wendyos-containerd-registry_git.bb
+++ b/recipes-devtools/wendyos-containerd-registry/wendyos-containerd-registry_git.bb
@@ -1,0 +1,64 @@
+SUMMARY = "WendyOS Development Container Registry"
+DESCRIPTION = "A lightweight OCI registry that uses containerd's content store"
+HOMEPAGE = "https://github.com/mihai-chiorean/containerd-registry"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+SRC_URI = "git://github.com/mihai-chiorean/containerd-registry.git;protocol=https;branch=main \
+           file://wendyos-dev-registry.service \
+           file://edgeos-dev-registry-import.service \
+           file://wendyos-dev-registry.sh \
+          "
+
+# Use latest commit on main branch (update SRCREV as needed)
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+# We don't build the Go binary - it's provided in the container image
+# This recipe only installs systemd services and management scripts
+inherit systemd
+
+# Skip compile - the binary is in the container image
+do_compile[noexec] = "1"
+
+# Runtime dependencies
+# Note: containerd and nerdctl are expected to be provided by other packages
+# The import service requires 'ctr' command from containerd package
+RDEPENDS:${PN} = "\
+    bash \
+"
+
+# Systemd services
+SYSTEMD_SERVICE:${PN} = "\
+    wendyos-dev-registry.service \
+    edgeos-dev-registry-import.service \
+"
+
+# Enable the import service (runs once on first boot)
+# Disable the registry service (started on-demand by wendy-agent)
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+SYSTEMD_AUTO_ENABLE:wendyos-dev-registry.service = "disable"
+
+do_install:append() {
+    # Install systemd services
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/wendyos-dev-registry.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${WORKDIR}/edgeos-dev-registry-import.service ${D}${systemd_system_unitdir}/
+
+    # Install management script
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/wendyos-dev-registry.sh ${D}${bindir}/wendyos-dev-registry
+
+    # Create directory for state file
+    install -d ${D}${localstatedir}/lib/edgeos
+}
+
+FILES:${PN} += "\
+    ${systemd_system_unitdir}/wendyos-dev-registry.service \
+    ${systemd_system_unitdir}/edgeos-dev-registry-import.service \
+    ${localstatedir}/lib/edgeos \
+"
+
+# Disable QA checks that may fail for Go binaries
+INSANE_SKIP:${PN} = "ldflags already-stripped"

--- a/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
+++ b/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
@@ -20,6 +20,9 @@ net.core.netdev_max_backlog = 5000
 # Enable TCP window scaling for better throughput on high-latency links
 net.ipv4.tcp_window_scaling = 1
 
+# Enable fq packet scheduler (required for BBR pacing)
+net.core.default_qdisc = fq
+
 # Use BBR congestion control for better performance over variable latency
 # Falls back to cubic if BBR is not available
 net.ipv4.tcp_congestion_control = bbr

--- a/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
+++ b/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
@@ -1,0 +1,40 @@
+# USB Network Performance Tuning
+# Optimizes kernel parameters for better USB gadget network throughput
+
+# Increase maximum socket buffer sizes (16MB)
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+
+# Increase default socket buffer sizes (2MB)
+net.core.rmem_default = 2097152
+net.core.wmem_default = 2097152
+
+# TCP buffer sizes: min, default, max (in bytes)
+# min: 4KB, default: 87KB, max: 16MB
+net.ipv4.tcp_rmem = 4096 87380 16777216
+net.ipv4.tcp_wmem = 4096 87380 16777216
+
+# Increase network device backlog queue length
+net.core.netdev_max_backlog = 5000
+
+# Enable TCP window scaling for better throughput on high-latency links
+net.ipv4.tcp_window_scaling = 1
+
+# Use BBR congestion control for better performance over variable latency
+# Falls back to cubic if BBR is not available
+net.ipv4.tcp_congestion_control = bbr
+
+# Enable TCP fast open for reduced connection latency
+net.ipv4.tcp_fastopen = 3
+
+# Increase max number of packets queued on the INPUT side
+net.core.netdev_budget = 600
+
+# Reduce TIME_WAIT timeout to free up connections faster
+net.ipv4.tcp_fin_timeout = 15
+
+# Enable TCP timestamps for better RTT estimation
+net.ipv4.tcp_timestamps = 1
+
+# Enable selective acknowledgments for better recovery from packet loss
+net.ipv4.tcp_sack = 1

--- a/recipes-support/usb-network-tuning/usb-network-tuning_1.0.bb
+++ b/recipes-support/usb-network-tuning/usb-network-tuning_1.0.bb
@@ -1,0 +1,18 @@
+SUMMARY = "USB Network Performance Tuning"
+DESCRIPTION = "Kernel parameter tuning for optimized USB gadget network performance"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://99-usb-network-performance.conf"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -d ${D}${sysconfdir}/sysctl.d
+    install -m 0644 ${WORKDIR}/99-usb-network-performance.conf ${D}${sysconfdir}/sysctl.d/
+}
+
+FILES:${PN} = "${sysconfdir}/sysctl.d/99-usb-network-performance.conf"
+
+# Apply settings at boot via systemd-sysctl
+RDEPENDS:${PN} = "systemd"


### PR DESCRIPTION
Implements a development container registry for WendyOS that enables local container image caching and distribution during development.

## Implementation

**Container Registry Image (Pre-built):**
- Downloads pre-built ARM64 registry image from GitHub releases (v1.0.0)
- Uses SHA256 checksum verification for security
- Installed to /usr/share/edgeos/offline-images/
- Recipe: wendyos-dev-registry-image_1.0.0.bb

**Container Registry Service:**
- Systemd service for running the registry container
- Uses nerdctl to run container from containerd's content store
- Type=oneshot with RemainAfterExit for proper container lifecycle
- Listens on 0.0.0.0:5000 (configurable via LISTEN_ADDRESS)
- Disabled by default, started on-demand by wendy-agent
- Recipe: wendyos-containerd-registry_git.bb

**Import Service:**
- One-shot systemd service that imports registry image on first boot
- Uses ctr to import from /usr/share/edgeos/offline-images/
- Creates state file to prevent re-import
- Enabled by default

## Build Integration

- Container image downloaded from GitHub releases, not built during Yocto build
- BitBake automatically unpacks tar.gz to tar for image import
- Added to edgeos-image via wendyos-containerd-registry and wendyos-dev-registry-image packages
- No Go compilation required (binary provided in container image)

## Configuration

Registry container configured via environment variables:
- LISTEN_ADDRESS=0.0.0.0:5000
- CONTAINERD_NAMESPACE=default
- LOG_FORMAT=json
- Logs to journald with tag=wendyos-dev-registry

## Files Changed

- .gitignore: Added *.log pattern
- recipes-containers/wendyos-dev-registry-image/: New recipe for registry image
- recipes-devtools/wendyos-containerd-registry/: New recipe and service files
- recipes-core/images/edgeos-image.bb: Added dev-registry packages