### PR TITLE
WDY-610: Add PipeWire, PulseAudio compatibility, and BlueZ support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,481 @@
+# WendyOS Build System for NVIDIA Jetson Orin Nano
+# ================================================
+#
+# Usage:
+#   make help        - Show this help message
+#   make setup       - Bootstrap the build environment (first time setup)
+#   make build       - Build the complete WendyOS image
+#   make shell       - Open interactive shell in build container
+#
+# For macOS users: Ensure Docker Desktop is running with sufficient resources
+# (8GB+ RAM, 4+ CPUs, 150GB+ disk recommended)
+#
+# Note: On macOS, build artifacts are stored in Docker volumes (case-sensitive)
+# rather than the host filesystem to work around macOS case-insensitivity.
+
+.PHONY: help setup bootstrap docker-create docker-run docker-remove shell build build-sdk clean distclean volumes-create volumes-remove deploy flash-to-external
+
+# Configuration
+SHELL := /bin/bash
+IMAGE_NAME := wendyos
+DOCKER_REPO := wendyos-build
+DOCKER_TAG := scarthgap
+DOCKER_USER := dev
+DOCKER_WORKDIR := /home/$(DOCKER_USER)/$(IMAGE_NAME)
+BUILD_DIR := build
+MACHINE ?= jetson-orin-nano-devkit-nvme-edgeos
+IMAGE_TARGET ?= edgeos-image
+
+# Flash configuration
+FLASH_DEVICE ?=
+FLASH_IMAGE_SIZE ?= 64G
+FLASH_CONFIRM ?=
+
+# Directories (relative to where Makefile is located)
+MAKEFILE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+PROJECT_DIR := $(shell dirname $(MAKEFILE_DIR))
+DOCKER_DIR := $(PROJECT_DIR)/docker
+
+# Docker volumes for macOS (case-sensitive storage)
+VOLUME_BUILD := wendyos-build-tmp
+VOLUME_SSTATE := wendyos-sstate-cache
+VOLUME_DOWNLOADS := wendyos-downloads
+
+# Colors for output
+CYAN := \033[0;36m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m
+RED := \033[0;31m
+NC := \033[0m # No Color
+
+# Default target
+.DEFAULT_GOAL := help
+
+#
+# Help
+#
+help:
+	@printf "\n"
+	@printf "$(CYAN)WendyOS Build System$(NC)\n"
+	@printf "$(CYAN)====================$(NC)\n"
+	@printf "\n"
+	@printf "$(GREEN)Setup Commands:$(NC)\n"
+	@printf "  make setup          - First-time setup: clone repos, create Docker image\n"
+	@printf "  make docker-create  - Create/rebuild the Docker build image\n"
+	@printf "  make docker-remove  - Remove the Docker build image\n"
+	@printf "\n"
+	@printf "$(GREEN)Build Commands:$(NC)\n"
+	@printf "  make build          - Build the complete WendyOS image ($(IMAGE_TARGET))\n"
+	@printf "  make build-sdk      - Build the SDK for application development\n"
+	@printf "  make shell          - Open interactive shell in build container\n"
+	@printf "  make deploy         - Copy tegraflash tarball to host (macOS only)\n"
+	@printf "\n"
+	@printf "$(GREEN)Flash Commands:$(NC)\n"
+	@printf "  make flash-to-external - Interactive: create .img and flash to external drive\n"
+	@printf "\n"
+	@printf "$(GREEN)Clean Commands:$(NC)\n"
+	@printf "  make clean          - Remove build artifacts (keeps downloads/sstate)\n"
+	@printf "  make distclean      - Remove everything (downloads, sstate, build)\n"
+	@printf "\n"
+	@printf "$(GREEN)macOS Volume Commands:$(NC)\n"
+	@printf "  make volumes-create - Create Docker volumes for case-sensitive storage\n"
+	@printf "  make volumes-remove - Remove Docker volumes (deletes all build data)\n"
+	@printf "\n"
+	@printf "$(GREEN)Configuration:$(NC)\n"
+	@printf "  MACHINE=$(MACHINE)\n"
+	@printf "  IMAGE_TARGET=$(IMAGE_TARGET)\n"
+	@printf "  FLASH_IMAGE_SIZE=$(FLASH_IMAGE_SIZE)  (must match EDGEOS_FLASH_IMAGE_SIZE)\n"
+	@printf "  FLASH_DEVICE=        (e.g., /dev/disk4)\n"
+	@printf "  FLASH_CONFIRM=       (set to 'yes' for non-interactive mode)\n"
+	@printf "\n"
+	@printf "$(YELLOW)Examples:$(NC)\n"
+	@printf "  make setup                                    # First time setup\n"
+	@printf "  make build                                    # Build default image\n"
+	@printf "  make build MACHINE=jetson-orin-nano-devkit-edgeos  # Build for SD card\n"
+	@printf "  make shell                                    # Interactive development\n"
+	@printf "  make flash-to-external                        # Interactive flash\n"
+	@printf "  make flash-to-external FLASH_DEVICE=/dev/disk4 FLASH_CONFIRM=yes  # Non-interactive\n"
+	@printf "\n"
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		printf "$(YELLOW)macOS Note:$(NC) Build artifacts stored in Docker volumes (case-sensitive)\n"; \
+		printf "            Use 'make deploy' to copy tegraflash tarball after build.\n\n"; \
+	fi
+
+#
+# Setup / Bootstrap
+#
+setup: bootstrap
+	@printf "\n"
+	@printf "$(GREEN)Setup complete!$(NC)\n"
+	@printf "\n"
+	@printf "Next steps:\n"
+	@printf "  1. (Optional) Edit $(PROJECT_DIR)/build/conf/local.conf\n"
+	@printf "  2. Run: make build\n"
+	@printf "\n"
+
+bootstrap:
+	@printf "$(CYAN)Running bootstrap...$(NC)\n"
+	@cd $(PROJECT_DIR) && $(MAKEFILE_DIR)/bootstrap.sh
+
+#
+# Docker Management
+#
+docker-create:
+	@printf "$(CYAN)Creating Docker image...$(NC)\n"
+	@if [ -d "$(DOCKER_DIR)" ]; then \
+		cd $(DOCKER_DIR) && ./docker-util.sh create; \
+	else \
+		printf "$(RED)Error: Docker directory not found. Run 'make setup' first.$(NC)\n"; \
+		exit 1; \
+	fi
+
+docker-remove:
+	@printf "$(CYAN)Removing Docker image...$(NC)\n"
+	@cd $(DOCKER_DIR) && ./docker-util.sh remove
+
+#
+# Interactive Shell
+#
+shell:
+	@printf "$(CYAN)Starting interactive build shell...$(NC)\n"
+	@if [ ! -d "$(DOCKER_DIR)" ]; then \
+		printf "$(RED)Error: Docker directory not found. Run 'make setup' first.$(NC)\n"; \
+		exit 1; \
+	fi
+	@printf "\n"
+	@printf "$(YELLOW)Inside the container, run:$(NC)\n"
+	@printf "  cd ./$(IMAGE_NAME)\n"
+	@printf "  . ./repos/poky/oe-init-build-env build\n"
+	@printf "  bitbake $(IMAGE_TARGET)\n"
+	@printf "\n"
+	@cd $(DOCKER_DIR) && ./docker-util.sh run
+
+#
+# Build Commands
+#
+build: _check-setup _ensure-volumes
+	@printf "$(CYAN)Building $(IMAGE_TARGET) for $(MACHINE)...$(NC)\n"
+	@printf "$(YELLOW)This may take several hours on first build.$(NC)\n"
+	@printf "\n"
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		docker run \
+			--rm -t \
+			--privileged \
+			-e "TERM=xterm-256color" \
+			-e "LANG=C.UTF-8" \
+			-v $(PROJECT_DIR):$(DOCKER_WORKDIR) \
+			-v $(VOLUME_BUILD):$(DOCKER_WORKDIR)/build/tmp \
+			-v $(VOLUME_SSTATE):$(DOCKER_WORKDIR)/build/sstate-cache \
+			-v $(VOLUME_DOWNLOADS):$(DOCKER_WORKDIR)/build/downloads \
+			$(DOCKER_REPO):$(DOCKER_TAG) \
+			/bin/bash -c '\
+				cd $(DOCKER_WORKDIR) && \
+				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
+				MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
+			'; \
+	else \
+		cd $(DOCKER_DIR) && docker run \
+			--rm \
+			-v /tmp/.X11-unix:/tmp/.X11-unix \
+			--network host \
+			--privileged \
+			-e "TERM=xterm-256color" \
+			-e "LANG=C.UTF-8" \
+			-v $(PROJECT_DIR):$(DOCKER_WORKDIR) \
+			$(DOCKER_REPO):$(DOCKER_TAG) \
+			/bin/bash -c '\
+				cd $(DOCKER_WORKDIR) && \
+				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
+				MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
+			'; \
+	fi
+	@printf "\n"
+	@printf "$(GREEN)Build complete!$(NC)\n"
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		printf "Run 'make deploy' to copy tegraflash tarball, or 'make flash-to-external' to flash.\n"; \
+	else \
+		printf "Image location: $(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/\n"; \
+	fi
+
+build-sdk: _check-setup _ensure-volumes
+	@printf "$(CYAN)Building SDK for $(MACHINE)...$(NC)\n"
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		docker run \
+			--rm -t \
+			--privileged \
+			-e "TERM=xterm-256color" \
+			-e "LANG=C.UTF-8" \
+			-v $(PROJECT_DIR):$(DOCKER_WORKDIR) \
+			-v $(VOLUME_BUILD):$(DOCKER_WORKDIR)/build/tmp \
+			-v $(VOLUME_SSTATE):$(DOCKER_WORKDIR)/build/sstate-cache \
+			-v $(VOLUME_DOWNLOADS):$(DOCKER_WORKDIR)/build/downloads \
+			$(DOCKER_REPO):$(DOCKER_TAG) \
+			/bin/bash -c '\
+				cd $(DOCKER_WORKDIR) && \
+				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
+				MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
+			'; \
+	else \
+		cd $(DOCKER_DIR) && docker run \
+			--rm \
+			-v /tmp/.X11-unix:/tmp/.X11-unix \
+			--network host \
+			--privileged \
+			-e "TERM=xterm-256color" \
+			-e "LANG=C.UTF-8" \
+			-v $(PROJECT_DIR):$(DOCKER_WORKDIR) \
+			$(DOCKER_REPO):$(DOCKER_TAG) \
+			/bin/bash -c '\
+				cd $(DOCKER_WORKDIR) && \
+				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
+				MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
+			'; \
+	fi
+	@printf "\n"
+	@printf "$(GREEN)SDK build complete!$(NC)\n"
+
+#
+# Clean Commands
+#
+clean:
+	@printf "$(CYAN)Cleaning build artifacts...$(NC)\n"
+	@if [ -d "$(PROJECT_DIR)/build/tmp" ]; then \
+		rm -rf $(PROJECT_DIR)/build/tmp; \
+		printf "Removed build/tmp\n"; \
+	fi
+	@if [ -d "$(PROJECT_DIR)/build/cache" ]; then \
+		rm -rf $(PROJECT_DIR)/build/cache; \
+		printf "Removed build/cache\n"; \
+	fi
+	@printf "$(GREEN)Clean complete.$(NC)\n"
+	@printf "Note: downloads/ and sstate-cache/ preserved for faster rebuilds.\n"
+
+distclean:
+	@printf "$(RED)WARNING: This will remove ALL build artifacts including downloads and sstate-cache.$(NC)\n"
+	@printf "This cannot be undone and will require re-downloading all sources.\n"
+	@read -p "Are you sure? [y/N] " confirm && \
+		if [ "$$confirm" = "y" ] || [ "$$confirm" = "Y" ]; then \
+			rm -rf $(PROJECT_DIR)/build $(PROJECT_DIR)/downloads $(PROJECT_DIR)/sstate-cache; \
+			printf "$(GREEN)Distclean complete.$(NC)\n"; \
+		else \
+			printf "Cancelled.\n"; \
+		fi
+
+#
+# macOS Volume Management
+#
+volumes-create:
+	@if [ "$$(uname)" != "Darwin" ]; then \
+		printf "$(YELLOW)Volumes only needed on macOS. Skipping.$(NC)\n"; \
+		exit 0; \
+	fi
+	@printf "$(CYAN)Creating Docker volumes for case-sensitive storage...$(NC)\n"
+	@docker volume create $(VOLUME_BUILD) >/dev/null && printf "  Created $(VOLUME_BUILD)\n"
+	@docker volume create $(VOLUME_SSTATE) >/dev/null && printf "  Created $(VOLUME_SSTATE)\n"
+	@docker volume create $(VOLUME_DOWNLOADS) >/dev/null && printf "  Created $(VOLUME_DOWNLOADS)\n"
+	@printf "$(GREEN)Volumes created.$(NC)\n"
+
+volumes-remove:
+	@if [ "$$(uname)" != "Darwin" ]; then \
+		printf "$(YELLOW)Volumes only used on macOS. Skipping.$(NC)\n"; \
+		exit 0; \
+	fi
+	@printf "$(RED)WARNING: This will delete all build data in Docker volumes.$(NC)\n"
+	@read -p "Are you sure? [y/N] " confirm && \
+		if [ "$$confirm" = "y" ] || [ "$$confirm" = "Y" ]; then \
+			docker volume rm $(VOLUME_BUILD) $(VOLUME_SSTATE) $(VOLUME_DOWNLOADS) 2>/dev/null || true; \
+			printf "$(GREEN)Volumes removed.$(NC)\n"; \
+		else \
+			printf "Cancelled.\n"; \
+		fi
+
+#
+# Deploy tegraflash tarball (macOS)
+#
+deploy:
+	@if [ "$$(uname)" != "Darwin" ]; then \
+		printf "Images are already on host filesystem at:\n"; \
+		printf "  $(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/\n"; \
+		exit 0; \
+	fi
+	@printf "$(CYAN)Copying tegraflash tarball from Docker volume...$(NC)\n"
+	@mkdir -p $(PROJECT_DIR)/deploy
+	@rm -f $(PROJECT_DIR)/deploy/wendyos.img
+	@docker run --rm -t \
+		-v $(VOLUME_BUILD):/build-volume:ro \
+		-v $(PROJECT_DIR)/deploy:/output \
+		$(DOCKER_REPO):$(DOCKER_TAG) \
+		/bin/bash -c '\
+			TARBALL="/build-volume/deploy/images/$(MACHINE)/$(IMAGE_TARGET)-$(MACHINE).tegraflash.tar.gz"; \
+			if [ -f "$$TARBALL" ]; then \
+				rsync -ahL --progress "$$TARBALL" /output/; \
+			else \
+				echo "Error: tegraflash tarball not found. Run make build first."; \
+				exit 1; \
+			fi \
+		'
+	@printf "$(GREEN)Tegraflash tarball copied to: $(PROJECT_DIR)/deploy/$(NC)\n"
+
+#
+# Flash Commands
+#
+flash-to-external:
+	@printf "$(CYAN)WendyOS Flash Tool$(NC)\n"
+	@printf "$(CYAN)==================$(NC)\n\n"
+	@OS_TYPE=$$(uname); \
+	if [ "$$OS_TYPE" = "Darwin" ]; then DD_BS="4m"; else DD_BS="4M"; fi; \
+	if [ -f "$(PROJECT_DIR)/deploy/wendyos.img" ]; then \
+		IMG_SIZE=$$(ls -lh "$(PROJECT_DIR)/deploy/wendyos.img" | awk '{print $$5}'); \
+		printf "Using existing image: $(PROJECT_DIR)/deploy/wendyos.img ($$IMG_SIZE)\n\n"; \
+	else \
+		if [ "$$OS_TYPE" = "Darwin" ]; then \
+			if [ ! -f "$(PROJECT_DIR)/deploy/$(IMAGE_TARGET)-$(MACHINE).tegraflash.tar.gz" ]; then \
+				printf "Fetching tegraflash tarball from Docker volume...\n"; \
+				$(MAKE) deploy; \
+			fi; \
+		fi; \
+		TEGRAFLASH="$(PROJECT_DIR)/deploy/$(IMAGE_TARGET)-$(MACHINE).tegraflash.tar.gz"; \
+		if [ ! -f "$$TEGRAFLASH" ]; then \
+			if [ "$$OS_TYPE" != "Darwin" ] && [ -f "$(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/$(IMAGE_TARGET)-$(MACHINE).tegraflash.tar.gz" ]; then \
+				TEGRAFLASH="$(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/$(IMAGE_TARGET)-$(MACHINE).tegraflash.tar.gz"; \
+				mkdir -p "$(PROJECT_DIR)/deploy"; \
+			else \
+				printf "$(RED)Error: tegraflash package not found.$(NC)\n"; \
+				printf "Run 'make build' first.\n"; \
+				exit 1; \
+			fi; \
+		fi; \
+		printf "$(CYAN)Creating flashable image...$(NC)\n"; \
+		mkdir -p $(PROJECT_DIR)/deploy/flash-work; \
+		printf "Extracting tegraflash package...\n"; \
+		tar -xzf "$$TEGRAFLASH" -C $(PROJECT_DIR)/deploy/flash-work; \
+		printf "Creating $(FLASH_IMAGE_SIZE) image file (this may take a while)...\n"; \
+		if [ "$$OS_TYPE" = "Darwin" ]; then \
+			docker run --rm -t \
+				--privileged \
+				-v $(PROJECT_DIR)/deploy/flash-work:/flash \
+				-v $(PROJECT_DIR)/deploy:/output \
+				$(DOCKER_REPO):$(DOCKER_TAG) \
+				/bin/bash -c '\
+					cd /flash && \
+					sudo ./doexternal.sh -s $(FLASH_IMAGE_SIZE) /output/wendyos.img \
+				'; \
+		else \
+			cd $(PROJECT_DIR)/deploy/flash-work && \
+			sudo ./doexternal.sh -s $(FLASH_IMAGE_SIZE) $(PROJECT_DIR)/deploy/wendyos.img; \
+		fi; \
+		rm -rf $(PROJECT_DIR)/deploy/flash-work; \
+		printf "\n$(GREEN)Image created: $(PROJECT_DIR)/deploy/wendyos.img$(NC)\n\n"; \
+	fi; \
+	if [ -n "$(FLASH_DEVICE)" ] && [ "$(FLASH_CONFIRM)" = "yes" ]; then \
+		printf "$(YELLOW)Non-interactive mode: flashing to $(FLASH_DEVICE)$(NC)\n\n"; \
+	else \
+		printf "$(YELLOW)Available external disks:$(NC)\n\n"; \
+		if [ "$$OS_TYPE" = "Darwin" ]; then \
+			diskutil list external physical 2>/dev/null || printf "No external disks found.\n"; \
+		else \
+			lsblk -d -o NAME,SIZE,MODEL,TRAN 2>/dev/null | grep -E "usb|sata|nvme" || \
+			lsblk -d -o NAME,SIZE,MODEL 2>/dev/null | grep -vE "^(loop|sr|ram)" | head -20; \
+		fi; \
+		printf "\n"; \
+	fi; \
+	if [ -n "$(FLASH_DEVICE)" ]; then \
+		DEVICE="$(FLASH_DEVICE)"; \
+	else \
+		if [ "$$OS_TYPE" = "Darwin" ]; then \
+			printf "$(YELLOW)Enter the disk to flash (e.g., disk42) or 'q' to quit:$(NC) "; \
+		else \
+			printf "$(YELLOW)Enter the disk to flash (e.g., sdb, nvme0n1) or 'q' to quit:$(NC) "; \
+		fi; \
+		read device_input; \
+		if [ "$$device_input" = "q" ] || [ "$$device_input" = "Q" ]; then \
+			printf "\nCancelled. Image saved at: $(PROJECT_DIR)/deploy/wendyos.img\n"; \
+			exit 0; \
+		fi; \
+		if [ "$$OS_TYPE" = "Darwin" ]; then \
+			case "$$device_input" in \
+				disk[0-9]*) DEVICE="/dev/$$device_input" ;; \
+				/dev/disk[0-9]*) DEVICE="$$device_input" ;; \
+				*) printf "$(RED)Error: Invalid disk name '$$device_input'. Must be like 'disk42' or '/dev/disk42'$(NC)\n"; exit 1 ;; \
+			esac; \
+		else \
+			case "$$device_input" in \
+				sd[a-z]|sd[a-z][a-z]|nvme[0-9]n[0-9]|nvme[0-9][0-9]n[0-9]) DEVICE="/dev/$$device_input" ;; \
+				/dev/sd[a-z]*|/dev/nvme*) DEVICE="$$device_input" ;; \
+				*) printf "$(RED)Error: Invalid disk name '$$device_input'. Must be like 'sdb', 'nvme0n1', or '/dev/sdb'$(NC)\n"; exit 1 ;; \
+			esac; \
+		fi; \
+	fi; \
+	if [ ! -e "$$DEVICE" ]; then \
+		printf "$(RED)Error: Device $$DEVICE does not exist.$(NC)\n"; \
+		exit 1; \
+	fi; \
+	printf "\n"; \
+	printf "$(RED)WARNING: This will ERASE ALL DATA on $$DEVICE!$(NC)\n"; \
+	if [ "$$OS_TYPE" = "Darwin" ]; then \
+		diskutil info "$$DEVICE" 2>/dev/null | grep -E "Device / Media Name|Disk Size" || true; \
+	else \
+		lsblk -o NAME,SIZE,MODEL "$$DEVICE" 2>/dev/null || true; \
+	fi; \
+	printf "\n"; \
+	if [ "$(FLASH_CONFIRM)" = "yes" ]; then \
+		confirm="yes"; \
+	else \
+		printf "$(YELLOW)Type 'yes' to confirm:$(NC) "; \
+		read confirm; \
+	fi; \
+	if [ "$$confirm" = "yes" ]; then \
+		printf "\n$(CYAN)Unmounting $$DEVICE...$(NC)\n"; \
+		if [ "$$OS_TYPE" = "Darwin" ]; then \
+			diskutil unmountDisk "$$DEVICE" 2>/dev/null || true; \
+			RAW_DEVICE=$$(echo "$$DEVICE" | sed 's|/dev/disk|/dev/rdisk|'); \
+		else \
+			sudo umount "$$DEVICE"* 2>/dev/null || true; \
+			RAW_DEVICE="$$DEVICE"; \
+		fi; \
+		printf "$(CYAN)Flashing image to $$RAW_DEVICE...$(NC)\n"; \
+		printf "This may take 5-15 minutes depending on drive speed.\n\n"; \
+		if sudo dd if=$(PROJECT_DIR)/deploy/wendyos.img of="$$RAW_DEVICE" bs=$$DD_BS status=progress; then \
+			sync; \
+			printf "\n$(GREEN)Flash complete!$(NC)\n"; \
+			printf "You can now safely eject the drive and insert it into your Jetson.\n"; \
+			if [ "$$OS_TYPE" = "Darwin" ]; then \
+				diskutil eject "$$DEVICE" 2>/dev/null || true; \
+			else \
+				sudo eject "$$DEVICE" 2>/dev/null || udisksctl power-off -b "$$DEVICE" 2>/dev/null || true; \
+			fi; \
+		else \
+			printf "\n$(RED)Flash FAILED! Check the error above.$(NC)\n"; \
+			exit 1; \
+		fi; \
+	else \
+		printf "\nCancelled. Image saved at: $(PROJECT_DIR)/deploy/wendyos.img\n"; \
+	fi
+
+#
+# Internal Targets
+#
+_check-setup:
+	@if [ ! -d "$(DOCKER_DIR)" ]; then \
+		printf "$(RED)Error: Build environment not set up.$(NC)\n"; \
+		printf "Run 'make setup' first.\n"; \
+		exit 1; \
+	fi
+	@if ! docker image inspect $(DOCKER_REPO):$(DOCKER_TAG) >/dev/null 2>&1; then \
+		printf "$(RED)Error: Docker image not found.$(NC)\n"; \
+		printf "Run 'make setup' or 'make docker-create' first.\n"; \
+		exit 1; \
+	fi
+
+_ensure-volumes:
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		docker volume inspect $(VOLUME_BUILD) >/dev/null 2>&1 || docker volume create $(VOLUME_BUILD) >/dev/null; \
+		docker volume inspect $(VOLUME_SSTATE) >/dev/null 2>&1 || docker volume create $(VOLUME_SSTATE) >/dev/null; \
+		docker volume inspect $(VOLUME_DOWNLOADS) >/dev/null 2>&1 || docker volume create $(VOLUME_DOWNLOADS) >/dev/null; \
+		docker run --rm \
+			-v $(VOLUME_BUILD):/vol/build \
+			-v $(VOLUME_SSTATE):/vol/sstate \
+			-v $(VOLUME_DOWNLOADS):/vol/downloads \
+			$(DOCKER_REPO):$(DOCKER_TAG) \
+			/bin/bash -c 'sudo chown -R $$(id -u):$$(id -g) /vol/build /vol/sstate /vol/downloads' 2>/dev/null || true; \
+	fi

