### PR TITLE
Little fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,8 +167,8 @@ build: _check-setup _ensure-volumes
 			-e "LANG=C.UTF-8" \
 			-v $(PROJECT_DIR):$(DOCKER_WORKDIR) \
 			-v $(VOLUME_BUILD):$(DOCKER_WORKDIR)/build/tmp \
-			-v $(VOLUME_SSTATE):$(DOCKER_WORKDIR)/build/sstate-cache \
-			-v $(VOLUME_DOWNLOADS):$(DOCKER_WORKDIR)/build/downloads \
+			-v $(VOLUME_SSTATE):$(DOCKER_WORKDIR)/sstate-cache \
+			-v $(VOLUME_DOWNLOADS):$(DOCKER_WORKDIR)/downloads \
 			$(DOCKER_REPO):$(DOCKER_TAG) \
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
@@ -209,8 +209,8 @@ build-sdk: _check-setup _ensure-volumes
 			-e "LANG=C.UTF-8" \
 			-v $(PROJECT_DIR):$(DOCKER_WORKDIR) \
 			-v $(VOLUME_BUILD):$(DOCKER_WORKDIR)/build/tmp \
-			-v $(VOLUME_SSTATE):$(DOCKER_WORKDIR)/build/sstate-cache \
-			-v $(VOLUME_DOWNLOADS):$(DOCKER_WORKDIR)/build/downloads \
+			-v $(VOLUME_SSTATE):$(DOCKER_WORKDIR)/sstate-cache \
+			-v $(VOLUME_DOWNLOADS):$(DOCKER_WORKDIR)/downloads \
 			$(DOCKER_REPO):$(DOCKER_TAG) \
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
@@ -258,6 +258,10 @@ distclean:
 	@read -p "Are you sure? [y/N] " confirm && \
 		if [ "$$confirm" = "y" ] || [ "$$confirm" = "Y" ]; then \
 			rm -rf $(PROJECT_DIR)/build $(PROJECT_DIR)/downloads $(PROJECT_DIR)/sstate-cache; \
+			if [ "$$(uname)" = "Darwin" ]; then \
+				docker volume rm $(VOLUME_BUILD) $(VOLUME_SSTATE) $(VOLUME_DOWNLOADS) 2>/dev/null || true; \
+				printf "  Removed Docker volumes.\n"; \
+			fi; \
 			printf "$(GREEN)Distclean complete.$(NC)\n"; \
 		else \
 			printf "Cancelled.\n"; \

--- a/Makefile
+++ b/Makefile
@@ -375,10 +375,10 @@ flash-to-external:
 				/bin/bash -c '\
 					cd /flash && \
 					sudo ./doexternal.sh -s $(FLASH_IMAGE_SIZE) /output/wendyos.img \
-				'; \
+				' || { rm -rf $(PROJECT_DIR)/deploy/flash-work; printf "\n$(RED)Image creation FAILED. Check doexternal.sh output above.$(NC)\n"; exit 1; }; \
 		else \
 			cd $(PROJECT_DIR)/deploy/flash-work && \
-			sudo ./doexternal.sh -s $(FLASH_IMAGE_SIZE) $(PROJECT_DIR)/deploy/wendyos.img; \
+			sudo ./doexternal.sh -s $(FLASH_IMAGE_SIZE) $(PROJECT_DIR)/deploy/wendyos.img || { rm -rf $(PROJECT_DIR)/deploy/flash-work; printf "\n$(RED)Image creation FAILED. Check doexternal.sh output above.$(NC)\n"; exit 1; }; \
 		fi; \
 		rm -rf $(PROJECT_DIR)/deploy/flash-work; \
 		printf "\n$(GREEN)Image created: $(PROJECT_DIR)/deploy/wendyos.img$(NC)\n\n"; \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # Note: On macOS, build artifacts are stored in Docker volumes (case-sensitive)
 # rather than the host filesystem to work around macOS case-insensitivity.
 
-.PHONY: help setup bootstrap docker-create docker-run docker-remove shell build build-sdk clean distclean volumes-create volumes-remove deploy flash-to-external
+.PHONY: help setup bootstrap docker-create docker-run docker-remove shell build build-sdk clean distclean volumes-create volumes-remove deploy flash-to-external _check-machine _check-setup _ensure-volumes
 
 # Configuration
 SHELL := /bin/bash
@@ -23,7 +23,6 @@ DOCKER_TAG := scarthgap
 DOCKER_USER := dev
 DOCKER_WORKDIR := /home/$(DOCKER_USER)/$(IMAGE_NAME)
 BUILD_DIR := build
-MACHINE ?= jetson-orin-nano-devkit-nvme-wendyos
 IMAGE_TARGET ?= wendyos-image
 
 # Flash configuration
