### PR TITLE
Add deepstream support

### DIFF
--- a/conf/distro/edgeos.conf
+++ b/conf/distro/edgeos.conf
@@ -28,7 +28,7 @@ DISTRO = "edgeos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "edgeOS Linux platform"
-DISTRO_VERSION = "0.10.0"
+DISTRO_VERSION = "0.10.2"
 DISTRO_CODENAME = "scarthgap"
 
 SDK_VENDOR = "-edgeossdk"

--- a/recipes-containers/containerd-config/containerd-config_1.0.bb
+++ b/recipes-containers/containerd-config/containerd-config_1.0.bb
@@ -26,4 +26,5 @@ FILES:${PN} += "\
     ${docdir}/${PN}/README-memory-limits.md \
 "
 
-RDEPENDS:${PN} = "containerd"
+# Note: No RDEPENDS needed - this just provides config files
+# containerd-opencontainers will be pulled in by other packages (k3s-agent, etc.)

--- a/recipes-containers/containerd-config/containerd-config_1.0.bb
+++ b/recipes-containers/containerd-config/containerd-config_1.0.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Containerd global memory limit configuration"
+DESCRIPTION = "Configures containerd with a global 7.4GB memory limit for ALL containers combined to prevent device lockup"
+
+inherit systemd
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = "\
+    file://containerd-memory-limit.conf \
+    file://README-memory-limits.md \
+"
+
+do_install() {
+    # Install systemd drop-in to limit total containerd memory
+    install -d ${D}${systemd_system_unitdir}/containerd.service.d
+    install -m 0644 ${WORKDIR}/containerd-memory-limit.conf ${D}${systemd_system_unitdir}/containerd.service.d/memory-limit.conf
+
+    install -d ${D}${docdir}/${PN}
+    install -m 0644 ${WORKDIR}/README-memory-limits.md ${D}${docdir}/${PN}/README-memory-limits.md
+}
+
+FILES:${PN} += "\
+    ${systemd_system_unitdir}/containerd.service.d/memory-limit.conf \
+    ${docdir}/${PN}/README-memory-limits.md \
+"
+
+RDEPENDS:${PN} = "containerd"

--- a/recipes-containers/containerd-config/files/README-memory-limits.md
+++ b/recipes-containers/containerd-config/files/README-memory-limits.md
@@ -1,0 +1,152 @@
+# Container Memory Limits Configuration
+
+## Overview
+
+This system enforces a **global memory limit of 7.4GB for ALL containers combined** to prevent device lockup:
+
+- **Total Memory**: ~7.6GB
+- **System Reserved**: ~200MB for OS (kernel, systemd, essential services)
+- **Containerd + All Containers**: 7.4GB maximum
+- **Swap File**: 4GB (`/data/swapfile`) for temporary spikes
+
+## How It Works
+
+The containerd service is configured with systemd cgroup limits:
+
+- **MemoryMax=7.4G**: Hard limit - containerd killed if exceeded
+- **MemoryHigh=6.5G**: Soft limit - throttling begins at this threshold
+- **Swap Available**: 4GB additional buffer for memory pressure
+
+This means **all running containers share the 7.4GB pool**. Individual containers are NOT limited separately.
+
+## Configuration
+
+The limit is enforced via systemd drop-in:
+- **File**: `/etc/systemd/system/containerd.service.d/memory-limit.conf`
+- **Applied to**: containerd daemon and all child containers
+
+## Monitoring Memory Usage
+
+### Check Total Container Memory
+```bash
+# View all containers memory usage
+nerdctl stats
+
+# Check containerd cgroup memory
+systemctl status containerd
+cat /sys/fs/cgroup/system.slice/containerd.service/memory.current
+cat /sys/fs/cgroup/system.slice/containerd.service/memory.max
+```
+
+### Check System Memory
+```bash
+# Overall system memory
+free -h
+
+# Swap usage
+swapon --show
+
+# Memory pressure
+cat /sys/fs/cgroup/system.slice/containerd.service/memory.pressure
+```
+
+## What Happens When Limit is Reached
+
+1. **At 6.5GB (MemoryHigh)**: Containerd and containers are throttled
+2. **At 7.4GB (MemoryMax)**:
+   - If swap available: System uses swap (up to 4GB)
+   - If swap full: containerd service is killed by OOM killer
+   - Containers are stopped gracefully
+
+## Managing Container Memory
+
+Since all containers share 7.4GB:
+
+### Running Fewer Containers
+Better to run 2-3 memory-intensive containers than many small ones:
+```bash
+# Good: 2 containers using 3GB each = 6GB total
+nerdctl run -d --name ml-model1 myimage
+nerdctl run -d --name ml-model2 myimage
+
+# Bad: 10 containers using 800MB each = 8GB total (exceeds limit!)
+```
+
+### Monitoring Before Launch
+Check available memory before starting new containers:
+```bash
+# Check current usage
+USED=$(nerdctl stats --no-stream --format "{{.MemUsage}}" | awk '{sum+=$1} END {print sum}')
+echo "Currently using: ${USED}GB of 7.4GB"
+```
+
+### Setting Individual Container Limits (Optional)
+While not enforced, you can still use memory flags for documentation:
+```bash
+# Request 2GB for this container (advisory only)
+nerdctl run --memory="2g" myimage
+```
+
+## Troubleshooting
+
+### Containerd Service Killed
+If you see containerd restart unexpectedly:
+```bash
+# Check if OOM killed it
+journalctl -xeu containerd | grep -i "killed\|oom"
+
+# View memory usage history
+systemd-cgtop
+```
+
+**Solution**: Stop some containers to free memory
+
+### Containers Running Slow
+If containers are throttled (>6.5GB total):
+```bash
+# Check memory pressure
+cat /sys/fs/cgroup/system.slice/containerd.service/memory.pressure
+```
+
+**Solution**:
+- Stop non-critical containers
+- Wait for swap to help during temporary spikes
+
+### Out of Memory (OOM) Events
+```bash
+# Check kernel OOM logs
+dmesg | grep -i "out of memory\|oom"
+
+# Check swap usage
+free -h
+```
+
+**Solution**: Reduce total container memory footprint
+
+## Best Practices
+
+1. **Monitor Total Usage**: Keep combined container memory under 6GB for headroom
+2. **Use Swap Wisely**: 4GB swap is for temporary spikes, not steady state
+3. **Stop Unused Containers**: Free memory immediately
+4. **Plan Container Mix**: Know each container's memory needs before launching
+5. **Test Under Load**: Ensure your container mix fits within 7.4GB limit
+
+## Configuration Files
+
+- Systemd drop-in: `/etc/systemd/system/containerd.service.d/memory-limit.conf`
+- Swap file: `/data/swapfile` (4GB)
+- This README: `/usr/share/doc/containerd-config/README-memory-limits.md`
+
+## Adjusting the Limit
+
+To change the global limit, edit the systemd drop-in and reload:
+```bash
+# Edit the limit
+vi /etc/systemd/system/containerd.service.d/memory-limit.conf
+
+# Reload systemd
+systemctl daemon-reload
+
+# Restart containerd
+systemctl restart containerd
+```