--- a/README.md
+++ b/README.md
@@ -1,21 +1,45 @@
-
 # WendyOS for NVIDIA Jetson Orin Nano Developer Kit
 
 This repository provides the meta-layer and build flow to build **WendyOS** for the **NVIDIA Jetson Orin Nano Developer Kit**.
+
+## TL;DR
+
+```bash
+git clone git@github.com:wendylabsinc/meta-wendyos-jetson.git
+cd meta-wendyos-jetson
+make setup              # First-time setup (~10 min)
+make build              # Build the image (~2-4 hours first time, uses cache after)
+make flash-to-external  # Flash to external NVMe/USB drive
+```
 
 ## Quick Start
 
 ### Prerequisites
 
+**Common Requirements:**
 - Docker installed and running
 - Git
 - At least 100GB of free disk space
 - Reliable internet connection
-- The user under which the image is built must be added to `docker` group
 
-```bash
-$ sudo usermod -aG docker $USER
-```
+**Linux-specific:**
+- The user under which the image is built must be added to `docker` group:
+  ```bash
+  $ sudo usermod -aG docker $USER
+  ```
+
+**macOS-specific:**
+- [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop/) (version 4.0+ recommended)
+- Allocate sufficient resources in Docker Desktop settings:
+  - **Memory**: 8GB minimum (16GB+ recommended)
+  - **Disk**: 150GB minimum for build artifacts
+  - **CPUs**: 4+ cores recommended
+- Install GNU coreutils (optional, for older macOS versions):
+  ```bash
+  $ brew install coreutils
+  ```
+
+> **Note for macOS users**: The Yocto build runs inside a Docker container (Ubuntu 24.04 LTS), so macOS hosts can build just like Linux hosts. The build scripts automatically detect macOS and adjust Docker arguments accordingly.
 
 ### Directory Structure Requirements
 
