### PR TITLE
USB gadget link local

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository provides the meta-layer and build flow to build **WendyOS** for 
 | Jetson Orin Nano DevKit | Tegra234 | 8GB | `jetson-orin-nano-devkit-wendyos` | eMMC/SD |
 | Jetson Orin Nano DevKit | Tegra234 | 8GB | `jetson-orin-nano-devkit-nvme-wendyos` | NVMe |
 | Jetson AGX Orin DevKit | Tegra234 | 64GB | `jetson-agx-orin-devkit-nvme-wendyos` | NVMe |
+| Raspberry Pi 5 | Broadcom BCM2712 | 8GB | `raspberrypi5-wendyos` | SD |
+| Raspberry Pi 5 | Broadcom BCM2712 | 8GB | `raspberrypi5-nvme-wendyos` | NVMe |
 
 ## TL;DR
 
@@ -33,6 +35,7 @@ make flash-to-external  # Flash to external NVMe/USB drive
     - [Flashing the .img File](#flashing-the-img-file)
     - [Alternative: Flashing with initrd-flash (USB Recovery Mode)](#alternative-flashing-with-initrd-flash-usb-recovery-mode)
   - [Available Images](#available-images)
+- [USB Gadget Networking](#usb-gadget-networking)
 - [Mender OTA Updates](#mender-ota-updates)
   - [Partition Layout](#partition-layout)
   - [Manual Update](#manual-update)
@@ -49,6 +52,12 @@ make flash-to-external  # Flash to external NVMe/USB drive
   - [Supported Machines](#supported-machines)
   - [Build](#build)
   - [Flash the Image](#flash-the-image)
+- [QEMU (ARM64)](#qemu-arm64)
+  - [Prerequisites](#qemu-prerequisites)
+  - [Build](#qemu-build)
+  - [Run](#run)
+  - [Networking](#networking)
+  - [Cleanup](#cleanup)
 - [Architecture Notes](#architecture-notes)
 - [License](#license)
 
@@ -132,15 +141,22 @@ make shell
 
 **Build for different targets:**
 ```bash
-# Build for Orin Nano NVMe (default)
+# Jetson (Orin Nano NVMe — default)
+make setup MACHINE=jetson
 make build
 
-# Build for AGX Orin 64GB (NVMe)
-make build MACHINE=jetson-agx-orin-devkit-nvme-wendyos
+# Raspberry Pi 5
+make setup MACHINE=rpi5
+make build
 
-# Build for Orin Nano SD card/eMMC
-make build MACHINE=jetson-orin-nano-devkit-wendyos
+# QEMU (ARM64, for development)
+make setup MACHINE=qemu
+make build
 ```
+
+> To build for a different Jetson variant (e.g., AGX Orin or eMMC/SD card), run
+> `make setup MACHINE=jetson` then edit `build/conf/local.conf` to set the desired
+> `MACHINE` value before running `make build`.
 
 #### Option B: Manual Steps
 
@@ -503,6 +519,53 @@ The build produces multiple image formats:
 - `dataimg` - Data partition image
 - `ext4` - Raw rootfs (for debugging)
 
+## USB Gadget Networking
+
+When a Jetson running WendyOS is connected via USB-C, it exposes a composite USB gadget
+(NCM network + ACM serial). The Jetson configures `usb0` as a **DHCP client** — it does
+not assign its own address. The host must provide an IP via DHCP.
+
+### Linux host
+
+Use `scripts/manage-net-sharing.sh` from this repository:
+
+```bash
+# List detected WendyOS gadget devices:
+./scripts/manage-net-sharing.sh list
+
+# Auto-detect interface and enable internet sharing:
+./scripts/manage-net-sharing.sh enable
+
+# Check status (shows host IP and board IP once connected):
+./scripts/manage-net-sharing.sh status
+
+# Test connectivity:
+./scripts/manage-net-sharing.sh test
+
+# Disable sharing:
+./scripts/manage-net-sharing.sh disable
+```
+
+The script auto-detects the Jetson by USB manufacturer/product string or USB ID
+(`1d6b:0104`). It uses NetworkManager `method=shared`, which assigns `10.42.0.1` to the
+host, starts dnsmasq for DHCP, and enables NAT so the Jetson can reach the internet
+through the host.
+
+### macOS host
+
+Enable **Internet Sharing** in **System Settings → General → Sharing → Internet Sharing**:
+- Share connection from: **Wi-Fi** (or whichever interface has internet)
+- To computers using: the Jetson's USB NCM interface (shown as "RNDIS/Ethernet Gadget"
+  or "Ethernet Adapter" depending on macOS version)
+
+macOS assigns itself `192.168.2.1` and hands the Jetson an address in `192.168.2.x`.
+
+> **Note:** QEMU networking (`10.43.0.0/24`) is independent of Jetson USB gadget
+> networking (`10.42.0.0/24`). Both can be active simultaneously without conflict.
+
+For a detailed explanation of the full USB-C enumeration stack, see
+[`docs/usb-gadget-vbus-notification-deep-dive.md`](docs/usb-gadget-vbus-notification-deep-dive.md).
+
 ## Mender OTA Updates
 
 The system includes Mender for Over-The-Air updates with A/B partition redundancy.
@@ -693,12 +756,9 @@ enabled on `ttyAMA0` at 115200 baud.
    ```
 
    This copies `conf/template/bblayers.conf.rpi5` and `conf/template/local.conf.rpi5`
-   into `build/conf/`. The default BitBake machine is `raspberrypi5-wendyos` (SD card).
-   To target NVMe, edit `build/conf/local.conf` and change:
-
-   ```
-   MACHINE = "raspberrypi5-nvme-wendyos"
-   ```
+   into `build/conf/`. The default machine is `raspberrypi5-wendyos` (SD card boot).
+   The NVMe variant (`raspberrypi5-nvme-wendyos`) is also supported and can be selected
+   by editing `build/conf/local.conf`.
 
 2. **Build the image** inside the Docker container:
 
@@ -743,6 +803,88 @@ For SD card builds, insert the flashed card into the RPi5 and power on. For NVMe
 ensure the NVMe drive is connected via a PCIe adapter and that the EEPROM boot order is
 configured to boot from NVMe (see `rpi-eeprom-nvme-config` package included in the NVMe
 machine).
+
+## QEMU (ARM64)
+
+QEMU provides a virtual ARM64 machine for development and testing without physical hardware.
+It runs the same WendyOS image as physical devices but uses `virtio-net` instead of the USB
+gadget for networking.
+
+### QEMU Prerequisites
+
+Install `qemu-system-aarch64` on your host:
+
+```bash
+# Debian/Ubuntu
+sudo apt install qemu-system-arm
+
+# Fedora/RHEL
+sudo dnf install qemu-system-aarch64
+
+# Arch
+sudo pacman -S qemu-system-aarch64
+```
+
+### QEMU Build
+
+```bash
+make setup MACHINE=qemu
+make build
+```
+
+The build produces:
+```
+build/tmp/deploy/images/qemuarm64-wendyos/wendyos-image-qemuarm64-wendyos.rootfs.ext4
+build/tmp/deploy/images/qemuarm64-wendyos/Image
+```
+
+### Run
+
+Run the QEMU image directly from the **host** (not inside the Docker container):
+
+```bash
+./scripts/run-qemu.sh
+```
+
+**Options:**
+```bash
+./scripts/run-qemu.sh --build-dir /path/to/build   # custom build directory
+./scripts/run-qemu.sh --usb 1234:5678               # pass through a USB device
+./scripts/run-qemu.sh --dry-run                     # show what would run without executing
+```
+
+To exit QEMU: press **Ctrl-A**, then **X**.
+
+### Networking
+
+`run-qemu.sh` automatically sets up host networking on first run by calling
+`scripts/manage-qemu-network-host.sh setup`. This creates:
+
+- A TAP interface `tap-wendyos` and bridge `br-wendyos` on the host
+- Host IP `10.43.0.1/24`, QEMU guest receives an address in `10.43.0.10–10.43.0.250` via dnsmasq
+- NAT via iptables for internet access from inside the VM
+
+You may be prompted for your `sudo` password since creating network interfaces requires
+elevated privileges.
+
+> **Note:** QEMU networking (`10.43.0.0/24`) is independent of Jetson USB gadget networking
+> (`10.42.0.0/24`). Both can be active simultaneously on the same host without conflict.
+> Use `scripts/manage-net-sharing.sh` to manage internet sharing for a connected Jetson device.
+
+### Cleanup
+
+The bridge and TAP interface persist after QEMU exits (so subsequent runs start faster).
+When you no longer need the QEMU network, remove it:
+
+```bash
+sudo ./scripts/manage-qemu-network-host.sh cleanup
+```
+
+To check the current state:
+
+```bash
+./scripts/manage-qemu-network-host.sh status
+```
 
 ## Architecture Notes
 

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -65,6 +65,17 @@ DISTRO_FEATURES:append = " polkit"
 # These can be overridden in local.conf or on the command line
 WENDYOS_UPDATE_BOOTLOADER ?= "1"
 
+# USB gadget network mode for the usb0 interface
+# "link-local"  - RFC 3927 self-assigned 169.254.x.x (discovery via mDNS/Avahi)
+# "dhcp-client" - Device is DHCP client (host must run DHCP server)
+# "dhcp-server" - Device runs DHCP server via NM shared mode (requires dnsmasq)
+WENDYOS_USB_NET_MODE ?= "link-local"
+
+# Interfaces on which Avahi publishes mDNS services
+# Default: usb0 only (device discoverable only by the directly-connected host)
+# Set to "" to allow all interfaces (discoverable on LAN)
+WENDYOS_MDNS_INTERFACES ?= "usb0"
+
 # Enable UEFI/EFI debug build for verbose boot/capsule debug output
 # Set to "1" to enable DEBUG mode (verbose UART output)
 # Set to "0" for RELEASE mode (minimal output, production default)

--- a/conf/template/local.conf.jetson
+++ b/conf/template/local.conf.jetson
@@ -36,6 +36,19 @@ WENDYOS_DEBUG_UART = "1"
 #   QEMU: "0" (uses virtio-net instead)
 WENDYOS_USB_GADGET = "1"
 
+# USB gadget network mode (requires WENDYOS_USB_GADGET = "1"):
+#   "link-local"  - Self-assigned 169.254.x.x, discovery via mDNS/Avahi (default)
+#   "dhcp-client" - Device is DHCP client, host must run DHCP server
+#   "dhcp-server" - Device runs DHCP server (NM shared mode, requires dnsmasq)
+# Uncomment to override:
+#WENDYOS_USB_NET_MODE = "link-local"
+
+# Avahi mDNS interface restriction:
+#   "usb0" - Only discoverable via USB (default)
+#   ""     - Discoverable on all interfaces (including LAN)
+# Uncomment to override:
+#WENDYOS_MDNS_INTERFACES = "usb0"
+
 # WENDYOS_PERSIST_JOURNAL_LOGS - Automatically configured per machine:
 #   Real hardware (Tegra, etc.): "1" (persistent logs stored on /data partition)
 #   QEMU: "0" (volatile logs in tmpfs, no /data partition)

--- a/conf/template/local.conf.rpi5
+++ b/conf/template/local.conf.rpi5
@@ -34,6 +34,19 @@ WENDYOS_DEBUG_UART = "1"
 #   QEMU: "0" (uses virtio-net instead)
 WENDYOS_USB_GADGET = "1"
 
+# USB gadget network mode (requires WENDYOS_USB_GADGET = "1"):
+#   "link-local"  - Self-assigned 169.254.x.x, discovery via mDNS/Avahi (default)
+#   "dhcp-client" - Device is DHCP client, host must run DHCP server
+#   "dhcp-server" - Device runs DHCP server (NM shared mode, requires dnsmasq)
+# Uncomment to override:
+#WENDYOS_USB_NET_MODE = "link-local"
+
+# Avahi mDNS interface restriction:
+#   "usb0" - Only discoverable via USB (default)
+#   ""     - Discoverable on all interfaces (including LAN)
+# Uncomment to override:
+#WENDYOS_MDNS_INTERFACES = "usb0"
+
 # WENDYOS_PERSIST_JOURNAL_LOGS - Automatically configured per machine:
 #   RPi5: "0" (volatile logs in tmpfs; single partition, no /data)
 # Uncomment to override:

--- a/meta-tegra-extensions/recipes-kernel/usb-gadget-modules/usb-gadget-modules/usb-gadget.conf
+++ b/meta-tegra-extensions/recipes-kernel/usb-gadget-modules/usb-gadget-modules/usb-gadget.conf
@@ -1,4 +1,7 @@
 # USB Gadget modules for WendyOS
+# tegra_xudc must load before libcomposite so the UDC is present when
+# gadget-setup.sh runs and the usb_phy notifier chain is fully armed.
+tegra_xudc
 libcomposite
 u_ether
 usb_f_ncm

--- a/meta-tegra-extensions/recipes-kernel/usb-gadget-modules/usb-gadget-modules_1.0.bb
+++ b/meta-tegra-extensions/recipes-kernel/usb-gadget-modules/usb-gadget-modules_1.0.bb
@@ -17,6 +17,7 @@ do_install() {
 # Ensure the module packages are present.
 RDEPENDS:${PN} += " \
     kernel-modules \
+    kernel-module-tegra-xudc \
     "
 
 # kernel-module-libcomposite

--- a/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/recipes-connectivity/avahi/avahi_%.bbappend
@@ -25,9 +25,12 @@ do_install:append() {
     install -d ${D}${sbindir}
     install -m 0755 ${WORKDIR}/generate-hostname.sh ${D}${sbindir}/
 
-    # Install Avahi service file
+    # Install Avahi service file with platform substitution
     install -d ${D}${sysconfdir}/avahi/services
-    install -m 0644 ${WORKDIR}/wendyos-mdns.service ${D}${sysconfdir}/avahi/services/
+    sed 's|@WENDYOS_PLATFORM@|${MACHINE}|' \
+        ${WORKDIR}/wendyos-mdns.service \
+        > ${D}${sysconfdir}/avahi/services/wendyos-mdns.service
+    chmod 0644 ${D}${sysconfdir}/avahi/services/wendyos-mdns.service
 
     # Install systemd service for hostname setup
     install -d ${D}${systemd_system_unitdir}
@@ -51,8 +54,20 @@ do_install:append() {
         # Enable D-Bus support for proper service publishing
         sed -i 's/^#*enable-dbus=.*/enable-dbus=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
 
-        # Enable mDNS reflector for better discovery
+        # Enable mDNS reflector for cross-interface discovery
         sed -i 's/^#*enable-reflector=.*/enable-reflector=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
+
+        # Restrict Avahi to specific interfaces if configured
+        # Empty WENDYOS_MDNS_INTERFACES means all interfaces (no restriction)
+        if [ -n "${WENDYOS_MDNS_INTERFACES}" ]; then
+            if grep -q '^allow-interfaces=' "${D}${sysconfdir}/avahi/avahi-daemon.conf"; then
+                sed -i "s/^allow-interfaces=.*/allow-interfaces=${WENDYOS_MDNS_INTERFACES}/" \
+                    "${D}${sysconfdir}/avahi/avahi-daemon.conf"
+            else
+                sed -i '/^\[server\]/a allow-interfaces=${WENDYOS_MDNS_INTERFACES}' \
+                    "${D}${sysconfdir}/avahi/avahi-daemon.conf"
+            fi
+        fi
 
         # Set proper hostname behavior
         sed -i 's/^#*use-ipv4=.*/use-ipv4=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"

--- a/recipes-connectivity/avahi/files/wendyos-mdns.service
+++ b/recipes-connectivity/avahi/files/wendyos-mdns.service
@@ -8,7 +8,7 @@
     <type>_ssh._tcp</type>
     <port>22</port>
     <txt-record>model=WendyOS</txt-record>
-    <txt-record>platform=Jetson Orin Nano</txt-record>
+    <txt-record>platform=@WENDYOS_PLATFORM@</txt-record>
   </service>
 
   <!-- Device Info Service -->

--- a/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
@@ -1,10 +1,9 @@
-# The USB gadget NM connection uses ipv4.method=auto (DHCP client mode).
-# NM does not spawn dnsmasq in this mode; dnsmasq is present as a dependency
-# of NetworkManager itself. DBus support is enabled for NM integration in case
-# method=shared is used on other interfaces.
-# NOTE: if method=auto is used exclusively, the dbus PACKAGECONFIG can be removed.
+# dnsmasq configuration for NetworkManager integration.
+# dnsmasq is pulled into the image only when WENDYOS_USB_NET_MODE = "dhcp-server"
+# (via RDEPENDS in networkmanager_%.bbappend). This bbappend configures it for
+# NM's method=shared mode: DBus support is required for NM to manage dnsmasq.
 PACKAGECONFIG:append = " dbus"
 
 # Disable the system-wide dnsmasq.service so it does not conflict with
-# any NM-managed dnsmasq instances
+# the NM-managed dnsmasq instance
 SYSTEMD_AUTO_ENABLE = "disable"

--- a/recipes-connectivity/networkmanager/files/10-usb-gadget.conf
+++ b/recipes-connectivity/networkmanager/files/10-usb-gadget.conf
@@ -1,4 +1,4 @@
-# Configuration for USB gadget connection (client)
+# Configuration for USB gadget connection
 
 [device-usb-gadget]
 # Ensure usb0 is managed by NetworkManager
@@ -6,11 +6,11 @@ match-device=interface-name:usb0
 managed=true
 
 [main]
-# Use default DNS handling from DHCP
+# Use default DNS handling
 dns=default
 
 [connection]
-# DHCP client timeout (waiting for host to provide IP configuration)
+# DHCP client timeout — only relevant when WENDYOS_USB_NET_MODE=dhcp-client
 ipv4.dhcp-timeout=300
 
 [ipv6]

--- a/recipes-connectivity/networkmanager/files/usb-gadget.nmconnection
+++ b/recipes-connectivity/networkmanager/files/usb-gadget.nmconnection
@@ -11,10 +11,10 @@ wait-device-timeout=60000
 mac-address-blacklist=
 
 [ipv4]
-method=auto
+method=@USB_NET_MODE@
 dns-search=
 route-metric=700
-# Uses DHCP to get IP from host computer's internet sharing.
+# IPv4 mode is set at build time via WENDYOS_USB_NET_MODE (see wendyos.conf).
 # High route-metric ensures WiFi/eth (auto-metric ~100-600) is preferred as
 # the default internet route when available. usb0 becomes the fallback.
 

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -36,22 +36,27 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/10-usb-gadget.conf ${D}${sysconfdir}/NetworkManager/conf.d/10-usb-gadget.conf
     install -m 0644 ${WORKDIR}/99-interface-metrics.conf ${D}${sysconfdir}/NetworkManager/conf.d/99-interface-metrics.conf
 
-    # Install system connections (USB gadget profile)
-    # Substitute @USB_NET_MODE@ placeholder with the NM method for WENDYOS_USB_NET_MODE
-    install -d ${D}${sysconfdir}/NetworkManager/system-connections
+    # Install distro-managed connection profile to /usr/lib (read-only on rootfs).
+    # NM 1.46+ natively reads /usr/lib/NetworkManager/system-connections/ as a
+    # read-only keyfile path. User modifications via nmcli create a writable copy
+    # in /etc/NetworkManager/system-connections/ (persisted on /data) which takes
+    # priority. This ensures OTA updates always deliver the latest distro profile
+    # without overwriting user customizations.
+    install -d ${D}${nonarch_libdir}/NetworkManager/system-connections
     sed 's|@USB_NET_MODE@|${@usb_net_nm_method(d)}|' \
         ${WORKDIR}/usb-gadget.nmconnection \
-        > ${D}${sysconfdir}/NetworkManager/system-connections/usb-gadget.nmconnection
-    chmod 0600 ${D}${sysconfdir}/NetworkManager/system-connections/usb-gadget.nmconnection
+        > ${D}${nonarch_libdir}/NetworkManager/system-connections/usb-gadget.nmconnection
+    chmod 0600 ${D}${nonarch_libdir}/NetworkManager/system-connections/usb-gadget.nmconnection
 }
 
 # Make sure our config files are packaged
+# Note: usb-gadget.nmconnection is in ${nonarch_libdir}/NetworkManager/system-connections/
+# which is already covered by upstream FILES:${PN}-daemon
 FILES:${PN} += " \
     ${sysconfdir}/NetworkManager/NetworkManager.conf \
     ${sysconfdir}/NetworkManager/conf.d/00-manage-usb0.conf \
     ${sysconfdir}/NetworkManager/conf.d/10-usb-gadget.conf \
     ${sysconfdir}/NetworkManager/conf.d/99-interface-metrics.conf \
-    ${sysconfdir}/NetworkManager/system-connections/usb-gadget.nmconnection \
     "
 
 # Ensure NetworkManager starts after USB gadget is set up

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -10,6 +10,20 @@ SRC_URI += " \
     file://99-interface-metrics.conf \
     "
 
+# Map WENDYOS_USB_NET_MODE to NetworkManager ipv4.method value
+def usb_net_nm_method(d):
+    mode = d.getVar('WENDYOS_USB_NET_MODE') or 'link-local'
+    mapping = {'link-local': 'link-local', 'dhcp-client': 'auto', 'dhcp-server': 'shared'}
+    if mode not in mapping:
+        bb.warn("WENDYOS_USB_NET_MODE='%s' is not recognized, falling back to 'link-local'" % mode)
+    return mapping.get(mode, 'link-local')
+
+# dnsmasq is only needed for dhcp-server mode (NM spawns it for method=shared)
+RDEPENDS:${PN}-daemon += "${@'dnsmasq' if d.getVar('WENDYOS_USB_NET_MODE') == 'dhcp-server' else ''}"
+
+# Remove dnsmasq from NM's weak recommendations when not in dhcp-server mode
+RRECOMMENDS:${PN}-daemon:remove = "${@'' if d.getVar('WENDYOS_USB_NET_MODE') == 'dhcp-server' else 'dnsmasq'}"
+
 # Install main NetworkManager configuration
 do_install:append() {
     # Install main config
@@ -23,8 +37,12 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/99-interface-metrics.conf ${D}${sysconfdir}/NetworkManager/conf.d/99-interface-metrics.conf
 
     # Install system connections (USB gadget profile)
+    # Substitute @USB_NET_MODE@ placeholder with the NM method for WENDYOS_USB_NET_MODE
     install -d ${D}${sysconfdir}/NetworkManager/system-connections
-    install -m 0600 ${WORKDIR}/usb-gadget.nmconnection ${D}${sysconfdir}/NetworkManager/system-connections/usb-gadget.nmconnection
+    sed 's|@USB_NET_MODE@|${@usb_net_nm_method(d)}|' \
+        ${WORKDIR}/usb-gadget.nmconnection \
+        > ${D}${sysconfdir}/NetworkManager/system-connections/usb-gadget.nmconnection
+    chmod 0600 ${D}${sysconfdir}/NetworkManager/system-connections/usb-gadget.nmconnection
 }
 
 # Make sure our config files are packaged

--- a/recipes-core/gadget-setup/files/gadget-setup.sh
+++ b/recipes-core/gadget-setup/files/gadget-setup.sh
@@ -207,6 +207,27 @@ fi
 echo "$UDC" > UDC
 log_info "UDC activated: $UDC"
 
+# On tegra-xudc the UDC relies on a usb_phy notifier chain fed by the
+# padctl role switch (phy-tegra-xusb → fusb301 → tegra_xudc).  If that
+# chain has not fired yet (e.g. FUSB301 probed before padctl ports were
+# ready, or cable was connected before boot), the UDC sits in "default"
+# state and never enters device mode.  Force the role explicitly so the
+# usb_phy notifier fires and XUDC enters device mode regardless of the
+# CC-chip state machine.  The padctl exposes the role switch at:
+#   /sys/class/usb_role/usb2-0-role-switch/role
+# (name comes from dev_set_name(&port->dev, "usb2-0") in xusb.c and
+#  dev_set_name(&sw->dev, "%s-role-switch", dev_name(parent)) in roles/class.c)
+if [ "$USB_CONTROLLER" = "tegra-xudc" ]; then
+    ROLE_SW_PATH="/sys/class/usb_role/usb2-0-role-switch/role"
+    if [ -f "$ROLE_SW_PATH" ]; then
+        echo "device" > "$ROLE_SW_PATH" 2>/dev/null && \
+            log_info "Forced USB role switch to device" || \
+            log_warning "Failed to force USB role switch to device"
+    else
+        log_warning "tegra-xudc: USB role switch not found at $ROLE_SW_PATH — XUDC may stay in default state"
+    fi
+fi
+
 udevadm settle -t 20 || log_warning "udevadm settle timed out — gadget may not be fully enumerated"
 log_info "USB gadget initialised"
 

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -78,8 +78,8 @@ IMAGE_INSTALL:append = " \
         )} \
     "
 
-# Note: gadget-network-config (standalone dnsmasq) removed
-# NetworkManager's connection sharing provides DHCP via dnsmasq with DBus support
+# Note: gadget-network-config (standalone dnsmasq) removed.
+# USB gadget IPv4 mode is controlled by WENDYOS_USB_NET_MODE (see wendyos.conf).
 
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "", d)}"
@@ -90,6 +90,8 @@ BUILDCFG_VARS += " \
     WENDYOS_DEBUG \
     WENDYOS_DEBUG_UART \
     WENDYOS_USB_GADGET \
+    WENDYOS_USB_NET_MODE \
+    WENDYOS_MDNS_INTERFACES \
     WENDYOS_PERSIST_JOURNAL_LOGS \
     WENDYOS_UPDATE_BOOTLOADER \
     WENDYOS_DEEPSTREAM \

--- a/recipes-core/wendyos-etc-binds/files/setup-etc-binds.sh
+++ b/recipes-core/wendyos-etc-binds/files/setup-etc-binds.sh
@@ -69,33 +69,108 @@ fi
 # PHASE 2:
 log_info "Phase 2: Setting up NetworkManager user connections persistence"
 
-# Create directory structure for NetworkManager connections
+# Create directory structure for NetworkManager user connections
+# Note: distro-managed profiles (usb-gadget.nmconnection) live in
+# /usr/lib/NetworkManager/system-connections/ (read-only, on rootfs).
+# This directory is only for user-added connections (WiFi, VPN, etc.)
+# which NM writes to /etc/NetworkManager/system-connections/.
 if [ ! -d "${DATA_ETC}/${NM_CONNECTIONS}" ]
 then
-    log_info "Creating ${DATA_ETC}/${NM_CONNECTIONS}/ for persistent WiFi configs"
+    log_info "Creating ${DATA_ETC}/${NM_CONNECTIONS}/ for persistent user connections"
     mkdir -p "${DATA_ETC}/${NM_CONNECTIONS}"
     chmod 755 "${DATA_ETC}/${NM_CONNECTIONS}"
+fi
 
-    # Copy initial connection profiles from rootfs (e.g., usb-gadget.nmconnection)
-    if [ -d "/etc/${NM_CONNECTIONS}" ]
-    then
-        # Check if there are any files to copy
-        if ls "/etc/${NM_CONNECTIONS}"/*.nmconnection >/dev/null 2>&1
+# Migration: sync distro-managed profiles between /usr/lib and /data.
+#
+# Distro profiles live in /usr/lib/NetworkManager/system-connections/ (rootfs,
+# read-only, updated on every OTA). User-added/modified profiles live in
+# /data/etc/NetworkManager/system-connections/ (persistent, bind-mounted to /etc).
+# NM gives /etc priority over /usr/lib for same-named files.
+#
+# Problem: if /data has a stale distro copy, it shadows the /usr/lib version
+# and blocks OTA updates from taking effect. But if the user intentionally
+# modified the profile via nmcli, we must preserve their changes.
+#
+# Solution: track the distro version hash (like dpkg conffiles). On each boot:
+#   - If /data file hash matches the stored distro hash → not user-modified → remove
+#   - If /data file hash differs from stored hash → user modified → keep
+#   - Update the stored hash from the current /usr/lib version
+#
+NM_LIB_CONNECTIONS="/usr/lib/NetworkManager/system-connections"
+NM_HASH_DIR="${DATA_ETC}/${NM_CONNECTIONS}/.distro-hashes"
+
+# Migration runs with set +e so failures (disk full, I/O error) never abort the
+# script before the bind mounts below are established. Migration is best-effort;
+# bind mounts are critical for device operation.
+if [ -d "${NM_LIB_CONNECTIONS}" ] && [ -d "${DATA_ETC}/${NM_CONNECTIONS}" ]
+then
+    set +e
+    mkdir -p "${NM_HASH_DIR}" 2>/dev/null
+
+    for lib_file in "${NM_LIB_CONNECTIONS}"/*.nmconnection
+    do
+        [ -f "${lib_file}" ] || continue
+        local_name=$(basename "${lib_file}")
+        data_file="${DATA_ETC}/${NM_CONNECTIONS}/${local_name}"
+        hash_file="${NM_HASH_DIR}/${local_name}.sha256"
+
+        if [ -f "${data_file}" ]
         then
-            log_info "Copying initial NetworkManager connections from rootfs"
-            cp -a "/etc/${NM_CONNECTIONS}"/*.nmconnection \
-                "${DATA_ETC}/${NM_CONNECTIONS}/" 2>/dev/null || true
+            stored_hash=""
+            if [ -f "${hash_file}" ]
+            then
+                stored_hash=$(cat "${hash_file}" 2>/dev/null) || stored_hash=""
+            fi
 
-            # Ensure correct permissions (NetworkManager requires 0600)
-            chmod 600 "${DATA_ETC}/${NM_CONNECTIONS}"/*.nmconnection 2>/dev/null || true
-        else
-            log_info "No initial connection profiles found in rootfs"
+            if [ -n "${stored_hash}" ]
+            then
+                # Hash file exists and is valid: compare /data file against
+                # the stored distro hash. If they match, the user never
+                # modified it → safe to remove.
+                data_hash=$(sha256sum "${data_file}" 2>/dev/null | awk '{print $1}') || data_hash=""
+                if [ -n "${data_hash}" ] && [ "${data_hash}" = "${stored_hash}" ]
+                then
+                    log_info "Removing stale distro profile from /data: ${local_name}"
+                    rm -f "${data_file}"
+                    rm -f "${data_file}.backup" "${data_file}~" "${data_file}.un~" \
+                          "${DATA_ETC}/${NM_CONNECTIONS}/.${local_name}.un~"
+                else
+                    log_info "Keeping user-modified profile in /data: ${local_name}"
+                fi
+            else
+                # No valid hash: first migration from the old system, or
+                # hash file was corrupted (e.g., power loss during write).
+                # The /data copy was originally installed by setup-etc-binds
+                # (not user-created), so it is safe to remove.
+                log_info "First migration — removing old distro profile from /data: ${local_name}"
+                rm -f "${data_file}"
+                rm -f "${data_file}.backup" "${data_file}~" "${data_file}.un~" \
+                      "${DATA_ETC}/${NM_CONNECTIONS}/.${local_name}.un~"
+            fi
         fi
-    fi
+
+        # Update the stored hash from the current /usr/lib version so the next
+        # boot can detect whether the user has modified the profile.
+        # Atomic write: write to temp file then rename to avoid corruption on
+        # power failure.
+        if sha256sum "${lib_file}" 2>/dev/null | awk '{print $1}' > "${hash_file}.tmp" 2>/dev/null
+        then
+            mv "${hash_file}.tmp" "${hash_file}" 2>/dev/null || \
+                log_error "Failed to update hash for ${local_name}"
+        else
+            log_error "Failed to compute hash for ${local_name} (disk full?)"
+            rm -f "${hash_file}.tmp" 2>/dev/null
+        fi
+    done
+
+    set -e
 fi
 
 # Bind-mount NetworkManager system-connections directory
-# This allows user-configured WiFi/VPN connections to persist across OTA updates
+# This persists user-added connections (WiFi, VPN) across OTA updates.
+# Distro profiles in /usr/lib/NetworkManager/system-connections/ are not
+# affected — they come from the rootfs and are updated on every OTA.
 if ! mountpoint -q "/etc/${NM_CONNECTIONS}"
 then
     log_info "Bind-mounting ${DATA_ETC}/${NM_CONNECTIONS} → /etc/${NM_CONNECTIONS}"

--- a/recipes-core/wendyos-etc-binds/wendyos-etc-binds_1.0.bb
+++ b/recipes-core/wendyos-etc-binds/wendyos-etc-binds_1.0.bb
@@ -18,7 +18,7 @@ SRC_URI = " \
 SYSTEMD_SERVICE:${PN} = "wendyos-etc-binds.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
-RDEPENDS:${PN} += "bash"
+RDEPENDS:${PN} += "bash coreutils"
 
 do_install() {
     # Install systemd service unit

--- a/scripts/manage-net-sharing.sh
+++ b/scripts/manage-net-sharing.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Manage internet sharing to devices connected via USB gadget
+# (the host machine runs a DHCP server)
 #
 
 set -e

--- a/scripts/setup-host-usb-link-local.sh
+++ b/scripts/setup-host-usb-link-local.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+# setup-host-usb-link-local.sh — Configure the host for link-local on WendyOS USB gadget interfaces
+#
+# Detects whether the host uses NetworkManager or systemd-networkd and installs
+# the appropriate configuration so USB NCM/ECM gadget interfaces automatically
+# get a 169.254.x.x link-local address.
+#
+# Usage:
+#   sudo ./setup-host-usb-link-local.sh [install|uninstall|status]
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+
+# Configuration file paths
+NM_CONN="/etc/NetworkManager/system-connections/wendyos-usb.nmconnection"
+NETWORKD_CONF="/etc/systemd/network/80-wendyos-usb.network"
+
+# USB gadget drivers to match
+USB_DRIVERS="cdc_ncm cdc_ether"
+
+info()    { echo "[INFO]  $*"; }
+warning() { echo "[WARN]  $*"; }
+error()   { echo "[ERROR] $*" >&2; }
+
+usage() {
+    cat <<EOF
+Usage: sudo $SCRIPT_NAME [install|uninstall|status]
+
+Commands:
+  install    Install link-local config for WendyOS USB interfaces (default)
+  uninstall  Remove previously installed config
+  status     Show current state
+
+Detects NetworkManager or systemd-networkd automatically.
+EOF
+}
+
+check_root() {
+    if [ "$(id -u)" -ne 0 ]; then
+        error "This script must be run as root (sudo)"
+        exit 1
+    fi
+}
+
+# Detect which network manager is active
+detect_net_manager() {
+    if systemctl is-active --quiet NetworkManager 2>/dev/null; then
+        echo "networkmanager"
+    elif systemctl is-active --quiet systemd-networkd 2>/dev/null; then
+        echo "networkd"
+    else
+        echo "unknown"
+    fi
+}
+
+# Check for existing NM connection profiles that could match USB gadget interfaces
+check_existing_nm_profiles() {
+    local conn_dir="/etc/NetworkManager/system-connections"
+    local found=false
+
+    if [ ! -d "$conn_dir" ]; then
+        return
+    fi
+
+    # Look for profiles that match USB gadget interfaces by interface-name or driver
+    for f in "$conn_dir"/*.nmconnection; do
+        [ -f "$f" ] || continue
+        # Skip our own profile
+        [ "$f" = "$NM_CONN" ] && continue
+
+        local name
+        name=$(grep -m1 '^id=' "$f" 2>/dev/null | cut -d= -f2-)
+
+        # Check if profile matches by USB gadget interface name
+        if grep -qE 'interface-name=(usb[0-9]|enp.*u.*)' "$f" 2>/dev/null; then
+            if [ "$found" = false ]; then
+                warning "Found existing NM profiles that may match USB gadget interfaces:"
+                found=true
+            fi
+            echo "  - $f ($name)"
+        fi
+
+        # Check if profile matches by CDC driver
+        if grep -qE 'match\.driver=.*(cdc_ncm|cdc_ether)' "$f" 2>/dev/null; then
+            if [ "$found" = false ]; then
+                warning "Found existing NM profiles that may match USB gadget interfaces:"
+                found=true
+            fi
+            echo "  - $f ($name)"
+        fi
+    done
+
+    # Also check for generic "Wired connection" auto-created profiles (no interface match)
+    # These match any wired interface including USB gadget
+    for f in "$conn_dir"/*.nmconnection; do
+        [ -f "$f" ] || continue
+        [ "$f" = "$NM_CONN" ] && continue
+
+        if grep -q '^type=ethernet' "$f" 2>/dev/null \
+            && ! grep -qE '^interface-name=|^match\.' "$f" 2>/dev/null; then
+            local name
+            name=$(grep -m1 '^id=' "$f" 2>/dev/null | cut -d= -f2-)
+            if [ "$found" = false ]; then
+                warning "Found existing NM profiles that may match USB gadget interfaces:"
+                found=true
+            fi
+            echo "  - $f ($name) — generic wired profile (no interface filter)"
+        fi
+    done
+
+    if [ "$found" = true ]; then
+        info "The wendyos-usb profile uses autoconnect-priority=100 and driver matching,"
+        info "so it will take precedence over these profiles on USB gadget interfaces."
+        info "Existing profiles are not modified."
+        echo ""
+    fi
+}
+
+install_networkmanager() {
+    if [ -f "$NM_CONN" ]; then
+        warning "Config already exists: $NM_CONN"
+        info "Use '$SCRIPT_NAME uninstall' first to replace it"
+        return 0
+    fi
+
+    # Check for existing NM profiles that might match USB gadget interfaces
+    check_existing_nm_profiles
+
+    info "Installing NetworkManager connection profile"
+    cat > "$NM_CONN" <<'NMEOF'
+[connection]
+id=wendyos-usb
+type=ethernet
+autoconnect=true
+autoconnect-priority=100
+match.driver=cdc_ncm;cdc_ether
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=link-local
+addr-gen-mode=stable-privacy
+NMEOF
+    chmod 0600 "$NM_CONN"
+
+    info "Reloading NetworkManager connections"
+    nmcli connection reload
+
+    info "Installed: $NM_CONN"
+    info "Any WendyOS USB device will now get a link-local address automatically"
+}
+
+install_networkd() {
+    if [ -f "$NETWORKD_CONF" ]; then
+        warning "Config already exists: $NETWORKD_CONF"
+        info "Use '$SCRIPT_NAME uninstall' first to replace it"
+        return 0
+    fi
+
+    info "Installing systemd-networkd config"
+    cat > "$NETWORKD_CONF" <<'NDEOF'
+[Match]
+Driver=cdc_ncm cdc_ether
+
+[Network]
+LinkLocalAddressing=ipv4
+IPv6LinkLocalAddressGenerationMode=stable-privacy
+LLMNR=no
+MulticastDNS=yes
+NDEOF
+    chmod 0644 "$NETWORKD_CONF"
+
+    info "Reloading systemd-networkd"
+    networkctl reload
+
+    info "Installed: $NETWORKD_CONF"
+    info "Any WendyOS USB device will now get a link-local address automatically"
+}
+
+uninstall_networkmanager() {
+    if [ -f "$NM_CONN" ]; then
+        rm -f "$NM_CONN"
+        nmcli connection reload 2>/dev/null || true
+        info "Removed: $NM_CONN"
+    else
+        info "Nothing to remove (NetworkManager config not found)"
+    fi
+}
+
+uninstall_networkd() {
+    if [ -f "$NETWORKD_CONF" ]; then
+        rm -f "$NETWORKD_CONF"
+        networkctl reload 2>/dev/null || true
+        info "Removed: $NETWORKD_CONF"
+    else
+        info "Nothing to remove (systemd-networkd config not found)"
+    fi
+}
+
+show_status() {
+    local mgr
+    mgr=$(detect_net_manager)
+
+    echo "Network manager: $mgr"
+    echo ""
+
+    if [ -f "$NM_CONN" ]; then
+        echo "NetworkManager config: $NM_CONN [INSTALLED]"
+    else
+        echo "NetworkManager config: $NM_CONN [not installed]"
+    fi
+
+    if [ -f "$NETWORKD_CONF" ]; then
+        echo "systemd-networkd config: $NETWORKD_CONF [INSTALLED]"
+    else
+        echo "systemd-networkd config: $NETWORKD_CONF [not installed]"
+    fi
+
+    echo ""
+
+    # Show any currently connected USB gadget interfaces
+    local found=false
+    for driver in $USB_DRIVERS; do
+        for devpath in /sys/class/net/*/device/driver; do
+            if [ -e "$devpath" ] && [ "$(basename "$(readlink "$devpath")")" = "$driver" ]; then
+                local iface
+                iface="$(basename "$(dirname "$(dirname "$devpath")")")"
+                local addr
+                addr=$(ip -4 addr show "$iface" 2>/dev/null | grep -oP 'inet \K[0-9.]+/[0-9]+' || echo "no address")
+                echo "USB gadget interface: $iface ($driver) — $addr"
+                found=true
+            fi
+        done
+    done
+
+    if [ "$found" = false ]; then
+        echo "No USB gadget interfaces detected"
+    fi
+
+    # Show mDNS discovery if avahi-browse is available
+    if command -v avahi-browse &>/dev/null; then
+        echo ""
+        echo "Scanning for WendyOS devices..."
+        avahi-browse -t -p _wendyos._udp 2>/dev/null || echo "  No devices found"
+    fi
+}
+
+do_install() {
+    local mgr
+    mgr=$(detect_net_manager)
+
+    case "$mgr" in
+        networkmanager)
+            install_networkmanager
+            ;;
+        networkd)
+            install_networkd
+            ;;
+        *)
+            error "Could not detect NetworkManager or systemd-networkd"
+            error "Please configure link-local manually (see docs/HOST-USB-LINK-LOCAL-SETUP.md)"
+            exit 1
+            ;;
+    esac
+}
+
+do_uninstall() {
+    # Remove both — doesn't hurt if one doesn't exist
+    uninstall_networkmanager
+    uninstall_networkd
+}
+
+main() {
+    local cmd="${1:-install}"
+
+    case "$cmd" in
+        install)
+            check_root
+            do_install
+            ;;
+        uninstall)
+            check_root
+            do_uninstall
+            ;;
+        status)
+            show_status
+            ;;
+        -h|--help|help)
+            usage
+            ;;
+        *)
+            error "Unknown command: $cmd"
+            usage
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Description

### Add support for IPv4 method selection

Introduce **WENDYOS_USB_NET_MODE** variable to select the IPv4 method on
usb0 at build time: link-local (default), dhcp-client, or dhcp-server.

- link-local: RFC 3927 self-assigned 169.254.x.x, discovery via mDNS
- dhcp-client: device is DHCP client (host must run DHCP server)
- dhcp-server: device runs DHCP server via NM shared mode (dnsmasq)

`dnsmasq` is conditionally included only for dhcp-server mode.

Also adds **WENDYOS_MDNS_INTERFACES** (default: usb0) to restrict Avahi mDNS to specific interfaces, and fixes the hardcoded platform name in the Avahi service file to use MACHINE at build time.

### Move distro NM profile to /usr/lib for OTA-safe delivery

Currently, the `usb-gadget.nmconnection` was installed to `/etc/NetworkManager/system-connections/`, which `wendyos-etc-binds` bind-mounts from `/data` to persist user WiFi/VPN connections across OTA updates.
The copy from rootfs to `/data` happens only on first boot — after that, the /data version is bind-mounted over `/etc`, hiding any
rootfs changes. This meant build-time changes to `usb-gadget.nmconnection` (such as the link-local migration) never took effect on existing devices.

To fix this, the changes install distro-managed profiles to `/usr/lib/NetworkManager/system-connections/`, which is from NM v1.46+ a read-only keyfile path. NM natively merges both directories, with `/etc` taking priority — so user modifications via nmcli are preserved while OTA updates always deliver the latest distro profile.

Migration logic in `setup-etc-binds.sh` uses sha256 hash tracking (like dpkg conffiles) to clean stale distro copies from `/data`:
- Hash matches stored distro hash -> stale copy -> removed
- Hash differs → user-modified -> preserved
- No hash file → first migration -> removed (was distro-installed)
- Atomic hash writes and set +e guard against disk-full/power-loss