### PR TITLE
USB gadget improvements for better connectivity and device discovery

### DIFF
--- a/conf/distro/edgeos.conf
+++ b/conf/distro/edgeos.conf
@@ -28,7 +28,7 @@ DISTRO = "edgeos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "edgeOS Linux platform"
-DISTRO_VERSION = "0.1.0"
+DISTRO_VERSION = "0.10.0"
 DISTRO_CODENAME = "scarthgap"
 
 SDK_VENDOR = "-edgeossdk"

--- a/recipes-core/edgeos-motd/files/30-services
+++ b/recipes-core/edgeos-motd/files/30-services
@@ -33,5 +33,7 @@ check_service "systemd-resolved" "DNS"
 check_service "usb-gadget" "USB Gadget"
 check_service "avahi-daemon" "mDNS"
 check_service "systemd-timesyncd" "Time Sync"
+check_service "edge-agent" "Edge Agent"
+check_service "wendyos-dev-registry" "Dev Registry"
 
 echo

--- a/recipes-core/gadget-setup/files/gadget-setup.sh
+++ b/recipes-core/gadget-setup/files/gadget-setup.sh
@@ -1,23 +1,64 @@
 #!/bin/sh
 
-# Make the Jetson present itself as a USB NIC:
-# - Prefer NCM (Linux/Win11/macOS new); fall back to ECM (macOS-friendly)
-# - Give the host an automatic IP via dnsmasq (through a separate service)
+# USB Gadget Setup for WendyOS
+# Configures NCM (Network Control Model) USB gadget with optimized settings
+# Compatible with Linux, Windows 11, and macOS
 #
 set -eu
 
-G=/sys/kernel/config/usb_gadget/g1
+G=/sys/kernel/config/usb_gadget/edgeos_device
 NET_IF=usb0
 UDC=$(ls /sys/class/udc | head -n1 || true)
 
-USB_VID=${USB_VID:-0x1d6b}          # Linux Foundation
-USB_PID=${USB_PID:-0x0104}          # Multifunction composite
-USB_SERIAL=${USB_SERIAL:-0123456789}
-USB_MFR=${USB_MFR:-NVIDIA}
-USB_PROD=${USB_PROD:-"edgeOS USB Network"}   # Shown on host as adapter description
-CFG_NAME=${CFG_NAME:-"USB Networking"}
+# USB Device Identification
+USB_VID=${USB_VID:-0x1d6b}           # Linux Foundation
+USB_PID=${USB_PID:-0x0104}           # Multifunction Composite Gadget
+USB_MFR=${USB_MFR:-"Wendy Labs Inc"}
+CFG_NAME=${CFG_NAME:-"NCM Network"}
 MAX_PWR=${MAX_PWR:-250}
 GADGET_FUNC_ORDER="${GADGET_FUNC_ORDER:-ncm ecm}"
+
+# Get device serial number
+DEVICE_SERIAL=""
+if [ -f /proc/device-tree/serial-number ]; then
+    DEVICE_SERIAL=$(cat /proc/device-tree/serial-number 2>/dev/null | tr -d '\0')
+fi
+if [ -z "$DEVICE_SERIAL" ]; then
+    DEVICE_SERIAL=$(cat /sys/devices/platform/tegra-fuse/uid 2>/dev/null || echo "")
+fi
+if [ -z "$DEVICE_SERIAL" ]; then
+    DEVICE_SERIAL=$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d ':' || date +%s)
+fi
+USB_SERIAL=${USB_SERIAL:-$DEVICE_SERIAL}
+
+# Get friendly device name if available
+if [ -f /etc/edgeos/device-name ]; then
+    DEVICE_NAME=$(cat /etc/edgeos/device-name | tr -d '[:space:]')
+    USB_PROD=${USB_PROD:-"WendyOS Device ${DEVICE_NAME}"}
+else
+    SHORT_SERIAL=${DEVICE_SERIAL: -8}
+    USB_PROD=${USB_PROD:-"WendyOS Device ${SHORT_SERIAL}"}
+fi
+
+# Generate MAC address from input string (locally administered)
+generate_mac() {
+    local input="$1"
+    local hash=$(echo -n "$input" | md5sum | awk '{print $1}')
+    local mac_base=${hash:0:12}
+    local first_byte=${mac_base:0:2}
+    local second_char=$(printf '%x' $((0x$first_byte & 0xfe | 0x02)))
+    printf "%02x:%02x:%02x:%02x:%02x:%02x" \
+       0x$second_char \
+       0x${mac_base:2:2} \
+       0x${mac_base:4:2} \
+       0x${mac_base:6:2} \
+       0x${mac_base:8:2} \
+       0x${mac_base:10:2}
+}
+
+# Generate stable MAC addresses from device serial
+MAC_HOST=$(generate_mac "${DEVICE_SERIAL}-host")
+MAC_DEV=$(generate_mac "${DEVICE_SERIAL}-dev")
 
 # Clean previous gadget if any
 if [ -d "$G" ]; then