--- a/recipes-containers/containerd-config/files/containerd-memory-limit.conf
+++ b/recipes-containers/containerd-config/files/containerd-memory-limit.conf
@@ -1,0 +1,20 @@
+# Systemd drop-in for containerd.service
+# Limits total memory usage for ALL containers combined to 7.4GB
+#
+# This prevents device lockup by constraining the total memory that
+# containerd and all its child containers can consume together.
+#
+# Device Memory: ~7.6GB total
+# System Reserved: ~200MB for OS (kernel, systemd, etc)
+# Containerd+Containers: 7.4GB maximum
+# Swap: 4GB available for temporary spikes
+
+[Service]
+# Hard limit: Kill containerd if ALL containers together exceed 7.4GB
+MemoryMax=7.4G
+
+# Soft limit: Start throttling at 6.5GB to avoid hitting hard limit
+MemoryHigh=6.5G
+
+# Memory accounting must be enabled
+MemoryAccounting=yes

--- a/recipes-core/images/edgeos-image.bb
+++ b/recipes-core/images/edgeos-image.bb
@@ -74,6 +74,18 @@ IMAGE_INSTALL += " \
 # Note: gadget-network-config (standalone dnsmasq) removed
 # NetworkManager's connection sharing provides DHCP via dnsmasq with DBus support
 
+# Enable DeepStream SDK support (optional - adds ~1GB to image)
+EDGEOS_DEEPSTREAM ?= "0"
+IMAGE_INSTALL += " \
+    ${@oe.utils.ifelse( \
+        d.getVar('EDGEOS_DEEPSTREAM') == '1', \
+            ' \
+                deepstream-7.1 \
+            ', \
+            '' \
+        )} \
+    "
+
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "", d)}"
 
@@ -84,4 +96,5 @@ BUILDCFG_VARS += " \
     EDGEOS_DEBUG_UART \
     EDGEOS_USB_GADGET \
     EDGEOS_PERSIST_JOURNAL_LOGS \
+    EDGEOS_DEEPSTREAM \
     "

--- a/recipes-core/packagegroups/packagegroup-edgeos-base.bb
+++ b/recipes-core/packagegroups/packagegroup-edgeos-base.bb
@@ -33,6 +33,8 @@ RDEPENDS:${PN} = " \
     edgeos-user \
     edgeos-motd \
     systemd-mount-containerd \
+    swapfile-setup \
+    containerd-config \
     "
 
 RDEPENDS:${PN}:append = " \

--- a/recipes-core/packagegroups/packagegroup-edgeos-debug.bb
+++ b/recipes-core/packagegroups/packagegroup-edgeos-debug.bb
@@ -20,6 +20,7 @@ RDEPENDS:${PN} = " \
             sysstat \
             ldd \
             bc  \
+            python3-jetson-stats \
         ', \
         '' \
         )} \

--- a/recipes-core/packagegroups/packagegroup-nvidia-container.bb
+++ b/recipes-core/packagegroups/packagegroup-nvidia-container.bb
@@ -87,6 +87,7 @@ RDEPENDS:${PN} += "${@bb.utils.contains('EDGEOS_DEEPSTREAM', '1', ' \
     tegra-libraries-nvdsseimeta \
     libgstnvcustomhelper \
     yaml-cpp-070 \
+    tensorrt-trtexec-prebuilt \
     ', '', d)}"
 
 # Note: cuda-libraries likely includes:

--- a/recipes-core/packagegroups/packagegroup-nvidia-container.bb
+++ b/recipes-core/packagegroups/packagegroup-nvidia-container.bb
@@ -51,7 +51,7 @@ inherit packagegroup
 # - nvidia-container-toolkit (nvidia-ctk for CDI generation)
 # - nvidia-container-runtime
 
-# Core packages required for l4t.csv container support
+# Core packages required for l4t.csv container support (always included)
 RDEPENDS:${PN} = " \
     nvidia-container-config \
     nvidia-container-toolkit \
@@ -63,17 +63,31 @@ RDEPENDS:${PN} = " \
     cuda-nvrtc \
     cuda-nvtx \
     cuda-cupti \
+    tegra-libraries-core \
     tegra-libraries-cuda \
     tegra-libraries-multimedia \
     tegra-libraries-multimedia-utils \
+    tegra-libraries-multimedia-v4l \
     tegra-libraries-nvsci \
     tegra-libraries-camera \
+    tegra-libraries-eglcore \
+    tegra-libraries-glescore \
     cudnn \
     cusparselt \
     tensorrt-core \
     tensorrt-plugins \
     libcufile \
     "
+
+# DeepStream-specific packages (only when EDGEOS_DEEPSTREAM=1)
+# These provide libraries needed by DeepStream GStreamer plugins
+EDGEOS_DEEPSTREAM ?= "0"
+RDEPENDS:${PN} += "${@bb.utils.contains('EDGEOS_DEEPSTREAM', '1', ' \
+    tegra-libraries-multimedia-ds \
+    tegra-libraries-nvdsseimeta \
+    libgstnvcustomhelper \
+    yaml-cpp-070 \
+    ', '', d)}"
 
 # Note: cuda-libraries likely includes:
 #  - cuBLAS (cublas, cublasLt)

