### PR TITLE
Add persistent containerd storage on /data partition

### DIFF
--- a/recipes-core/packagegroups/packagegroup-edgeos-base.bb
+++ b/recipes-core/packagegroups/packagegroup-edgeos-base.bb
@@ -32,6 +32,7 @@ RDEPENDS:${PN} = " \
     edgeos-agent \
     edgeos-user \
     edgeos-motd \
+    systemd-mount-containerd \
     "
 
 RDEPENDS:${PN}:append = " \

--- a/recipes-core/systemd-mount-containerd/files/var-lib-containerd.mount
+++ b/recipes-core/systemd-mount-containerd/files/var-lib-containerd.mount
@@ -1,0 +1,24 @@
+[Unit]
+Description=Bind mount /var/lib/containerd from persistent data partition
+Documentation=man:systemd.mount(5)
+
+# Ensure data partition is mounted and filesystem is fully expanded
+RequiresMountsFor=/data
+After=data.mount
+
+# Wait for Mender data partition resize to complete (if enabled)
+# This is safe even if mender-systemd-growfs-data.service doesn't exist
+After=mender-systemd-growfs-data.service
+
+# Must be mounted before containerd starts
+Before=containerd.service
+DefaultDependencies=no
+
+[Mount]
+What=/data/containerd
+Where=/var/lib/containerd
+Type=none
+Options=bind,nosuid,nodev,x-systemd.mkdir
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-containerd/systemd-mount-containerd_1.0.bb
+++ b/recipes-core/systemd-mount-containerd/systemd-mount-containerd_1.0.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Systemd mount unit for persistent containerd data directory"
+DESCRIPTION = "Bind mounts /var/lib/containerd from /data/containerd to provide persistent \
+container images, volumes, and snapshots across Mender OTA updates. Ensures containers \
+and their data survive A/B partition switches."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit systemd
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = "file://var-lib-containerd.mount"
+
+SYSTEMD_SERVICE:${PN} = "var-lib-containerd.mount"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/var-lib-containerd.mount ${D}${systemd_system_unitdir}/var-lib-containerd.mount
+}
+
+FILES:${PN} += "${systemd_system_unitdir}/var-lib-containerd.mount"
+
+RDEPENDS:${PN} = "systemd"


### PR DESCRIPTION
Configures containerd to store container images, volumes, and snapshots on /data/containerd to persist across Mender A/B partition updates.

Benefits:
- Container images survive OTA updates (no re-download after A/B switch)
- Persistent volumes maintained across updates
- Follows established layer patterns (home.mount, var-log.mount)
- Secure by default with mount hardening