### PR TITLE
Add PipeWire and BlueZ audio/bluetooth support

### DIFF
--- a/conf/template/bblayers.conf
+++ b/conf/template/bblayers.conf
@@ -10,6 +10,7 @@ BBLAYERS ?= " \
     ${TOPDIR}/../repos/meta-mender-community/meta-mender-tegra/meta-mender-tegra-common \
     ${TOPDIR}/../repos/meta-mender-community/meta-mender-tegra/meta-mender-tegra-jetpack6 \
     ${TOPDIR}/../repos/meta-openembedded/meta-filesystems \
+    ${TOPDIR}/../repos/meta-openembedded/meta-multimedia \
     ${TOPDIR}/../repos/meta-openembedded/meta-networking \
     ${TOPDIR}/../repos/meta-openembedded/meta-oe \
     ${TOPDIR}/../repos/meta-openembedded/meta-python \

--- a/recipes-core/images/edgeos-image.bb
+++ b/recipes-core/images/edgeos-image.bb
@@ -49,6 +49,11 @@ IMAGE_INSTALL:append = " \
     wendyos-containerd-registry \
     wendyos-dev-registry-image \
     python3-pip-jetson-config \
+    bluez5 \
+    pipewire \
+    wireplumber \
+    pipewire-pulse \
+    pipewire-alsa \
     "
 
 # Enable USB peripheral (gadget) support

--- a/recipes-support/nvidia-container-config/files/devices-wendyos.csv
+++ b/recipes-support/nvidia-container-config/files/devices-wendyos.csv
@@ -8,3 +8,7 @@ dir, /proc/device-tree
 
 # CPU information (for cpuinfo library - fixes PyTorch initialization)
 dir, /sys/devices/system/cpu
+
+# PipeWire audio/video server sockets
+dir, /run/pipewire
+dir, /run/user/1000/pipewire


### PR DESCRIPTION
Changes:
- Add BlueZ5 for Bluetooth support
- Add PipeWire audio server with PulseAudio and ALSA compatibility
- Add WirePlumber session manager
- Enable meta-multimedia layer in bblayers template
- Add PipeWire socket directories to CDI spec for container access

This enables modern audio/video routing on the host with Bluetooth support, while allowing containers to access PipeWire via sockets.