--- a/recipes-core/swapfile-setup/files/data-swapfile.swap
+++ b/recipes-core/swapfile-setup/files/data-swapfile.swap
@@ -1,0 +1,14 @@
+[Unit]
+Description=/data/swapfile
+Documentation=man:systemd.swap(5)
+# Require swapfile-setup service to run first
+Requires=swapfile-setup.service
+After=swapfile-setup.service
+
+[Swap]
+What=/data/swapfile
+Options=sw
+Priority=-2
+
+[Install]
+WantedBy=swap.target

--- a/recipes-core/swapfile-setup/files/swapfile-setup.service
+++ b/recipes-core/swapfile-setup/files/swapfile-setup.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Setup swap file on data partition
+Documentation=man:swapon(8)
+# Ensure data partition is mounted and filesystem is fully expanded
+RequiresMountsFor=/data
+After=data.mount mender-systemd-growfs-data.service
+Before=swap.target
+DefaultDependencies=no
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/swapfile-setup.sh
+TimeoutSec=300
+
+[Install]
+WantedBy=swap.target

--- a/recipes-core/swapfile-setup/files/swapfile-setup.sh
+++ b/recipes-core/swapfile-setup/files/swapfile-setup.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Setup 4GB swap file on /data partition
+
+SWAPFILE="/data/swapfile"
+SWAPSIZE_MB=4096
+
+# Verify /data is mounted
+if ! mountpoint -q /data; then
+    echo "ERROR: /data is not mounted, cannot create swap file"
+    exit 1
+fi
+
+# Check if swap file already exists and is active
+if [ -f "$SWAPFILE" ] && swapon --show | grep -q "$SWAPFILE"; then
+    echo "Swap file $SWAPFILE already active"
+    exit 0
+fi
+
+# Create swap file if it doesn't exist
+if [ ! -f "$SWAPFILE" ]; then
+    echo "Creating ${SWAPSIZE_MB}MB swap file at $SWAPFILE..."
+
+    # Check available space on /data
+    AVAILABLE_MB=$(df -BM /data | tail -1 | awk '{print $4}' | sed 's/M//')
+    if [ "$AVAILABLE_MB" -lt "$((SWAPSIZE_MB + 1024))" ]; then
+        echo "ERROR: Not enough space on /data. Need ${SWAPSIZE_MB}MB + 1GB buffer, have ${AVAILABLE_MB}MB"
+        exit 1
+    fi
+
+    # Allocate the swap file (use fallocate for speed, fallback to dd)
+    if command -v fallocate >/dev/null 2>&1; then
+        fallocate -l "${SWAPSIZE_MB}M" "$SWAPFILE" || {
+            echo "fallocate failed, falling back to dd..."
+            dd if=/dev/zero of="$SWAPFILE" bs=1M count=$SWAPSIZE_MB status=progress || {
+                echo "ERROR: Failed to create swap file"
+                exit 1
+            }
+        }
+    else
+        dd if=/dev/zero of="$SWAPFILE" bs=1M count=$SWAPSIZE_MB status=progress || {
+            echo "ERROR: Failed to create swap file"
+            exit 1
+        }
+    fi
+
+    # Set proper permissions (readable/writable by root only)
+    chmod 600 "$SWAPFILE"
+
+    # Setup as swap
+    mkswap "$SWAPFILE" || {
+        echo "ERROR: Failed to format swap file"
+        rm -f "$SWAPFILE"
+        exit 1
+    }
+
+    echo "Swap file created successfully"
+fi
+
+# Enable swap
+if ! swapon --show | grep -q "$SWAPFILE"; then
+    echo "Enabling swap file..."
+    swapon "$SWAPFILE" || {
+        echo "ERROR: Failed to enable swap"
+        exit 1
+    }
+    echo "Swap enabled successfully"
+fi
+
+exit 0

--- a/recipes-core/swapfile-setup/swapfile-setup_1.0.bb
+++ b/recipes-core/swapfile-setup/swapfile-setup_1.0.bb
@@ -1,0 +1,34 @@
+SUMMARY = "Swapfile setup service"
+DESCRIPTION = "Creates and enables a 4GB swap file on /data partition to prevent memory exhaustion"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit systemd
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = "\
+    file://swapfile-setup.service \
+    file://swapfile-setup.sh \
+    file://data-swapfile.swap \
+"
+
+SYSTEMD_SERVICE:${PN} = "swapfile-setup.service data-swapfile.swap"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/swapfile-setup.service ${D}${systemd_system_unitdir}/swapfile-setup.service
+    install -m 0644 ${WORKDIR}/data-swapfile.swap ${D}${systemd_system_unitdir}/data-swapfile.swap
+
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/swapfile-setup.sh ${D}${bindir}/swapfile-setup.sh
+}
+
+FILES:${PN} += "\
+    ${systemd_system_unitdir}/swapfile-setup.service \
+    ${systemd_system_unitdir}/data-swapfile.swap \
+    ${bindir}/swapfile-setup.sh \
+"
+
+RDEPENDS:${PN} = "systemd"

--- a/recipes-devtools/deepstream/deepstream-7.1_%.bbappend
+++ b/recipes-devtools/deepstream/deepstream-7.1_%.bbappend
@@ -1,0 +1,15 @@
+# Skip X11 dependency for headless/container use
+# DeepStream has some X11-linked binaries but they're not needed for container deployments
+
+# Skip QA checks for missing dependencies
+INSANE_SKIP:${PN} += "file-rdeps"
+INSANE_SKIP:${PN}-samples += "file-rdeps"
+
+# Prevent automatic dependency detection from adding X11 libs
+# These libraries link to X11 but we don't need that functionality
+PRIVATE_LIBS:${PN} = "libX11.so.6"
+PRIVATE_LIBS:${PN}-samples = "libX11.so.6"
+
+# Also skip FILEDEPS scanning for these packages to avoid RPM dep generation
+SKIP_FILEDEPS:${PN} = "1"
+SKIP_FILEDEPS:${PN}-samples = "1"

--- a/recipes-support/nvidia-container-config/files/edgeos-cdi-generate.service
+++ b/recipes-support/nvidia-container-config/files/edgeos-cdi-generate.service
@@ -13,13 +13,22 @@ Type=oneshot
 ExecStartPre=/bin/sleep 2
 # Create directory if needed
 ExecStartPre=/bin/mkdir -p /etc/cdi
