### PR TITLE
Add Jetson AGX Orin 64GB NVMe support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ DOCKER_TAG := scarthgap
 DOCKER_USER := dev
 DOCKER_WORKDIR := /home/$(DOCKER_USER)/$(IMAGE_NAME)
 BUILD_DIR := build
-MACHINE ?= jetson-orin-nano-devkit-nvme-edgeos
-IMAGE_TARGET ?= edgeos-image
+MACHINE ?= jetson-orin-nano-devkit-nvme-wendyos
+IMAGE_TARGET ?= wendyos-image
 
 # Flash configuration
 FLASH_DEVICE ?=
@@ -91,7 +91,8 @@ help:
 	@printf "$(YELLOW)Examples:$(NC)\n"
 	@printf "  make setup                                    # First time setup\n"
 	@printf "  make build                                    # Build default image\n"
-	@printf "  make build MACHINE=jetson-orin-nano-devkit-edgeos  # Build for SD card\n"
+	@printf "  make build MACHINE=jetson-orin-nano-devkit-wendyos  # Build for SD card\n"
+	@printf "  make build MACHINE=jetson-agx-orin-devkit-nvme-wendyos  # Build for AGX Orin 64GB\n"
 	@printf "  make shell                                    # Interactive development\n"
 	@printf "  make flash-to-external                        # Interactive flash\n"
 	@printf "  make flash-to-external FLASH_DEVICE=/dev/disk4 FLASH_CONFIRM=yes  # Non-interactive\n"
@@ -171,7 +172,7 @@ build: _check-setup _ensure-volumes
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
 				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
-				MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
 			'; \
 	else \
 		cd $(DOCKER_DIR) && docker run \
@@ -186,7 +187,7 @@ build: _check-setup _ensure-volumes
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
 				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
-				MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
 			'; \
 	fi
 	@printf "\n"
@@ -213,7 +214,7 @@ build-sdk: _check-setup _ensure-volumes
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
 				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
-				MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
 			'; \
 	else \
 		cd $(DOCKER_DIR) && docker run \
@@ -228,7 +229,7 @@ build-sdk: _check-setup _ensure-volumes
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
 				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
-				MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
 			'; \
 	fi
 	@printf "\n"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# WendyOS for NVIDIA Jetson Orin Nano Developer Kit
+# WendyOS for NVIDIA Jetson Developer Kits
 
-This repository provides the meta-layer and build flow to build **WendyOS** for the **NVIDIA Jetson Orin Nano Developer Kit**.
+This repository provides the meta-layer and build flow to build **WendyOS** for **NVIDIA Jetson Developer Kits**, including:
+- **Jetson Orin Nano Developer Kit** (8GB)
+- **Jetson AGX Orin Developer Kit** (64GB)
+
+### Supported Hardware
+
+| Hardware | SoC | RAM | Machine Config | Boot Device |
+|----------|-----|-----|----------------|-------------|
+| Jetson Orin Nano DevKit | Tegra234 | 8GB | `jetson-orin-nano-devkit-wendyos` | eMMC/SD |
+| Jetson Orin Nano DevKit | Tegra234 | 8GB | `jetson-orin-nano-devkit-nvme-wendyos` | NVMe |
+| Jetson AGX Orin DevKit | Tegra234 | 64GB | `jetson-agx-orin-devkit-nvme-wendyos` | NVMe |
 
 ## TL;DR
 
@@ -118,11 +128,14 @@ make shell
 
 **Build for different targets:**
 ```bash
-# Build for NVMe (default)
+# Build for Orin Nano NVMe (default)
 make build
 
-# Build for SD card
-make build MACHINE=jetson-orin-nano-devkit-edgeos
+# Build for AGX Orin 64GB (NVMe)
+make build MACHINE=jetson-agx-orin-devkit-nvme-wendyos
+
+# Build for Orin Nano SD card/eMMC
+make build MACHINE=jetson-orin-nano-devkit-wendyos
 ```
 
 #### Option B: Manual Steps
@@ -157,8 +170,9 @@ make build MACHINE=jetson-orin-nano-devkit-edgeos
    - `DL_DIR` - Download directory for source tarballs (recommended for caching)
    - `SSTATE_DIR` - Shared state cache directory (speeds up rebuilds)
    - `MACHINE` - Target machine configuration:
-     - `jetson-orin-nano-devkit-nvme-wendyos` (NVMe boot) [**default**]
-     - `jetson-orin-nano-devkit-wendyos` (eMMC/SD card boot)
+     - `jetson-orin-nano-devkit-nvme-wendyos` (Orin Nano - NVMe boot) [**default**]
+     - `jetson-orin-nano-devkit-wendyos` (Orin Nano - eMMC/SD card boot)
+     - `jetson-agx-orin-devkit-nvme-wendyos` (AGX Orin 64GB - NVMe boot)
    - `WENDYOS_FLASH_IMAGE_SIZE` - Flash image size: "64GB"):
      - `"4GB"` - 3.2GB Mender storage (~1.3GB per rootfs partition)
      - `"8GB"` - 6.4GB Mender storage (~2.9GB per rootfs partition)