@@ -33,16 +57,57 @@ Recommended structure:
 
 ### Steps to Build
 
+#### Option A: Using Make (Recommended)
+
+The easiest way to build is using the provided Makefile:
+
+```bash
+# Clone and enter the repository
+cd /path/to/project
+git clone git@github.com:wendylabsinc/meta-wendyos-jetson.git meta-wendyos
+cd meta-wendyos
+
+# First-time setup (clones repos, creates Docker image)
+make setup
+
+# Build the image
+make build
+
+# Or open an interactive shell for development
+make shell
+```
+
+**Available Make Targets:**
+| Target | Description |
+|--------|-------------|
+| `make setup` | First-time setup: clone repos, create Docker image |
+| `make build` | Build the complete WendyOS image |
+| `make deploy` | Copy tegraflash tarball from Docker volume to `./deploy/` (macOS only) |
+| `make flash-to-external` | Interactive flash to external NVMe/USB drive (macOS & Linux) |
+| `make build-sdk` | Build the SDK for application development |
+| `make shell` | Open interactive shell in build container |
+| `make clean` | Remove build artifacts (keeps downloads/sstate) |
+| `make distclean` | Remove everything including downloads |
+| `make help` | Show all available targets |
+
+**Build for different targets:**
+```bash
+# Build for NVMe (default)
+make build
+
+# Build for SD card
+make build MACHINE=jetson-orin-nano-devkit-edgeos
+```
+
+#### Option B: Manual Steps
+
 1. **Clone the repository** (or place it in your working directory):
    ```bash
    cd /path/to/project
-   git clone <repository-url> meta-wendyos
+   git clone git@github.com:wendylabsinc/meta-wendyos-jetson.git meta-wendyos
    cd meta-wendyos
    git checkout <branch>
    ```
