### PR TITLE
Migrate mDNS TXT records: use id for UUID, drop wendyosdevice, add fqdn

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -28,7 +28,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.10.5"
+DISTRO_VERSION = "0.12.0"
 DISTRO_CODENAME = "scarthgap"
 
 SDK_VENDOR = "-wendyossdk"

--- a/recipes-connectivity/avahi/files/wendyos-mdns.service
+++ b/recipes-connectivity/avahi/files/wendyos-mdns.service
@@ -48,7 +48,6 @@
     <type>_wendyos._udp</type>
     <port>50051</port>
     <txt-record>id=DEVICE_ID_PLACEHOLDER</txt-record>
-    <txt-record>wendyosdevice=SOME_DEVICE_ID</txt-record>
     <txt-record>name=DEVICE_NAME_PLACEHOLDER</txt-record>
     <txt-record>displayname=DEVICE_DISPLAYNAME_PLACEHOLDER</txt-record>
   </service>

--- a/recipes-connectivity/avahi/files/wendyos-mdns.service
+++ b/recipes-connectivity/avahi/files/wendyos-mdns.service
@@ -48,6 +48,7 @@
     <type>_wendyos._udp</type>
     <port>50051</port>
     <txt-record>id=DEVICE_ID_PLACEHOLDER</txt-record>
+    <txt-record>fqdn=DEVICE_FQDN_PLACEHOLDER</txt-record>
     <txt-record>name=DEVICE_NAME_PLACEHOLDER</txt-record>
     <txt-record>displayname=DEVICE_DISPLAYNAME_PLACEHOLDER</txt-record>
   </service>

--- a/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
+++ b/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
@@ -38,14 +38,8 @@ DEVICE_NAME=$(cat "$DEVICE_NAME_FILE" 2>/dev/null || echo "unknown-device")
 # Generate display name (Title Case with spaces)
 DISPLAY_NAME=$(echo "$DEVICE_NAME" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2));}1')
 
-# Generate device ID for macOS app discovery (format: "WendyOS Device <device-name>")
-DEVICE_ID="WendyOS Device $DEVICE_NAME"
-
-# Replace SOME_DEVICE_ID with actual UUID
-sed -i "s/SOME_DEVICE_ID/$UUID/g" "$SERVICE_FILE"
-
-# Replace device ID placeholder (for macOS app discovery)
-sed -i "s/DEVICE_ID_PLACEHOLDER/$DEVICE_ID/g" "$SERVICE_FILE"
+# Replace device ID placeholder with UUID
+sed -i "s/DEVICE_ID_PLACEHOLDER/$UUID/g" "$SERVICE_FILE"
 
 # Replace device name placeholders
 sed -i "s/DEVICE_NAME_PLACEHOLDER/$DEVICE_NAME/g" "$SERVICE_FILE"

--- a/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
+++ b/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
@@ -38,10 +38,15 @@ DEVICE_NAME=$(cat "$DEVICE_NAME_FILE" 2>/dev/null || echo "unknown-device")
 # Generate display name (Title Case with spaces)
 DISPLAY_NAME=$(echo "$DEVICE_NAME" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2));}1')
 
-# Replace device ID placeholder with UUID
-sed -i "s/DEVICE_ID_PLACEHOLDER/$UUID/g" "$SERVICE_FILE"
+# Default domain for unprovisioned devices
+DEFAULT_DOMAIN="sh.wendy"
 
-# Replace device name placeholders
+# Build FQDN: <domain>.<device-name> (e.g. sh.wendy.warm-pepper)
+FQDN="${DEFAULT_DOMAIN}.${DEVICE_NAME}"
+
+# Replace placeholders in service file
+sed -i "s/DEVICE_ID_PLACEHOLDER/$UUID/g" "$SERVICE_FILE"
+sed -i "s/DEVICE_FQDN_PLACEHOLDER/$FQDN/g" "$SERVICE_FILE"
 sed -i "s/DEVICE_NAME_PLACEHOLDER/$DEVICE_NAME/g" "$SERVICE_FILE"
 sed -i "s/DEVICE_DISPLAYNAME_PLACEHOLDER/$DISPLAY_NAME/g" "$SERVICE_FILE"
 


### PR DESCRIPTION
## Summary
- **id** TXT record now contains the device UUID (was incorrectly set to `WendyOS Device <name>`)
- Removed redundant **wendyosdevice** TXT record
- Added **fqdn** TXT record in reverse-domain format (e.g. `sh.wendy.warm-pepper`), defaults to `sh.wendy.<device-name>` for unprovisioned devices
- Version bump to 0.12.0

## Test plan
- [ ] Flash device and run `avahi-browse -r _wendyos._udp --terminate`
- [ ] Verify `id` contains UUID, not "WendyOS Device ..."
- [ ] Verify `wendyosdevice` field is gone
- [ ] Verify `fqdn` shows `sh.wendy.<device-name>`