@@ -191,7 +205,7 @@ build/tmp/deploy/images/<machine>/wendyos-image-<machine>.rootfs.tegraflash.tar.
 ```
 
 **Important**: The flashing script differs based on your target machine:
-- **NVMe** (`jetson-orin-nano-devkit-nvme-wendyos`) → use `doexternal.sh`
+- **NVMe** (`jetson-orin-nano-devkit-nvme-wendyos`, `jetson-agx-orin-devkit-nvme-wendyos`) → use `doexternal.sh`
 - **eMMC/SD card** (`jetson-orin-nano-devkit-wendyos`) → use `dosdcard.sh`
 
 #### For eMMC/SD Card Builds
@@ -383,7 +397,7 @@ sudo ./initrd-flash.sh
 ```
 
 **Note:** The script reads configuration from `.env.initrd-flash` (created during build), which contains:
-- Machine type (jetson-orin-nano-devkit-nvme-wendyos or jetson-orin-nano-devkit-wendyos)
+- Machine type (e.g., `jetson-orin-nano-devkit-nvme-wendyos`, `jetson-agx-orin-devkit-nvme-wendyos`, `jetson-orin-nano-devkit-wendyos`)
 - Target device (NVMe or eMMC)
 - Board IDs and other hardware parameters
 

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -28,7 +28,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.10.4"
+DISTRO_VERSION = "0.10.5"
 DISTRO_CODENAME = "scarthgap"
 
 SDK_VENDOR = "-wendyossdk"

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -28,7 +28,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.10.5"
+DISTRO_VERSION = "0.12.0"
 DISTRO_CODENAME = "scarthgap"
 
 SDK_VENDOR = "-wendyossdk"

--- a/conf/machine/jetson-agx-orin-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-agx-orin-devkit-nvme-wendyos.conf
@@ -1,0 +1,62 @@
+
+# jetson-agx-orin-devkit-nvme-wendyos.conf
+# NVMe boot configuration for Jetson AGX Orin DevKit (P3701-0005, 64GB RAM variant)
+
+MACHINEOVERRIDES =. "jetson-agx-orin-devkit:"
+
+# Inherit from upstream 64GB AGX Orin config (P3701-0005, SKU 0005)
+# This sets TEGRA_BOARDSKU, KERNEL_DEVICETREE, BPMP DTB, PMIC, and SDRAM configs
+# for the 64GB module variant
+require conf/machine/p3737-0000-p3701-0005.conf
+
+# Use NVIDIA prebuilt UEFI firmware for AGX Orin
+# Source-built edk2-firmware-tegra causes a boot loop on this platform
+PREFERRED_PROVIDER_virtual/bootloader = "tegra-uefi-prebuilt"
+
+# AB upgrades & bootloader choices (board-specific)
+UBOOT_EXTLINUX = "1"
+USE_REDUNDANT_FLASH_LAYOUT_DEFAULT = "1"
+
+MENDER_FEATURES_DISABLE:append = " mender-uboot"
+MENDER_EFI_LOADER = ""
+
+# UEFI Capsule Update Configuration
+# Disable Secure Boot for development/testing (no signing keys configured)
+# When "false": No key enrollment, Secure Boot disabled, unsigned capsules accepted
+# Set to "true" for production after implementing proper signing infrastructure
+TEGRA_UEFI_USE_SIGNED_FILES = "false"
+
+# NVMe Storage geometry (board-specific)
+# Set flash image size to 64GB (automatically sets MENDER_STORAGE_TOTAL_SIZE_MB = 51000)
+WENDYOS_FLASH_IMAGE_SIZE = "64GB"
+MENDER_STORAGE_DEVICE_BASE = "/dev/nvme0n1p"
+MENDER_BOOT_PART = "${MENDER_STORAGE_DEVICE_BASE}11"
+MENDER_ROOTFS_PART_A = "${MENDER_STORAGE_DEVICE_BASE}1"
+MENDER_ROOTFS_PART_B = "${MENDER_STORAGE_DEVICE_BASE}2"
+
+# IMPORTANT: Use partition 17 for Mender data, NOT partition 15 (UDA)
+# UDA (p15) is reserved by NVIDIA and positioned before rootfs partitions,
+# preventing expansion. Partition 17 (mender_data, renamed from permanet_user_storage)
+# is positioned AFTER APP_b and can expand to fill remaining disk space.
+# See docs/partition-layout-fix-plan.md for detailed analysis.
+MENDER_DATA_PART_NUMBER = "17"
+MENDER_DATA_PART = "${MENDER_STORAGE_DEVICE_BASE}${MENDER_DATA_PART_NUMBER}"
+
+# Initial size - will auto-expand on first boot via mender-grow-data.service
+MENDER_DATA_PART_SIZE_MB = "512"
+
+# NVMe boot device configuration
+TNSPEC_BOOTDEV = "nvme0n1p1"
+
+# Use NVMe partition layout (same as Orin Nano - both use Tegra234)
+PARTITION_LAYOUT_TEMPLATE_DEFAULT = "flash_t234_qspi.xml"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT = "1"
+PARTITION_LAYOUT_EXTERNAL_DEFAULT = "flash_l4t_t234_nvme.xml"
+
+# Jetson image formats that are machine/BSP oriented:
+IMAGE_FSTYPES:tegra = "tegraflash mender dataimg"
+IMAGE_FSTYPES:pn-tegra-minimal-initramfs:tegra = "${INITRAMFS_FSTYPES}"
+IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INITRAMFS_FSTYPES}"
+
+# If you really need it, board param (but consider removing if unused):
+EMMC_SIZE = "0"

