### PR TITLE
Adopt NetworkManager as the network management system

### DIFF
--- a/conf/distro/edgeos.conf
+++ b/conf/distro/edgeos.conf
@@ -13,6 +13,13 @@ require conf/distro/include/flash-image-sizes.inc
 require systemd.conf
 require conf/distro/include/l4t-r36-4-4.conf
 
+# Network management with NetworkManager
+DISTRO_FEATURES:append = " networkmanager"
+VIRTUAL-RUNTIME_net_manager = "networkmanager"
+
+# Optional: Use systemd-resolved for DNS (alternative to dnsmasq)
+# DISTRO_FEATURES:append = " resolved"
+
 # Enable automatic data partition growth on first boot
 # This allows the data partition to expand to use all available disk space
 MENDER_FEATURES_ENABLE:append = " mender-growfs-data"

--- a/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/recipes-connectivity/avahi/avahi_%.bbappend
@@ -1,3 +1,4 @@
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
@@ -6,12 +7,16 @@ SRC_URI += " \
     file://edgeos-hostname.service \
     file://nsswitch.conf.append \
     file://90-edgeos.preset \
-"
+    "
+
 # Ensure D-Bus support is enabled for proper service publishing
 PACKAGECONFIG += "dbus"
 
 # Ensure Avahi compiles with static service file support
-EXTRA_OECONF += "--with-avahi-user=avahi --with-avahi-group=avahi"
+EXTRA_OECONF += " \
+    --with-avahi-user=avahi \
+    --with-avahi-group=avahi \
+    "
 
 inherit systemd
 