-# Generate CDI spec using CSV mode (reads default CSVs plus devices-wendyos.csv)
-# This runs on every boot to ensure CDI spec is up-to-date with current CSV files
-ExecStart=/usr/bin/nvidia-ctk cdi generate --mode=csv --output=/etc/cdi/nvidia.yaml \
-    --csv.file=/etc/nvidia-container-runtime/host-files-for-container.d/devices.csv \
-    --csv.file=/etc/nvidia-container-runtime/host-files-for-container.d/drivers.csv \
-    --csv.file=/etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv \
-    --csv.file=/etc/nvidia-container-runtime/host-files-for-container.d/devices-wendyos.csv
+# Generate CDI spec using CSV mode with explicit CSV file list
+# Includes: devices.csv (meta-tegra), drivers.csv (meta-tegra), l4t.csv (ours),
+#           devices-wendyos.csv (sysfs entries), and l4t-deepstream.csv (if present)
+ExecStart=/bin/sh -c '\
+    ARGS="--mode=csv --output=/etc/cdi/nvidia.yaml"; \
+    ARGS="$ARGS --csv.file=/etc/nvidia-container-runtime/host-files-for-container.d/devices.csv"; \
+    ARGS="$ARGS --csv.file=/etc/nvidia-container-runtime/host-files-for-container.d/drivers.csv"; \
+    ARGS="$ARGS --csv.file=/etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv"; \
+    ARGS="$ARGS --csv.file=/etc/nvidia-container-runtime/host-files-for-container.d/devices-wendyos.csv"; \
+    if [ -f /etc/nvidia-container-runtime/host-files-for-container.d/l4t-deepstream.csv ]; then \
+        ARGS="$ARGS --csv.file=/etc/nvidia-container-runtime/host-files-for-container.d/l4t-deepstream.csv"; \
+    fi; \
+    /usr/bin/nvidia-ctk cdi generate $ARGS'
+# Post-process CDI spec to fix GStreamer plugin paths for container compatibility
+# (Yocto uses /usr/lib/ but containers expect /usr/lib/aarch64-linux-gnu/)
+ExecStartPost=/usr/bin/fix-cdi-gstreamer-paths.sh
 StandardOutput=journal
 StandardError=journal
 

--- a/recipes-support/nvidia-container-config/files/fix-cdi-gstreamer-paths.sh
+++ b/recipes-support/nvidia-container-config/files/fix-cdi-gstreamer-paths.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# fix-cdi-gstreamer-paths.sh
+# Post-processes the CDI spec to fix path mappings for container compatibility
+#
+# Issue: Yocto installs GStreamer plugins to /usr/lib/gstreamer-1.0/deepstream/
+# but containers (Ubuntu/Debian based) expect /usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream/
+#
+# Solution: Modify the CDI spec to mount the Yocto path to the container's expected path
+
+CDI_SPEC="/etc/cdi/nvidia.yaml"
+
+if [ ! -f "$CDI_SPEC" ]; then
+    echo "CDI spec not found at $CDI_SPEC"
+    exit 1
+fi
+
+# Fix GStreamer plugin path: mount Yocto path to container's expected Ubuntu/Debian path
+# Change: hostPath: /usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream
+# To:     hostPath: /usr/lib/gstreamer-1.0/deepstream
+# This way the container sees plugins at the path it expects
+
+if grep -q "aarch64-linux-gnu/gstreamer-1.0/deepstream" "$CDI_SPEC"; then
+    sed -i 's|hostPath: /usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream|hostPath: /usr/lib/gstreamer-1.0/deepstream|g' "$CDI_SPEC"
+    echo "Fixed GStreamer plugin path mapping in CDI spec"
+fi
+
+# Add GST_PLUGIN_PATH environment variable if not present
+# This tells GStreamer inside the container where to find DeepStream plugins
+if ! grep -q "GST_PLUGIN_PATH=" "$CDI_SPEC"; then
+    # Add GST_PLUGIN_PATH after NVIDIA_VISIBLE_DEVICES
+    sed -i 's|NVIDIA_VISIBLE_DEVICES=void|NVIDIA_VISIBLE_DEVICES=void\n  - GST_PLUGIN_PATH=/usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream|g' "$CDI_SPEC"
+    echo "Added GST_PLUGIN_PATH to CDI spec"
+fi
+
+echo "CDI spec post-processing complete"