-
-The repository URL is:
-`git@github.com:wendylabsinc/meta-wendyos-jetson.git`
 
 2. **Run the bootstrap script**:
 
@@ -338,6 +403,72 @@ In `build/conf/local.conf`:
 - **Boot Method**: UEFI with extlinux
 - **OTA System**: Mender v5.0.x
 - **Display Features**: Removed (headless embedded system)
+
+## Building on macOS
+
+### Overview
+
+Building WendyOS on macOS is fully supported through Docker Desktop. The build process runs inside an Ubuntu 24.04 LTS container, making it identical to building on a Linux host.
+
+### macOS-specific Considerations
+
+1. **Docker Desktop Resources**: Yocto builds are resource-intensive. Configure Docker Desktop with:
+   - At least 8GB RAM (16GB recommended)
+   - 4+ CPUs
+   - 150GB+ disk space
+
+2. **Build Performance**: Builds on macOS may be slower than native Linux due to:
+   - Docker's virtualization layer
+   - File system performance differences (VirtioFS is recommended in Docker Desktop settings)
+
+3. **Network Differences**: On macOS, `--network=host` doesn't work as it does on Linux. The build scripts automatically handle this by using Docker's default bridge networking, which is sufficient for the build process.
+
+4. **X11 Support**: X11 forwarding (for GUI tools like `devtool`) is not available by default on macOS. If needed, install XQuartz and configure it manually. However, Yocto command-line builds work without X11.
+
+### Flashing
+
+Use the interactive flash tool (works on both macOS and Linux):
+
+```bash
+make flash-to-external
+```
+
+This will:
+1. Create a flashable `.img` file (if not already created)
+2. List available external drives
+3. Prompt you to select the target disk
+   - macOS: e.g., `disk42`
+   - Linux: e.g., `sdb` or `nvme0n1`
+4. Flash the image and safely eject the drive
+
+**Non-interactive mode** (for scripting):
+```bash
+# macOS
+make flash-to-external FLASH_DEVICE=/dev/disk42 FLASH_CONFIRM=yes
+
+# Linux
+make flash-to-external FLASH_DEVICE=/dev/sdb FLASH_CONFIRM=yes
+```
+
+### Troubleshooting macOS Builds
+
+**Issue: Docker build fails with network errors**
+- Ensure Docker Desktop has internet access
+- Try restarting Docker Desktop
+
+**Issue: Build runs out of disk space**
+- Increase Docker Desktop disk allocation in Preferences → Resources
+- Clean up old images: `docker system prune -a`
+- Clear the Yocto sstate-cache if needed
+
+**Issue: Permission denied errors on mounted volumes**
+- Ensure the project directory is in a location Docker Desktop can access
+- Check Docker Desktop → Preferences → Resources → File Sharing
+
+**Issue: Build is very slow**
+- Use VirtioFS in Docker Desktop settings for better file system performance
+- Increase allocated CPUs and memory
+- Consider using a shared `sstate-cache` and `downloads` directory across builds
 
 ## License
 