@@ -23,41 +28,44 @@ do_install:append() {
     # Install Avahi service file
     install -d ${D}${sysconfdir}/avahi/services
     install -m 0644 ${WORKDIR}/edgeos-mdns.service ${D}${sysconfdir}/avahi/services/
-    
+
     # Install systemd service for hostname setup
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/edgeos-hostname.service ${D}${systemd_system_unitdir}/
 
     # Ensure NSS mDNS is properly configured
-    if [ -f ${D}${sysconfdir}/nsswitch.conf ]; then
+    if [ -f "${D}${sysconfdir}/nsswitch.conf" ]
+    then
         # Check if mdns is already configured
-        if ! grep -q "mdns" ${D}${sysconfdir}/nsswitch.conf; then
+        if ! grep -q "mdns" "${D}${sysconfdir}/nsswitch.conf"
+        then
             # Replace the hosts line with our configuration
-            sed -i '/^hosts:/d' ${D}${sysconfdir}/nsswitch.conf
-            cat ${WORKDIR}/nsswitch.conf.append >> ${D}${sysconfdir}/nsswitch.conf
+            sed -i '/^hosts:/d' "${D}${sysconfdir}/nsswitch.conf"
+            cat "${WORKDIR}/nsswitch.conf.append" >> "${D}${sysconfdir}/nsswitch.conf"
         fi
     fi
 
     # Enable Avahi daemon and ensure it starts with proper settings
-    if [ -f ${D}${sysconfdir}/avahi/avahi-daemon.conf ]; then
+    if [ -f "${D}${sysconfdir}/avahi/avahi-daemon.conf" ]
+    then
         # Enable D-Bus support for proper service publishing
-        sed -i 's/^#*enable-dbus=.*/enable-dbus=yes/' ${D}${sysconfdir}/avahi/avahi-daemon.conf
+        sed -i 's/^#*enable-dbus=.*/enable-dbus=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
 
         # Enable mDNS reflector for better discovery
-        sed -i 's/^#*enable-reflector=.*/enable-reflector=yes/' ${D}${sysconfdir}/avahi/avahi-daemon.conf
+        sed -i 's/^#*enable-reflector=.*/enable-reflector=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
 
         # Set proper hostname behavior
-        sed -i 's/^#*use-ipv4=.*/use-ipv4=yes/' ${D}${sysconfdir}/avahi/avahi-daemon.conf
-        sed -i 's/^#*use-ipv6=.*/use-ipv6=yes/' ${D}${sysconfdir}/avahi/avahi-daemon.conf
+        sed -i 's/^#*use-ipv4=.*/use-ipv4=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
+        sed -i 's/^#*use-ipv6=.*/use-ipv6=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
 
         # Enable publishing
-        sed -i 's/^#*publish-addresses=.*/publish-addresses=yes/' ${D}${sysconfdir}/avahi/avahi-daemon.conf
-        sed -i 's/^#*publish-hinfo=.*/publish-hinfo=yes/' ${D}${sysconfdir}/avahi/avahi-daemon.conf
-        sed -i 's/^#*publish-workstation=.*/publish-workstation=yes/' ${D}${sysconfdir}/avahi/avahi-daemon.conf
-        sed -i 's/^#*publish-domain=.*/publish-domain=yes/' ${D}${sysconfdir}/avahi/avahi-daemon.conf
+        sed -i 's/^#*publish-addresses=.*/publish-addresses=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
+        sed -i 's/^#*publish-hinfo=.*/publish-hinfo=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
+        sed -i 's/^#*publish-workstation=.*/publish-workstation=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
+        sed -i 's/^#*publish-domain=.*/publish-domain=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
 
         # Set host name
-        sed -i 's/^#*host-name=.*/# host-name is set dynamically by edgeos-hostname.service/' ${D}${sysconfdir}/avahi/avahi-daemon.conf
+        sed -i 's/^#*host-name=.*/# host-name is set dynamically by edgeos-hostname.service/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
     fi
 
     # Systemd preset to auto-enable hostname service by default
@@ -75,7 +83,7 @@ FILES:${PN}-edgeos-hostname = " \
     ${sbindir}/generate-hostname.sh \
     ${systemd_system_unitdir}/edgeos-hostname.service \
     ${systemd_unitdir}/system-preset/90-edgeos.preset \
-"
+    "
 
 RDEPENDS:${PN}-edgeos-hostname = "bash iproute2 systemd avahi-daemon"
 SYSTEMD_SERVICE:${PN}-edgeos-hostname = "edgeos-hostname.service"
@@ -83,7 +91,8 @@ SYSTEMD_AUTO_ENABLE:${PN}-edgeos-hostname = "enable"
 
 # Postinstall hook: safety net in case preset doesn't run at image build time
 pkg_postinst:${PN}-edgeos-hostname () {
-    if [ -z "$D" ]; then
+    if [ -z "$D" ]
+    then
         systemctl enable edgeos-hostname.service || true
         systemctl start  edgeos-hostname.service || true
     fi

--- a/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
@@ -1,0 +1,9 @@
+# Enable DBus support for NetworkManager integration
+# NetworkManager's connection sharing (ipv4.method=shared) requires
+# dnsmasq with DBus support to provide DHCP service
+
+PACKAGECONFIG:append = " dbus"
+
+# Disable the system-wide dnsmasq.service
+# NetworkManager will spawn its own dnsmasq instances as needed
+SYSTEMD_AUTO_ENABLE = "disable"

--- a/recipes-connectivity/networkmanager/files/00-manage-usb0.conf
+++ b/recipes-connectivity/networkmanager/files/00-manage-usb0.conf
@@ -1,0 +1,5 @@
+# Ensure usb0 USB gadget interface is managed by NetworkManager
+# By default, NetworkManager may not manage certain interface types
+[keyfile]
+# Don't set any interfaces as unmanaged (manage all by default)
+unmanaged-devices=

--- a/recipes-connectivity/networkmanager/files/10-usb-gadget-shared.conf
+++ b/recipes-connectivity/networkmanager/files/10-usb-gadget-shared.conf
@@ -1,0 +1,19 @@
+# Configuration for USB gadget connection sharing
+
+[device-usb-gadget]
+# Ensure usb0 is managed by NetworkManager
+match-device=interface-name:usb0
+managed=true
+
+[main]
+# Use internal DHCP server instead of dnsmasq (dnsmasq lacks DBus support)
+dns=default
+
+[ipv4]
+# DHCP range for connection sharing
+# NetworkManager's dnsmasq will serve DHCP on shared connections
+dhcp-timeout=300
+
+[ipv6]
+# IPv6 configuration for link-local
+method=link-local

--- a/recipes-connectivity/networkmanager/files/10-usb-gadget-shared.conf
+++ b/recipes-connectivity/networkmanager/files/10-usb-gadget-shared.conf
@@ -6,7 +6,7 @@ match-device=interface-name:usb0
 managed=true
 
 [main]
-# Use internal DHCP server instead of dnsmasq (dnsmasq lacks DBus support)
+# Use default DNS handling (dnsmasq spawned by NM for connection sharing)
 dns=default
 
 [ipv4]

--- a/recipes-connectivity/networkmanager/files/NetworkManager.conf
+++ b/recipes-connectivity/networkmanager/files/NetworkManager.conf
@@ -1,0 +1,31 @@
+[main]
+# Use traditional DNS management (not systemd-resolved)
+dns=default
+
+# Manage /etc/resolv.conf directly
+rc-manager=file
+
+# Enable plugins
+plugins=keyfile
+
+# Don't manage lo (loopback)
+no-auto-default=lo
+
+# Enable connectivity checking (optional, can disable to save bandwidth)
+connectivity.enabled=false
+
+[logging]
+# Log level: ERR, WARN, INFO, DEBUG
+level=INFO
+
+# Log to systemd journal
+backend=journal
+
+[device]
+# Automatically manage all devices by default
+# Specific interfaces can be excluded in connection profiles
+wifi.scan-rand-mac-address=no
+
+[connection]
+# Set default connection timeout
+connection.auth-retries=0

--- a/recipes-connectivity/networkmanager/files/usb-gadget.nmconnection
+++ b/recipes-connectivity/networkmanager/files/usb-gadget.nmconnection
@@ -1,0 +1,24 @@
+[connection]
+id=usb-gadget
+uuid=12345678-1234-1234-1234-123456789abc
+type=ethernet
+interface-name=usb0
+autoconnect=true
+autoconnect-priority=100
+wait-device-timeout=60000
+
+[ethernet]
+mac-address-blacklist=
+
+[ipv4]
+method=shared
+address1=10.42.0.1/24
+dns-search=
+# Connection sharing enables built-in DHCP server (via dnsmasq internally)
+# DHCP range will be automatically assigned from 10.42.0.0/24 subnet
+
+[ipv6]
+method=link-local
+addr-gen-mode=stable-privacy
+
+[proxy]

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -36,5 +36,5 @@ FILES:${PN} += " \
 # Ensure NetworkManager starts after USB gadget is set up
 SYSTEMD_AUTO_ENABLE = "enable"
 
-# Dependencies
-RDEPENDS:${PN} += "networkmanager"
+# dnsmasq required for connection sharing (ipv4.method=shared)
+RDEPENDS:${PN} += "dnsmasq"

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,40 @@
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Install NetworkManager configuration files
+SRC_URI += " \
+    file://NetworkManager.conf \
+    file://00-manage-usb0.conf \
+    file://10-usb-gadget-shared.conf \
+    file://usb-gadget.nmconnection \
+    "
+
+# Install main NetworkManager configuration
+do_install:append() {
+    # Install main config
+    install -d ${D}${sysconfdir}/NetworkManager
+    install -m 0644 ${WORKDIR}/NetworkManager.conf ${D}${sysconfdir}/NetworkManager/NetworkManager.conf
+
+    # Install NetworkManager config drop-ins
+    install -d ${D}${sysconfdir}/NetworkManager/conf.d
+    install -m 0644 ${WORKDIR}/00-manage-usb0.conf ${D}${sysconfdir}/NetworkManager/conf.d/00-manage-usb0.conf
+    install -m 0644 ${WORKDIR}/10-usb-gadget-shared.conf ${D}${sysconfdir}/NetworkManager/conf.d/10-usb-gadget-shared.conf
+
+    # Install system connections (USB gadget profile)
+    install -d ${D}${sysconfdir}/NetworkManager/system-connections
+    install -m 0600 ${WORKDIR}/usb-gadget.nmconnection ${D}${sysconfdir}/NetworkManager/system-connections/usb-gadget.nmconnection
+}
+
+# Make sure our config files are packaged
+FILES:${PN} += " \
+    ${sysconfdir}/NetworkManager/NetworkManager.conf \
+    ${sysconfdir}/NetworkManager/conf.d/00-manage-usb0.conf \
+    ${sysconfdir}/NetworkManager/conf.d/10-usb-gadget-shared.conf \
+    ${sysconfdir}/NetworkManager/system-connections/usb-gadget.nmconnection \
+    "
+
+# Ensure NetworkManager starts after USB gadget is set up
+SYSTEMD_AUTO_ENABLE = "enable"
+
+# Dependencies
+RDEPENDS:${PN} += "networkmanager"

--- a/recipes-core/images/edgeos-image.bb
+++ b/recipes-core/images/edgeos-image.bb
@@ -57,7 +57,6 @@ IMAGE_INSTALL += " \
         d.getVar('EDGEOS_USB_GADGET') == '1', \
             ' \
                 gadget-setup \
-                gadget-network-config \
                 usb-gadget-modules \
                 usb-network-tuning \
                 e2fsprogs-mke2fs \
@@ -66,6 +65,9 @@ IMAGE_INSTALL += " \
             '' \
         )} \
     "