--- a/recipes-support/nvidia-container-config/files/generate-cuda-env.sh
+++ b/recipes-support/nvidia-container-config/files/generate-cuda-env.sh
@@ -52,6 +52,7 @@ main() {
     log "Generating CUDA environment file for version $cuda_ver"
 
     # Generate environment file
+    # Note: Yocto builds use /usr/local/cuda-X.X/lib/ (not lib64) and /usr/lib/ (not aarch64-linux-gnu)
     cat > "$ENV_FILE" << EOF
 # EdgeOS CUDA Environment Configuration
 # Auto-generated on $(date)
@@ -60,7 +61,7 @@ main() {
 CUDA_VER=$cuda_ver
 CUDA_HOME=/usr/local/cuda-$cuda_ver
 PATH=/usr/local/cuda-$cuda_ver/bin:\$PATH
-LD_LIBRARY_PATH=/usr/local/cuda-$cuda_ver/lib64:/usr/lib/aarch64-linux-gnu
+LD_LIBRARY_PATH=/usr/local/cuda-$cuda_ver/lib:/usr/lib
 EOF
 
     chmod 644 "$ENV_FILE"

--- a/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
+++ b/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
@@ -131,6 +131,10 @@ lib, /usr/lib/libnvidia-tls.so.540.4.0
 lib, /usr/lib/libnvidia-glcore.so.540.4.0
 lib, /usr/lib/libnvidia-glsi.so.540.4.0
 
+# VPI3 - Vision Programming Interface (computer vision acceleration)
+lib, /opt/nvidia/vpi3/lib/aarch64-linux-gnu/libnvvpi.so.3.2.4
+sym, /opt/nvidia/vpi3/lib/aarch64-linux-gnu/libnvvpi.so.3
+
 # Tegra-specific libraries (video processing) - in /usr/lib/ directly on Yocto
 sym, /usr/lib/libnvbufsurface.so
 sym, /usr/lib/libnvbufsurface.so.1

--- a/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
+++ b/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
@@ -1,0 +1,461 @@
+# Device nodes (required for GPU access)
+dev, /dev/nvidiactl
+dev, /dev/nvidia0
+dev, /dev/nvhost-gpu
+dev, /dev/nvhost-ctrl-gpu
+dev, /dev/nvhost-as-gpu
+dev, /dev/nvhost-dbg-gpu
+dev, /dev/nvhost-prof-gpu
+dev, /dev/nvhost-ctxsw-gpu
+dev, /dev/nvhost-sched-gpu
+dev, /dev/nvhost-tsg-gpu
+
+# Video decode device (hardware video decoding)
+dev, /dev/v4l2-nvdec
+
+# DRI devices (for graphics/display if needed)
+dev, /dev/dri/card*
+dev, /dev/dri/renderD*
+dir, /dev/dri/by-path
+
+# CUDA Runtime (required by all CUDA applications)
+sym, /usr/local/cuda-12.6/lib/libcudart.so.12
+lib, /usr/local/cuda-12.6/lib/libcudart.so.12.6.68
+
+# cuBLAS - Linear algebra (REQUIRED by PyTorch)
+sym, /usr/local/cuda-12.6/lib/libcublas.so.12
+lib, /usr/local/cuda-12.6/lib/libcublas.so.12.6.1.4
+sym, /usr/local/cuda-12.6/lib/libcublasLt.so.12
+lib, /usr/local/cuda-12.6/lib/libcublasLt.so.12.6.1.4
+
+# cuDNN - Deep learning primitives (REQUIRED by PyTorch)
+sym, /usr/lib/libcudnn.so.9
+lib, /usr/lib/libcudnn.so.9.3.0
+sym, /usr/lib/libcudnn_ops.so.9
+lib, /usr/lib/libcudnn_ops.so.9.3.0
+sym, /usr/lib/libcudnn_cnn.so.9
+lib, /usr/lib/libcudnn_cnn.so.9.3.0
+sym, /usr/lib/libcudnn_adv.so.9
+lib, /usr/lib/libcudnn_adv.so.9.3.0
+sym, /usr/lib/libcudnn_graph.so.9
+lib, /usr/lib/libcudnn_graph.so.9.3.0
+sym, /usr/lib/libcudnn_engines_precompiled.so.9
+lib, /usr/lib/libcudnn_engines_precompiled.so.9.3.0
+sym, /usr/lib/libcudnn_engines_runtime_compiled.so.9
+lib, /usr/lib/libcudnn_engines_runtime_compiled.so.9.3.0
+sym, /usr/lib/libcudnn_heuristic.so.9
+lib, /usr/lib/libcudnn_heuristic.so.9.3.0
+
+# cuSPARSE - Sparse matrix operations (used by PyTorch sparse tensors)
+sym, /usr/local/cuda-12.6/lib/libcusparse.so.12
+lib, /usr/local/cuda-12.6/lib/libcusparse.so.12.5.3.3
+
+# cuSPARSELt - Lightweight sparse matrix operations
+lib, /usr/lib/libcusparseLt.so.0
+lib, /usr/lib/libcusparseLt.so.0.8.1.1
+
+# cuSOLVER - Linear solvers (used by torch.linalg operations)
+sym, /usr/local/cuda-12.6/lib/libcusolver.so.11
+lib, /usr/local/cuda-12.6/lib/libcusolver.so.11.6.4.69
+sym, /usr/local/cuda-12.6/lib/libcusolverMg.so.11
+lib, /usr/local/cuda-12.6/lib/libcusolverMg.so.11.6.4.69
+
+# cuRAND - Random number generation (used by torch.rand with CUDA)
+sym, /usr/local/cuda-12.6/lib/libcurand.so.10
+lib, /usr/local/cuda-12.6/lib/libcurand.so.10.3.7.68
+
+# cuFFT - Fast Fourier Transform (used by torch.fft)
+sym, /usr/local/cuda-12.6/lib/libcufft.so
+sym, /usr/local/cuda-12.6/lib/libcufft.so.11
+lib, /usr/local/cuda-12.6/lib/libcufft.so.11.2.6.59
+
+# NVRTC - Runtime compilation (used by torch.jit)
+sym, /usr/local/cuda-12.6/lib/libnvrtc.so.12
+lib, /usr/local/cuda-12.6/lib/libnvrtc.so.12.6.68
+sym, /usr/local/cuda-12.6/lib/libnvrtc-builtins.so.12.6
+lib, /usr/local/cuda-12.6/lib/libnvrtc-builtins.so.12.6.68
+
+# nvJitLink - JIT Linker (required by PyTorch JIT compilation and torch.compile)
+sym, /usr/local/cuda-12.6/lib/libnvJitLink.so.12
+lib, /usr/local/cuda-12.6/lib/libnvJitLink.so.12.6.68
+
+# NVTX - NVIDIA Tools Extension for profiling (used by PyTorch profiler)
+sym, /usr/local/cuda-12.6/lib/libnvToolsExt.so.1
+lib, /usr/local/cuda-12.6/lib/libnvToolsExt.so.1.0.0
+
+# CUPTI - CUDA Profiling Tools Interface (used by PyTorch profiler)
+sym, /usr/local/cuda-12.6/lib/libcupti.so.12
+lib, /usr/local/cuda-12.6/lib/libcupti.so.2024.3.1
+
+# NVJPEG - Hardware JPEG encoding/decoding
+sym, /usr/local/cuda-12.6/lib/libnvjpeg.so.12
+lib, /usr/local/cuda-12.6/lib/libnvjpeg.so.12.3.3.54
+
+# NPP - Image processing primitives (used by vision operations)
+sym, /usr/local/cuda-12.6/lib/libnppc.so.12
+lib, /usr/local/cuda-12.6/lib/libnppc.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnppial.so.12
+lib, /usr/local/cuda-12.6/lib/libnppial.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnppicc.so.12
+lib, /usr/local/cuda-12.6/lib/libnppicc.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnppidei.so.12
+lib, /usr/local/cuda-12.6/lib/libnppidei.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnppif.so.12
+lib, /usr/local/cuda-12.6/lib/libnppif.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnppig.so.12
+lib, /usr/local/cuda-12.6/lib/libnppig.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnppim.so.12
+lib, /usr/local/cuda-12.6/lib/libnppim.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnppist.so.12
+lib, /usr/local/cuda-12.6/lib/libnppist.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnppisu.so.12
+lib, /usr/local/cuda-12.6/lib/libnppisu.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnppitc.so.12
+lib, /usr/local/cuda-12.6/lib/libnppitc.so.12.3.1.54
+sym, /usr/local/cuda-12.6/lib/libnpps.so.12
+lib, /usr/local/cuda-12.6/lib/libnpps.so.12.3.1.54
+
+# Tegra core libraries (libnvrm_gpu, etc.)
+lib, /usr/lib/libnvrm_gpu.so
+lib, /usr/lib/libnvrm_chip.so
+lib, /usr/lib/libnvrm_mem.so
+lib, /usr/lib/libnvrm_sync.so
+lib, /usr/lib/libnvrm_host1x.so
+lib, /usr/lib/libnvdc.so
+lib, /usr/lib/libnvddk_2d_v2.so
+lib, /usr/lib/libnvddk_vic.so
+lib, /usr/lib/libnvimp.so
+lib, /usr/lib/libnvphs.so
+lib, /usr/lib/libnvidia-rmapi-tegra.so.540.4.0
+lib, /usr/lib/libnvidia-tls.so.540.4.0
+lib, /usr/lib/libnvidia-glcore.so.540.4.0
+lib, /usr/lib/libnvidia-glsi.so.540.4.0
+
+# Tegra-specific libraries (video processing) - in /usr/lib/ directly on Yocto
+sym, /usr/lib/libnvbufsurface.so
+sym, /usr/lib/libnvbufsurface.so.1
+lib, /usr/lib/libnvbufsurface.so.1.0.0
+sym, /usr/lib/libnvbufsurftransform.so
+sym, /usr/lib/libnvbufsurftransform.so.1
+lib, /usr/lib/libnvbufsurftransform.so.1.0.0
+lib, /usr/lib/libnvbuf_fdmap.so.1.0.0
+sym, /usr/lib/libnvdsbufferpool.so
+sym, /usr/lib/libnvdsbufferpool.so.1
+lib, /usr/lib/libnvdsbufferpool.so.1.0.0
+lib, /usr/lib/libnvid_mapper.so.1.0.0
+
+# NvSci libraries (NVIDIA Software Communication Interface)
+sym, /usr/lib/libnvscibuf.so
+lib, /usr/lib/libnvscibuf.so.1
+sym, /usr/lib/libnvscicommon.so
+lib, /usr/lib/libnvscicommon.so.1
+sym, /usr/lib/libnvscisync.so
+lib, /usr/lib/libnvscisync.so.1
+sym, /usr/lib/libnvscistream.so
+lib, /usr/lib/libnvscistream.so.1
+lib, /usr/lib/libnvscievent.so
+lib, /usr/lib/libnvsciipc.so
+
+# NVMM multimedia libraries (media framework)
+lib, /usr/lib/libnvmm.so
+lib, /usr/lib/libnvmm_utils.so
+lib, /usr/lib/libnvmm_contentpipe.so
+lib, /usr/lib/libnvmm_parser.so
+
+# EGL/OpenGL libraries (for GPU rendering)
+lib, /usr/lib/libEGL_nvidia.so.0
+lib, /usr/lib/libGLESv2_nvidia.so.2
+lib, /usr/lib/libnvidia-eglcore.so.540.4.0
+
+# CUDA driver (critical for all GPU operations)
+sym, /usr/lib/libcuda.so
+sym, /usr/lib/libcuda.so.1
+lib, /usr/lib/libcuda.so.1.1
+
+# TensorRT - Inference optimization (required by torch-tensorrt)
+sym, /usr/lib/libnvinfer.so
+sym, /usr/lib/libnvinfer.so.10
+lib, /usr/lib/libnvinfer.so.10.3.0
+sym, /usr/lib/libnvinfer_plugin.so
+sym, /usr/lib/libnvinfer_plugin.so.10
+lib, /usr/lib/libnvinfer_plugin.so.10.3.0
+lib, /usr/lib/libnvinfer_builder_resource.so.10.3.0
+
+# cuFile - GPUDirect Storage (required by PyTorch 2.8.0)
+sym, /usr/local/cuda-12.6/lib/libcufile.so
+sym, /usr/local/cuda-12.6/lib/libcufile.so.0
+lib, /usr/local/cuda-12.6/lib/libcufile.so.1.11.1
+
+# TensorRT ONNX Parser - Model import (required by torch-tensorrt)
+sym, /usr/lib/libnvonnxparser.so
+sym, /usr/lib/libnvonnxparser.so.10
+lib, /usr/lib/libnvonnxparser.so.10.3.0
+
+# CUDA DLA Runtime - Deep Learning Accelerator
+sym, /usr/local/cuda-12.6/lib/libcudla.so
+sym, /usr/local/cuda-12.6/lib/libcudla.so.1
+lib, /usr/local/cuda-12.6/lib/libcudla.so.1.0.0
+
+# DeepStream SDK 7.1 Libraries (only present if deepstream-7.1 is installed)
+# Environment variable for GStreamer to find DeepStream plugins
+env, GST_PLUGIN_PATH=/usr/lib/gstreamer-1.0/deepstream
+
+# Mount entire library directory for DeepStream
+dir, /opt/nvidia/deepstream/deepstream-7.1/lib
+
+# DeepStream symlink
+dir, /opt/nvidia/deepstream/deepstream
+
+# DeepStream GStreamer plugins directories
+dir, /usr/lib/gstreamer-1.0/deepstream
+dir, /usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream
+dir, /usr/lib/aarch64-linux-gnu/nvidia
+
+# DeepStream core libraries
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_meta.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_meta.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_helper.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_batch_jpegenc.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_infer.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_inferutils.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_nvmultiobjecttracker.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_osd.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_msgbroker.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_msgconv.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_msgconv.so.1.0.0
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_yml_parser.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_utils.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_dsanalytics.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_lljpegenc.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_nvtxhelper.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_dewarper.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_infer_server.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_smartrecord.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_inferbase.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_3d_gst.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_dewarper.so
+
+# Tegra container passthrough libraries (provides additional NVIDIA libs for containers)
+dir, /usr/share/nvidia-container-passthrough
+
+# GStreamer NVIDIA custom helper (required by DeepStream)
+# May be in /usr/lib/aarch64-linux-gnu/nvidia/ or /usr/share/nvidia-container-passthrough/
+sym, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so
+lib, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so.1.0.0
+sym, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so
+lib, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so.1.0.0
+# Fallback to container passthrough location
+lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so
+lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so.1.0.0
+lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so
+lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so.1.0.0
+
+# Tegra platform information (required for GPU driver initialization)
+dir, /sys/devices/soc0
+dir, /proc/device-tree
+
+# YAML-CPP library (required by DeepStream plugins)
+lib, /usr/lib/libnvrm_surface.so
+lib, /usr/lib/libnvos.so
+
+# Additional Tegra libraries (pyds dependencies)
+lib, /usr/lib/libnvsocsys.so
+lib, /usr/lib/libnvtegrahv.so
+lib, /usr/lib/libnvvic.so
+lib, /usr/lib/libnvrm_stream.so
+lib, /usr/lib/libnvcolorutil.so
+
+# EGL vendor configuration (required for nvbufsurftransform)
+dir, /usr/share/glvnd/egl_vendor.d
+
+# Additional EGL/GL libraries
+
+# ========================================
+
+lib, /usr/lib/libnvdla_compiler.so
+
+lib, /usr/lib/libnvcudla.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so.1
+
+# ========================================
+
+# ========================================
+# Additional DeepStream Plugin Dependencies
+# ========================================
+
+# NVIDIA DLA runtime
+
+# GStreamer RTSP server
+
+# JSON GLib
+
+# Pango text rendering
+
+# NVIDIA DLA runtime
+lib, /usr/lib/libnvdla_runtime.so
+
+# GStreamer RTSP server
+lib, /usr/lib/libgstrtspserver-1.0.so.0
+lib, /usr/lib/libgstrtspserver-1.0.so.0.2212.0
+
+# JSON GLib
+lib, /usr/lib/libjson-glib-1.0.so.0
+lib, /usr/lib/libjson-glib-1.0.so.0.800.0
+
+# Pango text rendering
+lib, /usr/lib/libpango-1.0.so.0
+lib, /usr/lib/libpango-1.0.so.0.5200.1
+lib, /usr/lib/libpangocairo-1.0.so.0
+lib, /usr/lib/libpangocairo-1.0.so.0.5200.1
+lib, /usr/lib/libpangoft2-1.0.so.0
+lib, /usr/lib/libpangoft2-1.0.so.0.5200.1
+
+# Symlinks for GStreamer plugin dependencies
+sym, /usr/lib/libpango-1.0.so.0
+sym, /usr/lib/libpangocairo-1.0.so.0
+sym, /usr/lib/libpangoft2-1.0.so.0
+sym, /usr/lib/libjson-glib-1.0.so.0
+sym, /usr/lib/libgstrtspserver-1.0.so.0
+
+# FriBidi (BiDirectional text support for Pango)
+sym, /usr/lib/libfribidi.so.0
+lib, /usr/lib/libfribidi.so.0.4.0
+
+# DeepStream dewarper library (needed by deepstream_bins plugin)
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_dewarper.so
+
+# HarfBuzz (text shaping for Pango)
+sym, /usr/lib/libharfbuzz.so.0
+lib, /usr/lib/libharfbuzz.so.0.60830.0
+
+# ==========================================
+# Additional Dependencies for DeepStream Container
+# ==========================================
+
+# YAML C++ library 0.7 (required by DeepStream plugins, different from container's 0.8)
+sym, /usr/lib/libyaml-cpp.so.0.7
+lib, /usr/lib/libyaml-cpp.so.0.7.0
+
+# EGL libraries for GPU-accelerated operations
+sym, /usr/lib/libEGL.so.1
+lib, /usr/lib/libEGL.so.1.1.0
+lib, /usr/lib/libEGL_nvidia.so.0
+lib, /usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0
+
+# ========================================
+# DeepStream 7.1 Complete Dependencies
+# ========================================
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so.1.16.0
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcustom_A2Vtemplate.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcustom_audioimpl.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcustom_videoimpl.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_alignment_datafilter.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_common.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_depth2point_datafilter.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_depth_datasource.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_gl_datarender.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_gles_ensemble_render.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_glprocess.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_infer_postprocess_lidar_detection.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_lidar_preprocess_datafilter.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_multisensor_mixer.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_sensor_fusion_cluster.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_v2x_infer_custom_postprocess.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_v2x_infer_custom_preprocess.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_3d_video_databridge.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_audio_allocator.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_audiotransform.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_batch_jpegenc.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_csvparser.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_custom_sequence_preprocess.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_dewarper.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_dsanalytics.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_infer.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_infer_custom_parser_audio.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_infercustomparser.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_inferlogger.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_inferutils.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_lidar_custom_postprocess_impl.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_lidar_custom_preprocess_impl.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_lidarfileread.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_lidarfilewrite.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_logger.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_mem_allocator.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_meta.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_mqtt_proto.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_msgbroker.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_msgconv.so.1.0.0
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_msgconv_audio.so.1.0.0
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_nvmultiobjecttracker.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_nvtxhelper.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_opticalflow_dgpu.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_opticalflow_jetson.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_opticalflow_orin.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_osd.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_rest_server.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_riva_asr_grpc.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_riva_audio_proto.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_riva_tts.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_service_maker.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_utils.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_vpicanmatch.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvds_yml_parser.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_3d_gst.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_audio.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_customhelper.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_helper.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_inferbase.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_ipcmeta.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_meta.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_smartrecord.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libnvdsgst_tensor.so
+lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libpostprocess_impl.so
+
+# DeepStream GStreamer plugins directory
+dir, /usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream
+lib, /usr/lib/gstreamer-1.0/deepstream/libcustom2d_preprocess.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libgstnvvideoconvert.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgstA2Vtemplate.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_3dbridge.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_3dfilter.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_3dmixer.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_audiotemplate.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_deepstream_bins.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_dewarper.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_dsanalytics.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_dsexample.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_infer.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_inferaudio.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_logger.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_metamux.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_msgbroker.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_msgconv.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_multistream.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_multistreamtiler.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_nvmultiurisrcbin.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_nvurisrcbin.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_of.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_ofvisual.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_osd.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_postprocess.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_preprocess.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_segvisual.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_speech.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_text_to_speech.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_tracker.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_videotemplate.so
+
+# GL/GLES libraries for GPU-accelerated operations
+sym, /usr/lib/libGLESv2.so.2
+lib, /usr/lib/libGLESv2.so.2.1.0
+lib, /usr/lib/libGLESv2_nvidia.so.2
+sym, /usr/lib/libGLESv1_CM.so.1
+lib, /usr/lib/libGLESv1_CM.so.1.2.0
+lib, /usr/lib/libGLESv1_CM_nvidia.so.1
+sym, /usr/lib/libGLdispatch.so.0
+lib, /usr/lib/libGLdispatch.so.0.0.0
+
+# DRM devices for EGL/headless GPU operations
+dev-char, /dev/dri/card0
+dev-char, /dev/dri/renderD128

--- a/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
+++ b/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
@@ -280,7 +280,6 @@ dir, /usr/share/glvnd/egl_vendor.d
 lib, /usr/lib/libnvdla_compiler.so
 
 lib, /usr/lib/libnvcudla.so
-lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so.1
 
 # ========================================
 
@@ -350,8 +349,9 @@ lib, /usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0
 # ========================================
 # DeepStream 7.1 Complete Dependencies
 # ========================================
-lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so
 lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so.1.16.0
+sym, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so.1
+sym, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so
 lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcustom_A2Vtemplate.so
 lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcustom_audioimpl.so
 lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcustom_videoimpl.so

--- a/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
+++ b/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
@@ -198,7 +198,8 @@ lib, /usr/local/cuda-12.6/lib/libcudla.so.1.0.0
 
 # DeepStream SDK 7.1 Libraries (only present if deepstream-7.1 is installed)
 # Environment variable for GStreamer to find DeepStream plugins
-env, GST_PLUGIN_PATH=/usr/lib/gstreamer-1.0/deepstream
+env, GST_PLUGIN_PATH=/usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream
+env, LD_LIBRARY_PATH=/opt/nvidia/deepstream/deepstream-7.1/lib
 
 # Mount entire library directory for DeepStream
 dir, /opt/nvidia/deepstream/deepstream-7.1/lib


### PR DESCRIPTION
## Summary

This PR adds NVIDIA DeepStream SDK 7.1 support and comprehensive container memory management to prevent device lockup on resource-constrained Jetson devices.

## Features

### 1. DeepStream SDK 7.1 Support (Optional)

Enable with `EDGEOS_DEEPSTREAM=1` in your build configuration.

**What's included:**
- `deepstream-7.1` package with X11 dependencies disabled for headless/container use
- Comprehensive CDI CSV file (`l4t-deepstream.csv`) with 460+ library/device mappings
- DeepStream-specific packages: `tegra-libraries-multimedia-ds`, `libgstnvcustomhelper`, `yaml-cpp-070`, etc.
- GStreamer plugin path fixes for Yocto → container compatibility
- Post-processing script to fix CDI spec paths automatically

**Container support:**
- All DeepStream GStreamer plugins mounted to containers
- Environment variables configured (`GST_PLUGIN_PATH`, `LD_LIBRARY_PATH`)
- Full TensorRT, cuDNN, CUDA libraries passthrough

### 2. Container Memory Management

Prevents device lockup by constraining total container memory usage.

| Setting | Value | Description |
|---------|-------|-------------|
| `MemoryMax` | 7.4GB | Hard limit - OOM killer triggers if exceeded |
| `MemoryHigh` | 6.5GB | Soft limit - throttling begins |
| Swap | 4GB | Buffer for temporary memory spikes |

**How it works:**
- Systemd cgroup limits applied to `containerd.service`
- All containers share the 7.4GB pool (not per-container)
- Comprehensive documentation at `/usr/share/doc/containerd-config/README-memory-limits.md`

### 3. Swap File Setup

Automatic 4GB swap file creation on `/data` partition.

- Created on first boot via `swapfile-setup.service`
- Validates available disk space before creation
- Low priority (-2) to prefer RAM
- Provides buffer for ML inference memory spikes

### 4. CDI Generation Improvements

- Conditional inclusion of `l4t-deepstream.csv` when DeepStream enabled
- Path translation from Yocto (`/usr/lib/`) to container-expected paths (`/usr/lib/aarch64-linux-gnu/`)
- Automatic `GST_PLUGIN_PATH` injection into CDI spec

## New Recipes

| Recipe | Description |
|--------|-------------|
| `containerd-config` | Systemd drop-in for container memory limits |
| `swapfile-setup` | Automatic swap file creation service |
| `deepstream-7.1_%.bbappend` | DeepStream X11 dependency skip |

## Configuration

### Enable DeepStream (adds ~1GB to image)
```bash
# In local.conf or your distro config
EDGEOS_DEEPSTREAM = "1"
```

### Build
```bash
MACHINE=jetson-orin-nano-devkit-nvme-edgeos bitbake edgeos-image
```

## Files Changed

- `recipes-containers/containerd-config/` - New recipe for memory limits
- `recipes-core/swapfile-setup/` - New recipe for swap file
- `recipes-devtools/deepstream/deepstream-7.1_%.bbappend` - X11 skip
- `recipes-support/nvidia-container-config/` - CDI generation + DeepStream CSV
- `recipes-core/packagegroups/packagegroup-nvidia-container.bb` - DeepStream packages
- `recipes-core/images/edgeos-image.bb` - EDGEOS_DEEPSTREAM feature flag

## Test Plan

- [x] Build with `EDGEOS_DEEPSTREAM=0` (default) - no DeepStream packages
- [x] Build with `EDGEOS_DEEPSTREAM=1` - DeepStream SDK included
- [x] Verify swap file created on first boot
- [x] Verify containerd memory limits applied (`systemctl show containerd | grep Memory`)
- [x] Run DeepStream container with GPU passthrough
- [ ] Stress test memory limits with multiple containers