--- a/conf/distro/edgeos.conf
+++ b/conf/distro/edgeos.conf
@@ -53,6 +53,12 @@ DISTRO_FEATURES:append = " opengl"
 # Add virtualization support for NVIDIA Container Toolkit
 DISTRO_FEATURES:append = " virtualization"
 
+# Add Bluetooth support
+DISTRO_FEATURES:append = " bluetooth"
+
+# Add audio support (ALSA)
+DISTRO_FEATURES:append = " alsa"
+
 # Set the '/var/log' location, i.e. either on persistent storage
 # of on volatile filesystem
 #

--- a/conf/template/bblayers.conf
+++ b/conf/template/bblayers.conf
@@ -11,6 +11,7 @@ BBLAYERS ?= " \
     ${TOPDIR}/../repos/meta-mender-community/meta-mender-tegra/meta-mender-tegra-jetpack6 \
     ${TOPDIR}/../repos/meta-openembedded/meta-filesystems \
     ${TOPDIR}/../repos/meta-openembedded/meta-networking \
+    ${TOPDIR}/../repos/meta-openembedded/meta-multimedia \
     ${TOPDIR}/../repos/meta-openembedded/meta-oe \
     ${TOPDIR}/../repos/meta-openembedded/meta-python \
     ${TOPDIR}/../repos/meta-virtualization \