--- a/conf/template/local.conf
+++ b/conf/template/local.conf
@@ -1,6 +1,11 @@
 
-#MACHINE = "jetson-orin-nano-devkit-wendyos"
-MACHINE = "jetson-orin-nano-devkit-nvme-wendyos"
+# Machine configuration (override with MACHINE=... make build):
+# Orin Nano - eMMC boot:
+#MACHINE ?= "jetson-orin-nano-devkit-wendyos"
+# Orin Nano - NVMe boot (default):
+MACHINE ?= "jetson-orin-nano-devkit-nvme-wendyos"
+# AGX Orin 64GB - NVMe boot:
+#MACHINE ?= "jetson-agx-orin-devkit-nvme-wendyos"
 DL_DIR = "${TOPDIR}/../downloads"
 SSTATE_DIR = "${TOPDIR}/../sstate-cache"
 #TMPDIR = "${TOPDIR}/tmp"

--- a/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
+++ b/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
@@ -11,10 +11,14 @@ PATH =. "${STAGING_BINDIR_NATIVE}/tegra-flash:"
 # This runs AFTER meta-mender-tegra's do_install:append which creates the _rootfs_ab.xml variant
 
 do_install:append() {
-    # Only apply to NVMe variant
-    if [ "${MACHINE}" != "jetson-orin-nano-devkit-nvme-wendyos" ]; then
-        return
-    fi
+    # Only apply to NVMe variants (both Nano and AGX use same T234 partition layout)
+    case "${MACHINE}" in
+        jetson-orin-nano-devkit-nvme-wendyos|jetson-agx-orin-devkit-nvme-wendyos)
+            ;;
+        *)
+            return
+            ;;
+    esac
 
     # Modify the _rootfs_ab.xml file created by meta-mender-tegra
     local layout_file="flash_l4t_t234_nvme_rootfs_ab.xml"

--- a/recipes-bsp/uefi/l4t-launcher-extlinux.bbappend
+++ b/recipes-bsp/uefi/l4t-launcher-extlinux.bbappend
@@ -2,3 +2,6 @@
 # Override the mender-community setting which incorrectly uses /boot/ prefix
 UBOOT_EXTLINUX_FDT:jetson-orin-nano-devkit = "tegra234-p3768-0000+p3767-0005-nv-super.dtb"
 
+# AGX Orin DevKit (64GB variant uses P3701-0005 module on P3737-0000 carrier)
+UBOOT_EXTLINUX_FDT:jetson-agx-orin-devkit = "tegra234-p3737-0000+p3701-0005-nv.dtb"
+

--- a/recipes-connectivity/avahi/files/wendyos-mdns.service
+++ b/recipes-connectivity/avahi/files/wendyos-mdns.service
@@ -48,7 +48,6 @@
     <type>_wendyos._udp</type>
     <port>50051</port>
     <txt-record>id=DEVICE_ID_PLACEHOLDER</txt-record>
-    <txt-record>wendyosdevice=SOME_DEVICE_ID</txt-record>
     <txt-record>name=DEVICE_NAME_PLACEHOLDER</txt-record>
     <txt-record>displayname=DEVICE_DISPLAYNAME_PLACEHOLDER</txt-record>
   </service>

--- a/recipes-connectivity/avahi/files/wendyos-mdns.service
+++ b/recipes-connectivity/avahi/files/wendyos-mdns.service
@@ -48,6 +48,7 @@
     <type>_wendyos._udp</type>
     <port>50051</port>
     <txt-record>id=DEVICE_ID_PLACEHOLDER</txt-record>
+    <txt-record>fqdn=DEVICE_FQDN_PLACEHOLDER</txt-record>
     <txt-record>name=DEVICE_NAME_PLACEHOLDER</txt-record>
     <txt-record>displayname=DEVICE_DISPLAYNAME_PLACEHOLDER</txt-record>
   </service>