+
+# Note: gadget-network-config (standalone dnsmasq) removed
+# NetworkManager's connection sharing provides DHCP via dnsmasq with DBus support
 
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "", d)}"

--- a/recipes-core/packagegroups/packagegroup-edgeos-base.bb
+++ b/recipes-core/packagegroups/packagegroup-edgeos-base.bb
@@ -15,6 +15,9 @@ RDEPENDS:${PN} = " \
     file \
     util-linux \
     iproute2 \
+    lsof \
+    networkmanager \
+    networkmanager-nmcli \
     vim \
     htop \
     usbutils \

--- a/recipes-core/systemd/gadget-setup/gadget-setup.service
+++ b/recipes-core/systemd/gadget-setup/gadget-setup.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=USB Gadget setup (NCM)
 After=local-fs.target
-Before=network.target
+Before=NetworkManager.service network.target
+Wants=NetworkManager.service
 
 [Service]
 Type=oneshot

--- a/recipes-core/systemd/gadget-setup/gadget-setup.sh
+++ b/recipes-core/systemd/gadget-setup/gadget-setup.sh
@@ -89,11 +89,7 @@ done
 
 echo "$UDC" > UDC
 
-# Bring link up with static IP (DHCP to host handled by dnsmasq service)
-ip addr add 10.42.0.1/24 dev "$NET_IF" 2>/dev/null || true
-ip link set "$NET_IF" up 2>/dev/null || true
-
-# Kick dnsmasq (dedicated unit below) now that usb0 exists
-systemctl try-restart gadget-dnsmasq.service 2>/dev/null || true
-
-echo "Gadget ready: $SEL on $NET_IF (10.42.0.1/24), UDC=$UDC"
+# USB gadget interface will be configured by NetworkManager
+# NetworkManager will handle IP configuration and connection sharing
+echo "Gadget ready: $SEL on $NET_IF, UDC=$UDC"
+echo "NetworkManager will configure network settings"

--- a/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
+++ b/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
@@ -41,3 +41,17 @@ net.ipv4.tcp_timestamps = 1
 
 # Enable selective acknowledgments for better recovery from packet loss
 net.ipv4.tcp_sack = 1
+
+# Don't cache TCP metrics from previous connections
+net.ipv4.tcp_no_metrics_save = 1
+
+# TCP memory allocation: min, pressure, max (in pages)
+net.ipv4.tcp_mem = 786432 1048576 26777216
+
+# Maximum number of pending connections
+net.core.somaxconn = 1024
+
+# IPv6 forwarding (for radvd if used)
+net.ipv6.conf.all.forwarding = 1
+net.ipv6.conf.default.forwarding = 1
+net.ipv6.conf.usb0.forwarding = 1


### PR DESCRIPTION
Integrate NetworkManager to provide centralized, dynamic network management, replacing the previous minimal script-based approach.

USB gadget networking adapted to NetworkManager:
- Configure USB gadget connection profile (usb0)
- Use connection sharing for DHCP service (10.42.0.1/24)
- Update gadget-setup to delegate IP configuration to NetworkManager
- Remove gadget-network-config package (replaced by NetworkManager)