--- a/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,0 +1,16 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://main.conf"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/bluetooth
+    install -m 0644 ${WORKDIR}/main.conf ${D}${sysconfdir}/bluetooth/main.conf
+}
+
+FILES:${PN} += " \
+    ${sysconfdir}/bluetooth/main.conf \
+    "
+
+CONFFILES:${PN} += " \
+    ${sysconfdir}/bluetooth/main.conf \
+    "

--- a/recipes-connectivity/bluez5/files/main.conf
+++ b/recipes-connectivity/bluez5/files/main.conf
@@ -1,0 +1,8 @@
+[General]
+FastConnectable = true
+
+[Policy]
+AutoEnable = true
+ReconnectAttempts = 7
+ReconnectIntervals = 1,2,4,8,16,32,64
+ResumeDelay = 2

--- a/recipes-core/images/edgeos-image.bb
+++ b/recipes-core/images/edgeos-image.bb
@@ -40,6 +40,7 @@ IMAGE_INSTALL:append = " \
     packagegroup-edgeos-base \
     packagegroup-edgeos-kernel \
     packagegroup-edgeos-debug \
+    packagegroup-edgeos-audio \
     mender-esp \
     mender-configure \
     mender-connect \

--- a/recipes-core/packagegroups/packagegroup-edgeos-audio.bb
+++ b/recipes-core/packagegroups/packagegroup-edgeos-audio.bb
@@ -11,6 +11,7 @@ inherit packagegroup
 RDEPENDS:${PN} = " \
     pipewire \
     pipewire-alsa \
+    pipewire-modules-meta \
     pipewire-pulse \
     pipewire-spa-plugins-meta \
     wireplumber \

--- a/recipes-core/packagegroups/packagegroup-edgeos-audio.bb
+++ b/recipes-core/packagegroups/packagegroup-edgeos-audio.bb
@@ -1,0 +1,28 @@
+SUMMARY = "EdgeOS Audio and Bluetooth support"
+DESCRIPTION = "PipeWire, PulseAudio compatibility, and BlueZ for audio and Bluetooth"
+LICENSE = "MIT"
+
+PR = "r0"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+# PipeWire - modern audio/video server (replaces PulseAudio)
+RDEPENDS:${PN} = " \
+    pipewire \
+    pipewire-alsa \
+    pipewire-pulse \
+    pipewire-spa-plugins-meta \
+    wireplumber \
+    "
+
+# BlueZ - Bluetooth stack
+RDEPENDS:${PN}:append = " \
+    bluez5 \
+    bluez5-obex \
+    "
+
+# ALSA utilities
+RDEPENDS:${PN}:append = " \
+    alsa-utils \
+    "

--- a/recipes-core/packagegroups/packagegroup-edgeos-audio.bb
+++ b/recipes-core/packagegroups/packagegroup-edgeos-audio.bb
@@ -26,3 +26,8 @@ RDEPENDS:${PN}:append = " \
 RDEPENDS:${PN}:append = " \
     alsa-utils \
     "
+
+# PipeWire CLI utilities (pw-cli, pw-dump, etc.)
+RDEPENDS:${PN}:append = " \
+    pipewire-tools \
+    "

--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -1,0 +1,3 @@
+# Enable PipeWire as a system service for headless operation
+SYSTEMD_SERVICE:${PN} = "pipewire.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"

--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -4,3 +4,12 @@ SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 SYSTEMD_SERVICE:pipewire-pulse = "pipewire-pulse.service"
 SYSTEMD_AUTO_ENABLE:pipewire-pulse = "enable"
+
+# Ensure Bluetooth support is enabled in PipeWire builds.
+PACKAGECONFIG:append = " bluez bluez-opus"
+
+# Ensure the service user has a writable home for WirePlumber state.
+USERADD_PARAM:${PN} = "--system --home /var/lib/pipewire --create-home \
+                       --comment 'PipeWire multimedia daemon' \
+                       --gid pipewire --groups audio,video \
+                       pipewire"

--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -1,3 +1,6 @@
 # Enable PipeWire as a system service for headless operation
 SYSTEMD_SERVICE:${PN} = "pipewire.service"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+SYSTEMD_SERVICE:pipewire-pulse = "pipewire-pulse.service"
+SYSTEMD_AUTO_ENABLE:pipewire-pulse = "enable"