@@ -40,6 +81,22 @@ cd "$G"
 echo "$USB_VID" > idVendor
 echo "$USB_PID" > idProduct
 
+# Detect USB controller and set USB version
+# Jetson Orin uses 3550000.usb (tegra-xudc), check via symlink target path
+USB_VERSION="0x0200"  # Default USB 2.0
+UDC_LINK=$(ls -la /sys/class/udc/ 2>/dev/null | head -2 | tail -1)
+if echo "$UDC_LINK" | grep -qE "dwc3|tegra|3550000"; then
+    USB_VERSION="0x0320"  # USB 3.2
+    echo "Detected USB 3.x capable controller - enabling USB 3.2 mode"
+fi
+echo "$USB_VERSION" > bcdUSB
+echo "0x0100" > bcdDevice
+
+# Device class for composite device (IAD)
+echo 0xEF > bDeviceClass      # Miscellaneous
+echo 0x02 > bDeviceSubClass   # Common Class
+echo 0x01 > bDeviceProtocol   # Interface Association Descriptor
+
 mkdir -p strings/0x409
 echo "$USB_SERIAL" > strings/0x409/serialnumber
 echo "$USB_MFR"    > strings/0x409/manufacturer
@@ -48,19 +105,23 @@ echo "$USB_PROD"   > strings/0x409/product
 mkdir -p configs/c.1/strings/0x409
 echo "$CFG_NAME" > configs/c.1/strings/0x409/configuration
 echo "$MAX_PWR"  > configs/c.1/MaxPower
+echo 0xC0 > configs/c.1/bmAttributes  # Self-powered
 
 add_func() {
     case "$1" in
     ncm)
         mkdir -p functions/ncm.usb0 2>/dev/null || return 1
+        echo "$MAC_HOST" > functions/ncm.usb0/host_addr 2>/dev/null || true
+        echo "$MAC_DEV" > functions/ncm.usb0/dev_addr 2>/dev/null || true
+        # Performance tuning: increase queue multiplier (default 5, use 10 for ~2x throughput)
+        echo 10 > functions/ncm.usb0/qmult 2>/dev/null || true
         ln -sf functions/ncm.usb0 configs/c.1/
         return 0
         ;;
     ecm)
         mkdir -p functions/ecm.usb0 2>/dev/null || return 1
-        # Stable MACs help some hosts cache correctly
-        echo 02:1A:11:00:00:01 > functions/ecm.usb0/dev_addr 2>/dev/null || true
-        echo 02:1A:11:00:00:02 > functions/ecm.usb0/host_addr 2>/dev/null || true
+        echo "$MAC_HOST" > functions/ecm.usb0/host_addr 2>/dev/null || true
+        echo "$MAC_DEV" > functions/ecm.usb0/dev_addr 2>/dev/null || true
         ln -sf functions/ecm.usb0 configs/c.1/
         return 0
         ;;
@@ -89,7 +150,21 @@ done
 
 echo "$UDC" > UDC
 
-# USB gadget interface will be configured by NetworkManager
-# NetworkManager will handle IP configuration and connection sharing
-echo "Gadget ready: $SEL on $NET_IF, UDC=$UDC"
+# Wait for interface to appear
+sleep 1
+
+# Apply network interface performance tuning
+if ip link show "$NET_IF" >/dev/null 2>&1; then
+    # Set TX queue length for better burst handling (default ~1000, use 2000)
+    ip link set "$NET_IF" txqueuelen 2000 2>/dev/null || true
+fi
+
+# Optimize USB IRQ affinity for Jetson (pin to CPUs 0-3)
+USB_IRQ=$(grep -E "3550000\.usb|tegra-xudc" /proc/interrupts 2>/dev/null | cut -d: -f1 | tr -d ' ' | head -1)
+if [ -n "$USB_IRQ" ]; then
+    echo "0f" > /proc/irq/$USB_IRQ/smp_affinity 2>/dev/null || true
+fi
+
+echo "Gadget ready: $SEL on $NET_IF, UDC=$UDC, USB=$USB_VERSION"
+echo "USB Product: $USB_PROD"
 echo "NetworkManager will configure network settings"

