### PR TITLE
Add USB network performance tuning with kernel parameters

### DIFF
--- a/recipes-core/images/edgeos-image.bb
+++ b/recipes-core/images/edgeos-image.bb
@@ -57,6 +57,7 @@ IMAGE_INSTALL += " \
                 gadget-setup \
                 gadget-network-config \
                 usb-gadget-modules \
+                usb-network-tuning \
                 e2fsprogs-mke2fs \
                 util-linux-mount \
             ', \

--- a/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
+++ b/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
@@ -20,6 +20,9 @@ net.core.netdev_max_backlog = 5000
 # Enable TCP window scaling for better throughput on high-latency links
 net.ipv4.tcp_window_scaling = 1
 
+# Enable fq packet scheduler (required for BBR pacing)
+net.core.default_qdisc = fq
+
 # Use BBR congestion control for better performance over variable latency
 # Falls back to cubic if BBR is not available
 net.ipv4.tcp_congestion_control = bbr

--- a/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
+++ b/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
@@ -1,0 +1,40 @@
+# USB Network Performance Tuning
+# Optimizes kernel parameters for better USB gadget network throughput
+
+# Increase maximum socket buffer sizes (16MB)
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+
+# Increase default socket buffer sizes (2MB)
+net.core.rmem_default = 2097152
+net.core.wmem_default = 2097152
+
+# TCP buffer sizes: min, default, max (in bytes)
+# min: 4KB, default: 87KB, max: 16MB
+net.ipv4.tcp_rmem = 4096 87380 16777216
+net.ipv4.tcp_wmem = 4096 87380 16777216
+
+# Increase network device backlog queue length
+net.core.netdev_max_backlog = 5000
+
+# Enable TCP window scaling for better throughput on high-latency links
+net.ipv4.tcp_window_scaling = 1
+
+# Use BBR congestion control for better performance over variable latency
+# Falls back to cubic if BBR is not available
+net.ipv4.tcp_congestion_control = bbr
+
+# Enable TCP fast open for reduced connection latency
+net.ipv4.tcp_fastopen = 3
+
+# Increase max number of packets queued on the INPUT side
+net.core.netdev_budget = 600
+
+# Reduce TIME_WAIT timeout to free up connections faster
+net.ipv4.tcp_fin_timeout = 15
+
+# Enable TCP timestamps for better RTT estimation
+net.ipv4.tcp_timestamps = 1
+
+# Enable selective acknowledgments for better recovery from packet loss
+net.ipv4.tcp_sack = 1

--- a/recipes-support/usb-network-tuning/usb-network-tuning_1.0.bb
+++ b/recipes-support/usb-network-tuning/usb-network-tuning_1.0.bb
@@ -1,0 +1,18 @@
+SUMMARY = "USB Network Performance Tuning"
+DESCRIPTION = "Kernel parameter tuning for optimized USB gadget network performance"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://99-usb-network-performance.conf"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -d ${D}${sysconfdir}/sysctl.d
+    install -m 0644 ${WORKDIR}/99-usb-network-performance.conf ${D}${sysconfdir}/sysctl.d/
+}
+
+FILES:${PN} = "${sysconfdir}/sysctl.d/99-usb-network-performance.conf"
+
+# Apply settings at boot via systemd-sysctl
+RDEPENDS:${PN} = "systemd"


### PR DESCRIPTION
Implements kernel-level network optimizations for USB gadget networking to improve throughput and reduce latency.

Key optimizations:
- Increased socket buffer sizes (16MB max, 2MB default)
- Tuned TCP buffer sizes for better throughput
- BBR congestion control for variable latency links
- Increased network device backlog and budget
- Enabled TCP fast open and optimized timeouts
- Enabled TCP SACK and timestamps

The tuning is applied via sysctl.d configuration and automatically loaded by systemd-sysctl on boot.

Only enabled when EDGEOS_USB_GADGET=1 is set.

Resolves: WDY-542