--- a/recipes-multimedia/wireplumber/files/50-wendy-bluetooth.conf
+++ b/recipes-multimedia/wireplumber/files/50-wendy-bluetooth.conf
@@ -3,6 +3,7 @@
 wireplumber.settings = {
   bluetooth.autoswitch-to-headset-profile = true
   bluetooth.use-persistent-storage = true
+  node.restore-default-targets = true
 }
 
 monitor.bluez.rules = [

--- a/recipes-multimedia/wireplumber/files/50-wendy-bluetooth.conf
+++ b/recipes-multimedia/wireplumber/files/50-wendy-bluetooth.conf
@@ -1,0 +1,21 @@
+## WendyOS Bluetooth audio policy
+
+wireplumber.settings = {
+  bluetooth.autoswitch-to-headset-profile = true
+  bluetooth.use-persistent-storage = true
+}
+
+monitor.bluez.rules = [
+  {
+    matches = [
+      {
+        device.name = "~bluez_card.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        bluez5.auto-connect = [ a2dp_sink hfp_hf hsp_hs ]
+      }
+    }
+  }
+]

--- a/recipes-multimedia/wireplumber/files/60-wendy-defaults.conf
+++ b/recipes-multimedia/wireplumber/files/60-wendy-defaults.conf
@@ -1,0 +1,8 @@
+## WendyOS default audio routing for Bluetooth devices
+
+wireplumber.components = [
+  {
+    name = wendy/default-nodes.lua, type = script/lua
+    requires = [ metadata.default ]
+  }
+]

--- a/recipes-multimedia/wireplumber/files/wendy-default-nodes.lua
+++ b/recipes-multimedia/wireplumber/files/wendy-default-nodes.lua
@@ -1,0 +1,168 @@
+-- WendyOS Bluetooth default node switching
+-- Prefer Bluetooth audio devices on connect and allow default restoration on disconnect.
+
+log = Log.open_topic ("s-wendy-default-nodes")
+
+local function is_bluetooth_node (props)
+  if not props then
+    return false
+  end
+
+  local api = props ["device.api"]
+  if api == "bluez5" or api == "bluez" then
+    return true
+  end
+
+  local node_name = props ["node.name"]
+  if node_name and node_name:match ("^bluez_") then
+    return true
+  end
+
+  local device_name = props ["device.name"]
+  if device_name and device_name:match ("^bluez_") then
+    return true
+  end
+
+  return false
+end
+
+local function parse_metadata_name (value)
+  if not value then
+    return nil
+  end
+
+  local ok, parsed = pcall (function ()
+    return Json.Raw (value):parse ()
+  end)
+  if not ok or not parsed then
+    return nil
+  end
+
+  return parsed.name
+end
+
+local function get_metadata_name (metadata, key)
+  local obj = metadata:find (0, key)
+  if not obj then
+    return nil
+  end
+
+  return parse_metadata_name (obj)
+end
+
+local function set_metadata_name (metadata, key, name)
+  if name and name ~= "" then
+    metadata:set (0, key, "Spa:String:JSON",
+        Json.Object { ["name"] = name }:to_string ())
+  else
+    metadata:set (0, key, nil, nil)
+  end
+end
+
+local function ensure_configured_seed (metadata, def_type)
+  local configured_key = "default.configured." .. def_type
+  local configured = get_metadata_name (metadata, configured_key)
+  if configured then
+    return configured
+  end
+
+  local current_default = get_metadata_name (metadata, "default." .. def_type)
+  if current_default then
+    set_metadata_name (metadata, configured_key, current_default)
+  end
+
+  return current_default
+end
+
+local function default_types_for_media_class (media_class)
+  if not media_class then
+    return nil
+  end
+
+  if media_class == "Audio/Duplex" then
+    return { "audio.sink", "audio.source" }
+  end
+
+  local types = {}
+  if media_class:find ("Sink") then
+    table.insert (types, "audio.sink")
+  end
+  if media_class:find ("Source") then
+    table.insert (types, "audio.source")
+  end
+
+  if #types == 0 then
+    return nil
+  end
+
+  return types
+end
+
+local function handle_bluetooth_linkable_added (event)
+  local si = event:get_subject ()
+  if not si then
+    return
+  end
+
+  local node = si:get_associated_proxy ("node")
+  if not node then
+    return
+  end
+
+  local props = node.properties
+  if not props or not is_bluetooth_node (props) then
+    return
+  end
+
+  local media_class = props ["media.class"]
+  if not media_class or not media_class:match ("^Audio/") then
+    return
+  end
+
+  local types = default_types_for_media_class (media_class)
+  if not types then
+    return
+  end
+
+  local node_name = props ["node.name"]
+  if not node_name or node_name == "" then
+    return
+  end
+
+  local source = event:get_source ()
+  local metadata_om = source:call ("get-object-manager", "metadata")
+  if not metadata_om then
+    return
+  end
+
+  local metadata = metadata_om:lookup {
+    Constraint { "metadata.name", "=", "default" },
+  }
+  if not metadata then
+    return
+  end
+
+  for _, def_type in ipairs (types) do
+    ensure_configured_seed (metadata, def_type)
+
+    local configured_key = "default.configured." .. def_type
+    local configured = get_metadata_name (metadata, configured_key)
+    if configured ~= node_name then
+      log:info ("Switching " .. configured_key .. " to " .. node_name)
+      set_metadata_name (metadata, configured_key, node_name)
+    end
+  end
+end
+
+SimpleEventHook {
+  name = "wendy-default-nodes/bluetooth-added",
+  before = "default-nodes/rescan-trigger",
+  interests = {
+    EventInterest {
+      Constraint { "event.type", "=", "session-item-added" },
+      Constraint { "event.session-item.interface", "=", "linkable" },
+      Constraint { "media.class", "#", "Audio/*" },
+    },
+  },
+  execute = handle_bluetooth_linkable_added
+}:register ()

--- a/recipes-multimedia/wireplumber/files/wireplumber.service.d/override.conf
+++ b/recipes-multimedia/wireplumber/files/wireplumber.service.d/override.conf
@@ -1,0 +1,5 @@
+[Service]
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
+Environment=HOME=/var/lib/pipewire
+Environment=XDG_RUNTIME_DIR=/run/pipewire
+Environment=XDG_STATE_HOME=/var/lib/pipewire/.local/state

--- a/recipes-multimedia/wireplumber/wireplumber_%.bbappend
+++ b/recipes-multimedia/wireplumber/wireplumber_%.bbappend
@@ -4,18 +4,36 @@ SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://50-wendy-bluetooth.conf"
+SRC_URI += "file://50-wendy-bluetooth.conf \
+            file://60-wendy-defaults.conf \
+            file://wendy-default-nodes.lua \
+            file://wireplumber.service.d/override.conf"
 
 do_install:append() {
     install -d ${D}${sysconfdir}/wireplumber/wireplumber.conf.d
     install -m 0644 ${WORKDIR}/50-wendy-bluetooth.conf \
         ${D}${sysconfdir}/wireplumber/wireplumber.conf.d/50-wendy-bluetooth.conf
+    install -m 0644 ${WORKDIR}/60-wendy-defaults.conf \
+        ${D}${sysconfdir}/wireplumber/wireplumber.conf.d/60-wendy-defaults.conf
+
+    install -d ${D}${datadir}/wireplumber/scripts/wendy
+    install -m 0644 ${WORKDIR}/wendy-default-nodes.lua \
+        ${D}${datadir}/wireplumber/scripts/wendy/default-nodes.lua
+
+    install -d ${D}${sysconfdir}/systemd/system/wireplumber.service.d
+    install -m 0644 ${WORKDIR}/wireplumber.service.d/override.conf \
+        ${D}${sysconfdir}/systemd/system/wireplumber.service.d/override.conf
 }
 
 FILES:${PN} += " \
     ${sysconfdir}/wireplumber/wireplumber.conf.d/50-wendy-bluetooth.conf \
+    ${sysconfdir}/wireplumber/wireplumber.conf.d/60-wendy-defaults.conf \
+    ${datadir}/wireplumber/scripts/wendy/default-nodes.lua \
+    ${sysconfdir}/systemd/system/wireplumber.service.d/override.conf \
     "
 
 CONFFILES:${PN} += " \
     ${sysconfdir}/wireplumber/wireplumber.conf.d/50-wendy-bluetooth.conf \
+    ${sysconfdir}/wireplumber/wireplumber.conf.d/60-wendy-defaults.conf \
+    ${sysconfdir}/systemd/system/wireplumber.service.d/override.conf \
     "

--- a/recipes-multimedia/wireplumber/wireplumber_%.bbappend
+++ b/recipes-multimedia/wireplumber/wireplumber_%.bbappend
@@ -1,0 +1,3 @@
+# Enable WirePlumber as a system service for headless operation
+SYSTEMD_SERVICE:${PN} = "wireplumber.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"

--- a/recipes-multimedia/wireplumber/wireplumber_%.bbappend
+++ b/recipes-multimedia/wireplumber/wireplumber_%.bbappend
@@ -1,3 +1,21 @@
 # Enable WirePlumber as a system service for headless operation
 SYSTEMD_SERVICE:${PN} = "wireplumber.service"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://50-wendy-bluetooth.conf"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/wireplumber/wireplumber.conf.d
+    install -m 0644 ${WORKDIR}/50-wendy-bluetooth.conf \
+        ${D}${sysconfdir}/wireplumber/wireplumber.conf.d/50-wendy-bluetooth.conf
+}
+
+FILES:${PN} += " \
+    ${sysconfdir}/wireplumber/wireplumber.conf.d/50-wendy-bluetooth.conf \
+    "
+
+CONFFILES:${PN} += " \
+    ${sysconfdir}/wireplumber/wireplumber.conf.d/50-wendy-bluetooth.conf \
+    "