@@ -156,7 +155,7 @@ shell:
 #
 # Build Commands
 #
-build: _check-setup _ensure-volumes
+build: _check-machine _check-setup _ensure-volumes
 	@printf "$(CYAN)Building $(IMAGE_TARGET) for $(MACHINE)...$(NC)\n"
 	@printf "$(YELLOW)This may take several hours on first build.$(NC)\n"
 	@printf "\n"
@@ -201,7 +200,7 @@ build: _check-setup _ensure-volumes
 		printf "Image location: $(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/\n"; \
 	fi
 
-build-sdk: _check-setup _ensure-volumes
+build-sdk: _check-machine _check-setup _ensure-volumes
 	@printf "$(CYAN)Building SDK for $(MACHINE)...$(NC)\n"
 	@if [ "$$(uname)" = "Darwin" ]; then \
 		docker run \
@@ -302,7 +301,7 @@ volumes-remove:
 #
 # Deploy tegraflash tarball (macOS)
 #
-deploy:
+deploy: _check-machine
 	@if [ "$$(uname)" != "Darwin" ]; then \
 		printf "Images are already on host filesystem at:\n"; \
 		printf "  $(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/\n"; \
@@ -329,7 +328,7 @@ deploy:
 #
 # Flash Commands
 #
-flash-to-external:
+flash-to-external: _check-machine
 	@printf "$(CYAN)WendyOS Flash Tool$(NC)\n"
 	@printf "$(CYAN)==================$(NC)\n\n"
 	@OS_TYPE=$$(uname); \
@@ -475,6 +474,19 @@ flash-to-external:
 #
 # Internal Targets
 #
