### PR TITLE
container: add libcufile and sysfs entries for GPU containers

### DIFF
--- a/recipes-core/packagegroups/packagegroup-nvidia-container.bb
+++ b/recipes-core/packagegroups/packagegroup-nvidia-container.bb
@@ -72,6 +72,7 @@ RDEPENDS:${PN} = " \
     cusparselt \
     tensorrt-core \
     tensorrt-plugins \
+    libcufile \
     "
 
 # Note: cuda-libraries likely includes:

--- a/recipes-support/nvidia-container-config/files/devices-platform.csv
+++ b/recipes-support/nvidia-container-config/files/devices-platform.csv
@@ -1,0 +1,7 @@
+# Tegra platform information (required for GPU driver initialization)
+dir, /sys/devices/soc0
+dir, /sys/devices/soc1
+dir, /proc/device-tree
+
+# CPU information (for cpuinfo library)
+dir, /sys/devices/system/cpu

--- a/recipes-support/nvidia-container-config/nvidia-container-config_1.0.bb
+++ b/recipes-support/nvidia-container-config/nvidia-container-config_1.0.bb
@@ -7,6 +7,7 @@ inherit systemd
 
 SRC_URI = " \
     file://l4t.csv \
+    file://devices-platform.csv \
     file://edgeos-cdi-generate.service \
     file://edgeos-cuda-detect.service \
     file://generate-cuda-env.sh \
@@ -19,9 +20,10 @@ SYSTEMD_SERVICE:${PN} = "edgeos-cdi-generate.service edgeos-cuda-detect.service"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 do_install() {
-    # Install l4t.csv to the NVIDIA container runtime config directory
+    # Install CSV files to the NVIDIA container runtime config directory
     install -d ${D}${sysconfdir}/nvidia-container-runtime/host-files-for-container.d
     install -m 0644 ${WORKDIR}/l4t.csv ${D}${sysconfdir}/nvidia-container-runtime/host-files-for-container.d/
+    install -m 0644 ${WORKDIR}/devices-platform.csv ${D}${sysconfdir}/nvidia-container-runtime/host-files-for-container.d/
 
     # Install CUDA environment detection script
     install -d ${D}${bindir}
@@ -41,6 +43,7 @@ do_install() {
 }
 
 FILES:${PN} += "${sysconfdir}/nvidia-container-runtime/host-files-for-container.d/l4t.csv"
+FILES:${PN} += "${sysconfdir}/nvidia-container-runtime/host-files-for-container.d/devices-platform.csv"
 FILES:${PN} += "${bindir}/generate-cuda-env.sh"
 FILES:${PN} += "${systemd_system_unitdir}/edgeos-cdi-generate.service"
 FILES:${PN} += "${systemd_system_unitdir}/edgeos-cuda-detect.service"


### PR DESCRIPTION
- Add libcufile (GPUDirect Storage) to packagegroup-nvidia-container Required by PyTorch containers that use GPU storage operations. Fixes: libcufile.so.0: cannot open shared object file

- Add devices-sysfs.csv with Tegra platform information:
  - /sys/devices/soc0, /sys/devices/soc1 (GPU driver init)
  - /proc/device-tree (platform detection)
  - /sys/devices/system/cpu (cpuinfo library)