--- a/recipes-kernel/linux/linux-jammy-nvidia-tegra/usb-gadget-builtin.cfg
+++ b/recipes-kernel/linux/linux-jammy-nvidia-tegra/usb-gadget-builtin.cfg
@@ -6,12 +6,19 @@ CONFIG_USB_GADGET=y
 CONFIG_USB_LIBCOMPOSITE=y
 CONFIG_USB_CONFIGFS=y
 
-# Pick your needed functions
-CONFIG_USB_CONFIGFS_ECM=y      # Ethernet over USB (ECM)
-CONFIG_USB_CONFIGFS_ACM=y      # Serial (CDC ACM)
-# Optional extras:
-# CONFIG_USB_CONFIGFS_RNDIS=y
-# CONFIG_USB_CONFIGFS_MASS_STORAGE=y
-# CONFIG_USB_CONFIGFS_F_FS=y
-# CONFIG_USB_CONFIGFS_F_HID=y
+# USB Network function drivers (built-in)
+CONFIG_USB_F_NCM=y
+CONFIG_USB_F_ECM=y
+
+# USB ConfigFS selectors
+CONFIG_USB_CONFIGFS_NCM=y      # NCM (preferred for Linux/Win11/macOS)
+CONFIG_USB_CONFIGFS_ECM=y      # ECM (fallback)
+
+# Serial console functions (for /dev/ttyGS0 if needed)
+# Generic serial - shows as ttyUSB on host
+CONFIG_USB_F_SERIAL=y
+CONFIG_USB_CONFIGFS_SERIAL=y
+# ACM - shows as ttyACM on host (better Windows/macOS support)
+CONFIG_USB_F_ACM=y
+CONFIG_USB_CONFIGFS_ACM=y
 

--- a/recipes-kernel/linux/linux-jammy-nvidia-tegra/usb-gadget.cfg
+++ b/recipes-kernel/linux/linux-jammy-nvidia-tegra/usb-gadget.cfg
@@ -1,4 +1,3 @@
-
 # Filesystem already present, but keep here for clarity
 CONFIG_CONFIGFS_FS=y
 
@@ -7,7 +6,19 @@ CONFIG_USB_GADGET=y
 CONFIG_USB_LIBCOMPOSITE=m
 CONFIG_USB_CONFIGFS=m
 
-CONFIG_USB_CONFIGFS_ECM=m
-CONFIG_USB_CONFIGFS_ACM=m
-# Add more if you need them: RNDIS/MASS_STORAGE/etc.
+# USB Network function modules (actual .ko files)
+CONFIG_USB_F_NCM=m
+CONFIG_USB_F_ECM=m
+
+# USB ConfigFS selectors (bool, not tristate)
+CONFIG_USB_CONFIGFS_NCM=y
+CONFIG_USB_CONFIGFS_ECM=y
+
+# Serial console functions (for /dev/ttyGS0 if needed)
+# Generic serial - shows as ttyUSB on host
+CONFIG_USB_F_SERIAL=m
+CONFIG_USB_CONFIGFS_SERIAL=y
+# ACM - shows as ttyACM on host (better Windows/macOS support)
+CONFIG_USB_F_ACM=m
+CONFIG_USB_CONFIGFS_ACM=y
 

--- a/recipes-kernel/usb-gadget-modules/usb-gadget-modules/usb-gadget.conf
+++ b/recipes-kernel/usb-gadget-modules/usb-gadget-modules/usb-gadget.conf
@@ -1,4 +1,4 @@
-
+# USB Gadget modules for WendyOS
 libcomposite
 u_ether
 usb_f_ncm


### PR DESCRIPTION
- gadget-setup.sh: Add L4T-style optimizations (qmult=10, txqueuelen=2000, IRQ affinity)
- gadget-setup.sh: Use device serial for stable MAC addresses across reboots
- gadget-setup.sh: Add USB 3.2 detection for Jetson Orin (3550000.usb)
- gadget-setup.sh: Change USB product name to "WendyOS Device" format for client grouping
- usb-gadget.cfg: Add explicit USB_F_NCM/ECM/SERIAL kernel module configs
- usb-gadget-builtin.cfg: Same kernel module configs for builtin version