### PR TITLE
Fix mDNS device ID format for macOS app discovery

### DIFF
--- a/recipes-connectivity/avahi/files/edgeos-mdns.service
+++ b/recipes-connectivity/avahi/files/edgeos-mdns.service
@@ -47,6 +47,7 @@
   <service>
     <type>_wendyos._udp</type>
     <port>50051</port>
+    <txt-record>id=DEVICE_ID_PLACEHOLDER</txt-record>
     <txt-record>wendyosdevice=SOME_DEVICE_ID</txt-record>
     <txt-record>name=DEVICE_NAME_PLACEHOLDER</txt-record>
     <txt-record>displayname=DEVICE_DISPLAYNAME_PLACEHOLDER</txt-record>

--- a/recipes-core/edgeos-identity/files/update-mdns-uuid.sh
+++ b/recipes-core/edgeos-identity/files/update-mdns-uuid.sh
@@ -38,8 +38,14 @@ DEVICE_NAME=$(cat "$DEVICE_NAME_FILE" 2>/dev/null || echo "unknown-device")
 # Generate display name (Title Case with spaces)
 DISPLAY_NAME=$(echo "$DEVICE_NAME" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2));}1')
 
+# Generate device ID for macOS app discovery (format: "WendyOS Device <device-name>")
+DEVICE_ID="WendyOS Device $DEVICE_NAME"
+
 # Replace SOME_DEVICE_ID with actual UUID
 sed -i "s/SOME_DEVICE_ID/$UUID/g" "$SERVICE_FILE"
+
+# Replace device ID placeholder (for macOS app discovery)
+sed -i "s/DEVICE_ID_PLACEHOLDER/$DEVICE_ID/g" "$SERVICE_FILE"
 
 # Replace device name placeholders
 sed -i "s/DEVICE_NAME_PLACEHOLDER/$DEVICE_NAME/g" "$SERVICE_FILE"


### PR DESCRIPTION
Add 'id' TXT record to _wendyos._udp service in format:
  id=WendyOS Device <device-name>

This matches the format expected by the macOS WendyOS app for LAN device discovery.