+_check-machine:
+	@if [ -z "$(MACHINE)" ]; then \
+		printf "$(RED)Error: MACHINE is required.$(NC)\n\n"; \
+		printf "Usage:\n"; \
+		printf "  make $(MAKECMDGOALS) MACHINE=<machine>\n\n"; \
+		printf "Available machines:\n"; \
+		for m in $(MAKEFILE_DIR)/conf/machine/*.conf; do \
+			printf "  %s\n" "$$(basename $$m .conf)"; \
+		done; \
+		printf "\n"; \
+		exit 1; \
+	fi
+
 _check-setup:
 	@if [ ! -d "$(DOCKER_DIR)" ]; then \
 		printf "$(RED)Error: Build environment not set up.$(NC)\n"; \

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ DOCKER_DIR := $(PROJECT_DIR)/docker
 VOLUME_BUILD := wendyos-build-tmp
 VOLUME_SSTATE := wendyos-sstate-cache
 VOLUME_DOWNLOADS := wendyos-downloads
+VOLUME_CACHE := wendyos-build-cache
 
 # Colors for output
 CYAN := \033[0;36m
@@ -169,6 +170,7 @@ build: _check-setup _ensure-volumes
 			-v $(VOLUME_BUILD):$(DOCKER_WORKDIR)/build/tmp \
 			-v $(VOLUME_SSTATE):$(DOCKER_WORKDIR)/sstate-cache \
 			-v $(VOLUME_DOWNLOADS):$(DOCKER_WORKDIR)/downloads \
+			-v $(VOLUME_CACHE):$(DOCKER_WORKDIR)/build/cache \
 			$(DOCKER_REPO):$(DOCKER_TAG) \
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
@@ -211,6 +213,7 @@ build-sdk: _check-setup _ensure-volumes
 			-v $(VOLUME_BUILD):$(DOCKER_WORKDIR)/build/tmp \
 			-v $(VOLUME_SSTATE):$(DOCKER_WORKDIR)/sstate-cache \
 			-v $(VOLUME_DOWNLOADS):$(DOCKER_WORKDIR)/downloads \
+			-v $(VOLUME_CACHE):$(DOCKER_WORKDIR)/build/cache \
 			$(DOCKER_REPO):$(DOCKER_TAG) \
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
@@ -259,7 +262,7 @@ distclean:
 		if [ "$$confirm" = "y" ] || [ "$$confirm" = "Y" ]; then \
 			rm -rf $(PROJECT_DIR)/build $(PROJECT_DIR)/downloads $(PROJECT_DIR)/sstate-cache; \
 			if [ "$$(uname)" = "Darwin" ]; then \
-				docker volume rm $(VOLUME_BUILD) $(VOLUME_SSTATE) $(VOLUME_DOWNLOADS) 2>/dev/null || true; \
+				docker volume rm $(VOLUME_BUILD) $(VOLUME_SSTATE) $(VOLUME_DOWNLOADS) $(VOLUME_CACHE) 2>/dev/null || true; \
 				printf "  Removed Docker volumes.\n"; \
 			fi; \
 			printf "$(GREEN)Distclean complete.$(NC)\n"; \
@@ -279,6 +282,7 @@ volumes-create:
 	@docker volume create $(VOLUME_BUILD) >/dev/null && printf "  Created $(VOLUME_BUILD)\n"
 	@docker volume create $(VOLUME_SSTATE) >/dev/null && printf "  Created $(VOLUME_SSTATE)\n"
 	@docker volume create $(VOLUME_DOWNLOADS) >/dev/null && printf "  Created $(VOLUME_DOWNLOADS)\n"
+	@docker volume create $(VOLUME_CACHE) >/dev/null && printf "  Created $(VOLUME_CACHE)\n"
 	@printf "$(GREEN)Volumes created.$(NC)\n"
 
 volumes-remove:
@@ -289,7 +293,7 @@ volumes-remove:
 	@printf "$(RED)WARNING: This will delete all build data in Docker volumes.$(NC)\n"
 	@read -p "Are you sure? [y/N] " confirm && \
 		if [ "$$confirm" = "y" ] || [ "$$confirm" = "Y" ]; then \
-			docker volume rm $(VOLUME_BUILD) $(VOLUME_SSTATE) $(VOLUME_DOWNLOADS) 2>/dev/null || true; \
+			docker volume rm $(VOLUME_BUILD) $(VOLUME_SSTATE) $(VOLUME_DOWNLOADS) $(VOLUME_CACHE) 2>/dev/null || true; \
 			printf "$(GREEN)Volumes removed.$(NC)\n"; \
 		else \
 			printf "Cancelled.\n"; \
@@ -488,10 +492,12 @@ _ensure-volumes:
 		docker volume inspect $(VOLUME_BUILD) >/dev/null 2>&1 || docker volume create $(VOLUME_BUILD) >/dev/null; \
 		docker volume inspect $(VOLUME_SSTATE) >/dev/null 2>&1 || docker volume create $(VOLUME_SSTATE) >/dev/null; \
 		docker volume inspect $(VOLUME_DOWNLOADS) >/dev/null 2>&1 || docker volume create $(VOLUME_DOWNLOADS) >/dev/null; \
+		docker volume inspect $(VOLUME_CACHE) >/dev/null 2>&1 || docker volume create $(VOLUME_CACHE) >/dev/null; \
 		docker run --rm \
 			-v $(VOLUME_BUILD):/vol/build \
 			-v $(VOLUME_SSTATE):/vol/sstate \
 			-v $(VOLUME_DOWNLOADS):/vol/downloads \
+			-v $(VOLUME_CACHE):/vol/cache \
 			$(DOCKER_REPO):$(DOCKER_TAG) \
-			/bin/bash -c 'sudo chown -R $$(id -u):$$(id -g) /vol/build /vol/sstate /vol/downloads' 2>/dev/null || true; \
+			/bin/bash -c 'sudo chown -R $$(id -u):$$(id -g) /vol/build /vol/sstate /vol/downloads /vol/cache' 2>/dev/null || true; \
 	fi

--- a/scripts/docker/dockerfile
+++ b/scripts/docker/dockerfile
@@ -24,7 +24,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && \
     apt-get -qy upgrade && \
     apt-get -qy install \
-        gawk wget git-core diffstat unzip texinfo gcc-multilib \
+        gawk wget git-core diffstat unzip texinfo \
         build-essential chrpath socat cpio \
         python3 python3-pip python3-pexpect python3-venv python3-git \
         xz-utils bzip2 libxml2-utils debianutils iputils-ping \
@@ -36,6 +36,11 @@ RUN apt-get update && \
         libncurses5-dev libncursesw5-dev bison flex patchutils \
         libssl-dev ca-certificates locales sudo mc quilt vim pkg-config \
         gdisk dosfstools bmap-tools && \
+    # gcc-multilib provides 32-bit x86 multilib headers and is only available
+    # on amd64. Skip it on arm64 (e.g. Apple Silicon Docker Desktop).
+    if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+        apt-get -qy install gcc-multilib; \
+    fi && \
     apt-get -qy clean
 
 # By default, Ubuntu uses dash as an alias for sh.


### PR DESCRIPTION
Issues fixed while working on [Wendy Config Partition](https://linear.app/wendylabsinc/project/wendy-config-partition-31bdfe153f20).

### TL;DR

Mac-specific fixes mostly, one Makefile error-handling fix, and two Makefile quality-of-life improvements. First, the Docker image build was failing on Apple Silicon because `gcc-multilib` is only available on `amd64` — it's now installed conditionally. Second, the `sstate-cache` and `downloads` Docker volumes were mounted inside `build/` instead of the project root, so BitBake was writing those directories directly onto the case-insensitive macOS host filesystem, causing build errors. Linux was never affected by either issue.

Also: `flash-to-external` now fails fast when `doexternal.sh` errors out instead of silently continuing to print "Image created" and prompting for a disk. BitBake's `build/cache` directory now gets its own named Docker volume on macOS to avoid virtiofs overhead. And `MACHINE` is no longer silently defaulted — it must be passed explicitly, with a helpful error listing available options if omitted.

---

### Commit 1 — skip gcc-multilib on arm64 (Apple Silicon)

The Dockerfile unconditionally installed `gcc-multilib`, which provides 32-bit x86 multilib support on the **host** side and is only available on `amd64`. On Apple Silicon (arm64), Docker Desktop runs an arm64 container, so the package doesn't exist and the image build fails outright.

There is no arm64 equivalent needed: `gcc-multilib` is a legacy host requirement (historically used by `pseudo` to fake file ownership during builds). Modern Yocto (Scarthgap 5.0) no longer depends on 32-bit host support, and arm64 has no 32-bit x86 multilib concept anyway.

Fixed by making the installation conditional:

```dockerfile
if [ "$(dpkg --print-architecture)" = "amd64" ]; then
    apt-get -qy install gcc-multilib;
fi
```

This is a no-op on amd64 Linux and silently skips the package on arm64.

---

### Commit 2 — mount sstate/downloads volumes at project root

All three `local.conf` templates declare:

```
DL_DIR     = "${TOPDIR}/../downloads"
SSTATE_DIR = "${TOPDIR}/../sstate-cache"
```

`${TOPDIR}` is the build directory, so `${TOPDIR}/../` resolves to the **project root** — `downloads/` and `sstate-cache/` are siblings of `build/`, not children of it. This is standard Yocto practice: a `make clean` wipes `build/tmp` without ever touching the caches.

On macOS, because the host filesystem is case-insensitive, those two directories must live inside Docker volumes. The volumes were previously mounted at:

```
$(DOCKER_WORKDIR)/build/sstate-cache   # ← wrong
$(DOCKER_WORKDIR)/build/downloads      # ← wrong
```

That's one level too deep. BitBake ignored those volumes entirely and instead wrote `downloads/` and `sstate-cache/` directly onto the case-insensitive macOS host filesystem, causing build errors when Yocto tried to create or resolve files differing only in case.

Fixed by mounting the volumes at the project root instead:

```
$(DOCKER_WORKDIR)/sstate-cache         # ✓
$(DOCKER_WORKDIR)/downloads            # ✓
```

This also aligns with the `distclean` target, which already correctly referenced `$(PROJECT_DIR)/downloads` and `$(PROJECT_DIR)/sstate-cache`.

**Linux is unaffected**: on Linux the host filesystem is already case-sensitive, so no Docker volumes are used for `sstate-cache` or `downloads`. The project root is bind-mounted directly into the container and Yocto creates both directories there naturally. The Linux path has always been correct and required no changes.

---

### Commit 3 — fail fast if doexternal.sh fails

`doexternal.sh` was silently failing (e.g. `tegraparser_v2` error 19 / ENOENT) but the Makefile unconditionally printed "Image created" and then prompted for a disk to flash. `dd` then failed immediately with "No such file or directory" since `wendyos.img` was never actually produced.

Fixed by adding `|| { ... exit 1 }` to both the `docker run` (macOS) and bare `doexternal.sh` (Linux) invocations in the `flash-to-external` target. A failed image creation now cleans up the temporary `flash-work` directory, prints a clear error, and stops the target immediately.

---

### Commit 4 — add named volume for build/cache to avoid virtiofs overhead

BitBake's `build/cache` directory (hashserv database, sanity checks, etc.) was being written through virtiofs on macOS, which is significantly slower than native filesystem access. Added a dedicated named Docker volume (`wendyos-build-cache`) mounted at `$(DOCKER_WORKDIR)/build/cache` so these frequent small I/O operations happen inside the VM's native filesystem.

The new volume is created/removed alongside the existing `build-tmp`, `sstate-cache`, and `downloads` volumes in all relevant targets (`volumes-create`, `volumes-remove`, `distclean`, `_ensure-volumes`).

**Linux is unaffected**: no Docker volumes are used on Linux; `build/cache` is written directly to the host filesystem as before.

---

### Commit 5 — require MACHINE explicitly, list available options on missing

`MACHINE` previously defaulted to `jetson-orin-nano-devkit-nvme-wendyos` via `?=`. This silent default was error-prone: running `make build` without specifying `MACHINE` would start a multi-hour build for a board you might not have intended.

Removed the default entirely. Targets that depend on `MACHINE` (`build`, `build-sdk`, `deploy`, `flash-to-external`) now depend on a new `_check-machine` internal target that verifies `MACHINE` is set and, if not, prints a usage message listing all available machine configurations found in `conf/machine/*.conf`.

---