--- a/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
+++ b/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
@@ -38,14 +38,8 @@ DEVICE_NAME=$(cat "$DEVICE_NAME_FILE" 2>/dev/null || echo "unknown-device")
 # Generate display name (Title Case with spaces)
 DISPLAY_NAME=$(echo "$DEVICE_NAME" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2));}1')
 
-# Generate device ID for macOS app discovery (format: "WendyOS Device <device-name>")
-DEVICE_ID="WendyOS Device $DEVICE_NAME"
-
-# Replace SOME_DEVICE_ID with actual UUID
-sed -i "s/SOME_DEVICE_ID/$UUID/g" "$SERVICE_FILE"
-
-# Replace device ID placeholder (for macOS app discovery)
-sed -i "s/DEVICE_ID_PLACEHOLDER/$DEVICE_ID/g" "$SERVICE_FILE"
+# Replace device ID placeholder with UUID
+sed -i "s/DEVICE_ID_PLACEHOLDER/$UUID/g" "$SERVICE_FILE"
 
 # Replace device name placeholders
 sed -i "s/DEVICE_NAME_PLACEHOLDER/$DEVICE_NAME/g" "$SERVICE_FILE"

--- a/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
+++ b/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
@@ -38,10 +38,15 @@ DEVICE_NAME=$(cat "$DEVICE_NAME_FILE" 2>/dev/null || echo "unknown-device")
 # Generate display name (Title Case with spaces)
 DISPLAY_NAME=$(echo "$DEVICE_NAME" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2));}1')
 
-# Replace device ID placeholder with UUID
-sed -i "s/DEVICE_ID_PLACEHOLDER/$UUID/g" "$SERVICE_FILE"
+# Default domain for unprovisioned devices
+DEFAULT_DOMAIN="sh.wendy"
 
-# Replace device name placeholders
+# Build FQDN: <domain>.<device-name> (e.g. sh.wendy.warm-pepper)
+FQDN="${DEFAULT_DOMAIN}.${DEVICE_NAME}"
+
+# Replace placeholders in service file
+sed -i "s/DEVICE_ID_PLACEHOLDER/$UUID/g" "$SERVICE_FILE"
+sed -i "s/DEVICE_FQDN_PLACEHOLDER/$FQDN/g" "$SERVICE_FILE"
 sed -i "s/DEVICE_NAME_PLACEHOLDER/$DEVICE_NAME/g" "$SERVICE_FILE"
 sed -i "s/DEVICE_DISPLAYNAME_PLACEHOLDER/$DISPLAY_NAME/g" "$SERVICE_FILE"
 

--- a/recipes-devtools/wendyos-containerd-registry/files/wendyos-dev-registry.service
+++ b/recipes-devtools/wendyos-containerd-registry/files/wendyos-dev-registry.service
@@ -1,9 +1,8 @@
 [Unit]
 Description=WendyOS Development Container Registry
 Documentation=https://github.com/mihai-chiorean/containerd-registry
-After=containerd.service network-online.target
+After=containerd.service
 Requires=containerd.service
-Wants=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Summary

- Add machine config `jetson-agx-orin-devkit-nvme-wendyos` for Jetson AGX Orin 64GB (P3701-0005) with NVMe boot
- Use upstream `p3737-0000-p3701-0005.conf` for correct SKU 0005, DTB, BPMP, PMIC, and SDRAM configs
- Use NVIDIA prebuilt UEFI firmware (`tegra-uefi-prebuilt`) — source-built edk2 causes a boot loop on AGX Orin
- Add NVMe partition layout with Mender A/B rootfs and expandable data partition
- Fix stale `edgeos` references in Makefile/README, update defaults to `wendyos`
- Bump DISTRO_VERSION to 0.10.5

## Build & Flash

One-command build with MACHINE as env var:
```bash
# AGX Orin 64GB (NVMe)
MACHINE=jetson-agx-orin-devkit-nvme-wendyos make build

# Orin Nano NVMe (default)
make build

# Orin Nano eMMC/SD
MACHINE=jetson-orin-nano-devkit-wendyos make build
```

Flash via USB recovery (initrd-flash):
```bash
cd deploy && sudo ./initrd-flash.sh
```

## Test plan

- [x] Built image for `jetson-agx-orin-devkit-nvme-wendyos`
- [x] Flashed AGX Orin 64GB via initrd-flash (USB recovery mode)
- [x] Device boots successfully (WendyOS 0.10.5, kernel 5.15.148-l4t-r36.4.4)
- [x] SSH access over USB gadget confirmed
- [x] 61GB RAM / 8 cores detected correctly
- [ ] Verify Orin Nano builds still work with updated Makefile defaults