--- a/scripts/docker/docker-util.sh
+++ b/scripts/docker/docker-util.sh
@@ -256,9 +256,14 @@ done
 }
 
 [ 1 -eq "${opts[remove]}" ] && {
-    printf "Remove Docker image... (%s:%s)\n" "${DOCKER_REPO}" "${DOCKER_TAG}"
-    docker image rm "${DOCKER_REPO}:${DOCKER_TAG}"
-    exit $?
+    if docker_image_exists "${DOCKER_REPO}" "${DOCKER_TAG}"; then
+        printf "Remove Docker image... (%s:%s)\n" "${DOCKER_REPO}" "${DOCKER_TAG}"
+        docker image rm "${DOCKER_REPO}:${DOCKER_TAG}"
+        exit $?
+    else
+        printf "Docker image not found (%s:%s), nothing to remove.\n" "${DOCKER_REPO}" "${DOCKER_TAG}"
+        exit 0
+    fi
 }
 
 if [[ 1 -eq "${opts[create]}" ]]

--- a/scripts/docker/dockerfile
+++ b/scripts/docker/dockerfile
@@ -24,12 +24,12 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && \
     apt-get -qy upgrade && \
     apt-get -qy install \
-        gawk wget git-core diffstat unzip texinfo gcc-multilib \
+        gawk wget git-core diffstat unzip texinfo \
         build-essential chrpath socat cpio python3 python3-pip \
         python3-pexpect xz-utils debianutils iputils-ping python3-git \
         python3-jinja2 python3-yaml libsdl1.2-dev xterm make \
         xsltproc docbook-utils fop dblatex xmlto git-lfs u-boot-tools \
-        strace tree fdisk \
+        strace tree fdisk rsync \
         lz4 zstd liblz4-tool graphviz \
         python3-gi python3-gi-cairo gir1.2-gtk-3.0 x11-apps \
         libncurses5-dev libncursesw5-dev bison flex patchutils \


### PR DESCRIPTION
> **Note**: This PR depends on #19 and should be merged after it.

## Summary

Add audio and Bluetooth support to WendyOS using PipeWire (with PulseAudio compatibility) and BlueZ.

## Changes

- Add `bluetooth` and `alsa` distro features to `edgeos.conf`
- Create `packagegroup-edgeos-audio` with:
  - **PipeWire** - Modern audio/video server (replaces PulseAudio)
  - **PipeWire-pulse** - PulseAudio compatibility layer
  - **PipeWire-ALSA** - ALSA plugin support
  - **PipeWire BlueZ5** - Bluetooth audio support (A2DP, HFP)
  - **WirePlumber** - Session manager for PipeWire
  - **BlueZ5** - Bluetooth stack
  - **ALSA utilities** - Audio debugging tools
- Include `packagegroup-edgeos-audio` in `edgeos-image`

## Features Enabled

| Feature | Description |
|---------|-------------|
| Bluetooth pairing | Pair with phones, headphones, speakers |
| Bluetooth audio (A2DP) | Stream audio to/from Bluetooth devices |
| Bluetooth HFP | Hands-free profile for calls |
| USB audio | Support for USB microphones/speakers |
| HDMI audio | Audio output via HDMI |
| PulseAudio apps | Run apps that expect PulseAudio |

## Test plan

- [ ] Build image with audio support
- [ ] Verify BlueZ service starts
- [ ] Verify PipeWire service starts
- [ ] Test Bluetooth pairing with a device
- [ ] Test audio playback

## Dependencies

- Depends on #19 (Makefile build system)