### PR TITLE
Enable PipeWire audio on RPi5 by splitting wendyos-user from /data de…

### DIFF
--- a/conf/distro/include/rpi-image.inc
+++ b/conf/distro/include/rpi-image.inc
@@ -35,16 +35,6 @@ IMAGE_INSTALL:remove = " \
     util-linux-mount \
     "
 
-# RPi5 has no Pipewire/audio stack like Jetson
-IMAGE_INSTALL:remove = " \
-    audio-config \
-    pipewire \
-    wireplumber \
-    pipewire-pulse \
-    pipewire-alsa \
-    rtkit \
-    "
-
 # WIC build dependencies
 do_image_wic[depends] += " \
     rpi-cmdline:do_deploy \

--- a/recipes-core/packagegroups/packagegroup-base-rpi.inc
+++ b/recipes-core/packagegroups/packagegroup-base-rpi.inc
@@ -3,7 +3,7 @@ RDEPENDS:${PN}:remove:rpi = " \
     wendyos-etc-binds \
     systemd-mount-containerd \
     swapfile-setup \
-    wendyos-user \
+    wendyos-user-data-setup \
     "
 
 # Add RPi5-specific kernel modules

--- a/recipes-core/packagegroups/packagegroup-wendyos-base.bb
+++ b/recipes-core/packagegroups/packagegroup-wendyos-base.bb
@@ -29,6 +29,7 @@ RDEPENDS:${PN} = " \
     wendyos-identity \
     wendyos-agent \
     wendyos-user \
+    wendyos-user-data-setup \
     wendyos-motd \
     systemd-mount-containerd \
     swapfile-setup \

--- a/recipes-core/packagegroups/qemu-packagegroup-base.inc
+++ b/recipes-core/packagegroups/qemu-packagegroup-base.inc
@@ -4,7 +4,7 @@
 # Remove data partition dependent services for QEMU
 # QEMU uses single-partition layout without separate /data
 RDEPENDS:${PN}:remove = " \
-    wendyos-user \
+    wendyos-user-data-setup \
     wendyos-etc-binds \
     swapfile-setup \
     systemd-mount-containerd \

--- a/recipes-extended/wendyos-user/wendyos-user_1.0.bb
+++ b/recipes-extended/wendyos-user/wendyos-user_1.0.bb
@@ -1,6 +1,8 @@
 SUMMARY = "WendyOS Default User Configuration"
 DESCRIPTION = "Creates the default 'wendy' user with appropriate permissions for WendyOS. \
-Home directory is initialized on first boot from persistent storage (/data/home)."
+The base package creates the user and sudoers config. The -data-setup package \
+provides the first-boot service that initializes the home directory on the \
+persistent /data partition (Tegra only)."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
@@ -11,22 +13,24 @@ SRC_URI = " \
     file://wendyos-user-setup.service \
 "
 
+PACKAGES = "${PN}-data-setup ${PN}"
+
 # Create wendy user - simplified group list (non-existent groups cause failures)
 USERADD_PACKAGES = "${PN}"
 # Password 'wendy' hash generated with: openssl passwd -6 -salt 5ixFr0sKRtsKKKhY wendy
-# NOTE: useradd with -m flag will try to create home, but since /home is bind-mounted
-# from /data/home, the actual initialization happens via first-boot service
+# useradd -m creates /home/wendy on the rootfs; on Tegra, the first-boot service
+# in wendyos-user-data-setup re-initializes it from persistent storage (/data/home)
 USERADD_PARAM:${PN} = "-m -d /home/wendy -s /bin/bash -G dialout,video,audio,users -p '\$6\$5ixFr0sKRtsKKKhY\$5SyCVB9y95JEITWZ8AMcMCrMF4Rvq97ymUjEoUCBKfTl7vWHjTLEboowxWF6hIJgBUMOnJQfeIRPPwYCUaIwm.' wendy"
 
-SYSTEMD_SERVICE:${PN} = "wendyos-user-setup.service"
-SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN}-data-setup = "wendyos-user-setup.service"
+SYSTEMD_AUTO_ENABLE:${PN}-data-setup = "enable"
 
 do_install() {
-    # Install first-boot setup script
+    # Install first-boot setup script (packaged in -data-setup)
     install -d ${D}${sbindir}
     install -m 0755 ${WORKDIR}/wendyos-user-setup.sh ${D}${sbindir}/wendyos-user-setup.sh
 
-    # Install systemd service
+    # Install systemd service (packaged in -data-setup)
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/wendyos-user-setup.service ${D}${systemd_system_unitdir}/wendyos-user-setup.service
 }
@@ -39,11 +43,15 @@ pkg_postinst_ontarget:${PN}() {
     fi
 }
 
-FILES:${PN} += " \
+# Base package: user creation + sudoers (no files, useradd class handles /etc/passwd)
+FILES:${PN} = ""
+ALLOW_EMPTY:${PN} = "1"
+RDEPENDS:${PN} = "sudo bash systemd"
+
+# Data setup package: first-boot /data/home initialization (Tegra only)
+SUMMARY:${PN}-data-setup = "WendyOS User Home Directory Setup for /data Partition"
+FILES:${PN}-data-setup = " \
     ${sbindir}/wendyos-user-setup.sh \
     ${systemd_system_unitdir}/wendyos-user-setup.service \
 "
-
-# Ensure required packages are available
-# systemd-mount-home provides the /home bind mount
-RDEPENDS:${PN} = "sudo bash systemd systemd-mount-home"
+RDEPENDS:${PN}-data-setup = "${PN} bash systemd-mount-home"

--- a/recipes-multimedia/audio-config/files/pipewire-user-setup.service
+++ b/recipes-multimedia/audio-config/files/pipewire-user-setup.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Enable PipeWire Audio for wendy User
 After=multi-user.target home.mount wendyos-user-setup.service
-Requires=home.mount
-Wants=wendyos-user-setup.service
+Wants=home.mount wendyos-user-setup.service
 ConditionPathExists=/home/wendy
 
 [Service]


### PR DESCRIPTION
Enable PipeWire audio on RPi5 by splitting wendyos-user from /data dependency

The `wendyos-user` package was excluded on RPi5 and QEMU because it had a hard dependency on the /data partition (Tegra-only). This also forced excluding the entire PipeWire audio stack on RPi5, since PipeWire runs as the wendy user. RPi5 has HDMI audio, USB audio, and Bluetooth A2DP hardware that was left unused.

Split `wendyos-user` into two packages:
- `wendyos-user`: creates the wendy user, groups, and sudoers (no /data dependency, included on all machines)
- `wendyos-user-data-setup`: first-boot /data/home initialization service (Tegra only, removed on RPi5 and QEMU)

Also soften `pipewire-user-setup.service` dependency on home.mount from Requires to Wants, so it starts on RPi5 where home.mount does not exist.