### PR TITLE
 Adds Raspberry Pi 3 (64-bit) and Raspberry Pi 4 (64-bit, SD card) as supported WendyOS targets.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,9 @@ jobs:
       - family=c7i-flex.8xlarge
       - spot=false
       - volume=400gb:gp3
-      - run-id=${{ github.run_id }}
+      - run-id=${{ github.run_id }}-${{ matrix.device }}
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         include:
           - device: rpi3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,20 @@ jobs:
       max-parallel: 1
       matrix:
         include:
+          - device: rpi3
+            board: rpi3-sd
+            machine: raspberrypi3-64-wendyos
+            publisher_device: raspberry-pi-3
+          - device: rpi4
+            board: rpi4-sd
+            machine: raspberrypi4-64-wendyos
+            publisher_device: raspberry-pi-4
           - device: rpi5
+            board: rpi5-sd
             machine: raspberrypi5-wendyos
             publisher_device: raspberry-pi-5
           - device: jetson
+            board: jetson-orin-nano-nvme
             machine: jetson-orin-nano-devkit-nvme-wendyos
             publisher_device: jetson-orin-nano
 
@@ -53,7 +63,7 @@ jobs:
 
       - name: Bootstrap build environment
         working-directory: ${{ github.workspace }}
-        run: MACHINE=${{ matrix.device }} ./wendyos/bootstrap.sh
+        run: BOARD=${{ matrix.board }} ./wendyos/bootstrap.sh
 
       - name: Fix workspace permissions for Docker
         run: chmod -R a+rwX ${{ github.workspace }} 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - family=c7i-flex.8xlarge
       - spot=false
       - volume=400gb:gp3
-      - run-id=${{ github.run_id }}
+      - run-id=${{ github.run_id }}-${{ matrix.device }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - device: rpi3
+            board: rpi3-sd
+            machine: raspberrypi3-64-wendyos
+            publisher_device: raspberry-pi-3
+          - device: rpi4
+            board: rpi4-sd
+            machine: raspberrypi4-64-wendyos
+            publisher_device: raspberry-pi-4
           - device: rpi5
+            board: rpi5-sd
             machine: raspberrypi5-wendyos
             publisher_device: raspberry-pi-5
           - device: jetson
+            board: jetson-orin-nano-nvme
             machine: jetson-orin-nano-devkit-nvme-wendyos
             publisher_device: jetson-orin-nano
 
@@ -46,7 +56,7 @@ jobs:
 
       - name: Bootstrap build environment
         working-directory: ${{ github.workspace }}
-        run: MACHINE=${{ matrix.device }} ./wendyos/bootstrap.sh
+        run: BOARD=${{ matrix.board }} ./wendyos/bootstrap.sh
 
       - name: Fix workspace permissions for Docker
         run: chmod -R a+rwX ${{ github.workspace }} 2>/dev/null || true

--- a/conf/machine/raspberrypi3-64-wendyos.conf
+++ b/conf/machine/raspberrypi3-64-wendyos.conf
@@ -1,0 +1,45 @@
+MACHINEOVERRIDES =. "rpi:raspberrypi3-64:"
+require conf/machine/raspberrypi3-64.conf
+
+# WIC GPT image — no Mender, no tegraflash
+IMAGE_FSTYPES = "wic wic.bmap"
+IMAGE_FSTYPES:remove = "tegraflash dataimg mender uefiimg uefiimg.bmap uefiimg.bz2"
+WKS_FILE = "rpi-partuuid.wks"
+WKS_FILE_DEPENDS += "gptfdisk"
+LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
+
+# No Mender, no UEFI capsule updates
+WENDYOS_UPDATE_BOOTLOADER ?= "0"
+WENDYOS_EFI_DEBUG ?= "0"
+WENDYOS_DEEPSTREAM ?= "0"
+# Default persist=off; single partition, no /data
+WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
+# RPi3 B/B+ cannot do USB gadget (LAN9514 hub blocks DWC2 peripheral mode)
+# RPi3 A+ technically can, but requires non-standard cable + external power
+WENDYOS_USB_GADGET ?= "0"
+# No usb0 interface on RPi3 — allow mDNS on all interfaces (WiFi/Ethernet)
+WENDYOS_MDNS_INTERFACES ?= ""
+WENDYOS_DEBUG ?= "0"
+WENDYOS_CONTAINER_RUNTIME ?= "1"
+
+# RPi3 boot config (consumed by rpi-config_%.bbappend)
+# No dtparam=pciex1 — RPi3 has no PCIe.
+# No UART overlay — Bluetooth stays on PL011 (ttyAMA0), serial console uses the
+# mini UART (ttyS0) on GPIO 14/15. Mini UART baud rate can drift under heavy
+# CPU load (its clock is derived from the VPU clock), so serial output may
+# occasionally garble during boot or under sustained load. Acceptable trade-off
+# for keeping onboard Bluetooth available.
+ENABLE_UART = "1"
+ENABLE_DWC2_PERIPHERAL = "${@oe.utils.ifelse(d.getVar('WENDYOS_USB_GADGET') == '1', '1', '0')}"
+DISABLE_RPI_BOOT_LOGO = "1"
+DISABLE_SPLASH = "1"
+DISABLE_OVERSCAN = "1"
+
+# Mini UART on GPIO 14/15 (upstream default for RPi3)
+SERIAL_CONSOLES = "115200;ttyS0"
+SERIAL_CONSOLES_CHECK = ""
+MACHINE_FEATURES:append = " wifi bluetooth"
+EXTRADEPS = ""
+
+# Stable board identity written to /etc/wendyos/device-type
+WENDYOS_BOARD_ID = "rpi3-sd"

--- a/conf/machine/raspberrypi4-64-wendyos.conf
+++ b/conf/machine/raspberrypi4-64-wendyos.conf
@@ -1,0 +1,44 @@
+MACHINEOVERRIDES =. "rpi:raspberrypi4-64:"
+require conf/machine/raspberrypi4-64.conf
+
+# WIC GPT image — no Mender, no tegraflash
+IMAGE_FSTYPES = "wic wic.bmap"
+IMAGE_FSTYPES:remove = "tegraflash dataimg mender uefiimg uefiimg.bmap uefiimg.bz2"
+WKS_FILE = "rpi-partuuid.wks"
+WKS_FILE_DEPENDS += "gptfdisk"
+LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
+
+# No Mender, no UEFI capsule updates
+WENDYOS_UPDATE_BOOTLOADER ?= "0"
+WENDYOS_EFI_DEBUG ?= "0"
+WENDYOS_DEEPSTREAM ?= "0"
+# Default persist=off; single partition, no /data
+WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
+# RPi4 has an OTG-capable USB-C port — enable gadget by default
+WENDYOS_USB_GADGET ?= "1"
+# Advertise mDNS on both USB gadget and WiFi interfaces
+WENDYOS_MDNS_INTERFACES ?= "usb0 wlan0"
+WENDYOS_DEBUG ?= "0"
+WENDYOS_CONTAINER_RUNTIME ?= "1"
+
+# RPi4 boot config (consumed by rpi-config_%.bbappend)
+# No dtparam=pciex1 — RPi4 has no user-facing PCIe lane.
+# No UART overlay — Bluetooth stays on PL011 (ttyAMA0), serial console uses the
+# mini UART (ttyS0) on GPIO 14/15. Mini UART baud rate can drift under heavy
+# CPU load (its clock is derived from the VPU clock), so serial output may
+# occasionally garble during boot or under sustained load. Acceptable trade-off
+# for keeping onboard Bluetooth available.
+ENABLE_UART = "1"
+ENABLE_DWC2_PERIPHERAL = "${@oe.utils.ifelse(d.getVar('WENDYOS_USB_GADGET') == '1', '1', '0')}"
+DISABLE_RPI_BOOT_LOGO = "1"
+DISABLE_SPLASH = "1"
+DISABLE_OVERSCAN = "1"
+
+# Mini UART on GPIO 14/15 (upstream default for RPi4)
+SERIAL_CONSOLES = "115200;ttyS0"
+SERIAL_CONSOLES_CHECK = ""
+MACHINE_FEATURES:append = " wifi bluetooth usbgadget"
+EXTRADEPS = ""
+
+# Stable board identity written to /etc/wendyos/device-type
+WENDYOS_BOARD_ID = "rpi4-sd"

--- a/conf/template/boards/rpi3-sd/bblayers.conf
+++ b/conf/template/boards/rpi3-sd/bblayers.conf
@@ -1,0 +1,4 @@
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/core.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/oe-common.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/rpi.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/wendyos.inc

--- a/conf/template/boards/rpi3-sd/local.conf
+++ b/conf/template/boards/rpi3-sd/local.conf
@@ -1,0 +1,9 @@
+# rpi3-sd: Raspberry Pi 3 B/B+ (64-bit) booting from SD card
+#
+# RPi3 B/B+ cannot run USB gadget (LAN9514 hub blocks DWC2 peripheral mode),
+# so usb-gadget.inc is deliberately NOT required here.
+
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
+
+MACHINE = "raspberrypi3-64-wendyos"

--- a/conf/template/boards/rpi3-sd/repos.overrides
+++ b/conf/template/boards/rpi3-sd/repos.overrides
@@ -1,0 +1,15 @@
+# Per-board repo version overrides for rpi3-sd.
+#
+# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set,
+# but before the repos[] array is built. Uncomment a line below to pin
+# this board to a different commit of an upstream layer.
+#
+# Also available (see bootstrap.sh):
+#   URL_<name>           override a source URL (e.g. to use a fork)
+#   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
+#                        each entry "enabled|url|folder|commit"
+
+#SRCREV_POKY="<commit-hash>"
+#SRCREV_OE="<commit-hash>"
+#SRCREV_VIRT="<commit-hash>"
+#SRCREV_RPI="<commit-hash>"

--- a/conf/template/boards/rpi4-sd/bblayers.conf
+++ b/conf/template/boards/rpi4-sd/bblayers.conf
@@ -1,0 +1,4 @@
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/core.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/oe-common.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/rpi.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/wendyos.inc

--- a/conf/template/boards/rpi4-sd/local.conf
+++ b/conf/template/boards/rpi4-sd/local.conf
@@ -1,0 +1,7 @@
+# rpi4-sd: Raspberry Pi 4 (64-bit) booting from SD card
+
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
+
+MACHINE = "raspberrypi4-64-wendyos"

--- a/conf/template/boards/rpi4-sd/repos.overrides
+++ b/conf/template/boards/rpi4-sd/repos.overrides
@@ -1,0 +1,15 @@
+# Per-board repo version overrides for rpi4-sd.
+#
+# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set,
+# but before the repos[] array is built. Uncomment a line below to pin
+# this board to a different commit of an upstream layer.
+#
+# Also available (see bootstrap.sh):
+#   URL_<name>           override a source URL (e.g. to use a fork)
+#   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
+#                        each entry "enabled|url|folder|commit"
+
+#SRCREV_POKY="<commit-hash>"
+#SRCREV_OE="<commit-hash>"
+#SRCREV_VIRT="<commit-hash>"
+#SRCREV_RPI="<commit-hash>"

--- a/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-config_%.bbappend
+++ b/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-config_%.bbappend
@@ -1,5 +1,10 @@
 # Only runs on RPi machines (rpi-config recipe only exists in meta-raspberrypi)
-do_deploy:append:rpi() {
+# RPi5 needs dtoverlay=uart0 to map PL011 to GPIO 14/15 (yields /dev/ttyAMA0).
+# RPi3/4 use the upstream default: PL011 stays on Bluetooth, serial console
+# runs on the mini UART (/dev/ttyS0) via enable_uart=1 set in their machine
+# configs. Do NOT apply dtoverlay=uart0 for all :rpi — on RPi3/4 it would
+# steal PL011 from Bluetooth.
+do_deploy:append:raspberrypi5() {
     # enable_uart=1 is already written by the upstream rpi-config recipe when
     # ENABLE_UART=1 (set in raspberrypi5-wendyos.conf). Do not duplicate it here.
     echo "dtoverlay=uart0" >> "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt"

--- a/meta-rpi-extensions/recipes-core/packagegroups/packagegroup-wendyos-rpi.bb
+++ b/meta-rpi-extensions/recipes-core/packagegroups/packagegroup-wendyos-rpi.bb
@@ -1,14 +1,24 @@
-SUMMARY = "WendyOS RPi5-specific packages"
+SUMMARY = "WendyOS RPi-specific packages"
 LICENSE = "MIT"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} = " \
-    rpi-eeprom-config \
     wireless-regdb-static \
     expand-rootfs \
     first-boot-timesync \
+    pi-bluetooth \
     "
+# pi-bluetooth ships hciuart.service, which attaches the onboard BT radio to
+# the system over UART on RPi3/4/5. Upstream meta-raspberrypi already pulls
+# it in via RDEPENDS:bluez5:append:rpi, but declare it explicitly here so we
+# don't silently lose BT if that bbappend ever changes.
+# rpi-eeprom-config sets PSU_MAX_CURRENT, which is an RPi5-only EEPROM key
+# (tied to BCM2712's PMIC). RPi4 has an EEPROM but PSU_MAX_CURRENT does not
+# apply there; RPi3 has no EEPROM at all. The runtime script skips on non-RPi5.
+# Include the package only on RPi5 to keep it out of RPi4/RPi3 builds.
+RDEPENDS:${PN}:append:raspberrypi5 = " rpi-eeprom-config"
+
 RDEPENDS:${PN}:append = " \
     ${@oe.utils.ifelse(d.getVar('WENDYOS_DEBUG') == '1', ' iw mmc-utils', '')} \
     "

--- a/recipes-containers/containerd-config/files/raspberrypi3/containerd-memory-limit.conf
+++ b/recipes-containers/containerd-config/files/raspberrypi3/containerd-memory-limit.conf
@@ -1,0 +1,20 @@
+# Systemd drop-in for containerd.service — RPi3 override
+# Picked up automatically via FILESOVERRIDES when MACHINE has the
+# 'raspberrypi3' override (raspberrypi3-64-wendyos).
+#
+# RPi3 B/B+ has 1 GB LPDDR2 RAM (fixed across all 64-bit RPi3 variants).
+# Baseline OS footprint (kernel, systemd, NetworkManager, Avahi, wendyos-agent,
+# containerd daemon itself) is roughly 300-400 MB, leaving ~600 MB for
+# containers. No swap is configured on RPi3 (swapfile-setup is excluded via
+# packagegroup-base-rpi.inc), so the hard limit must keep enough headroom to
+# avoid OOM-killing the host.
+
+[Service]
+# Hard limit: kill containerd (and its containers) if the cgroup exceeds 600 MB
+MemoryMax=600M
+
+# Soft limit: start throttling at 500 MB to avoid hitting the hard limit
+MemoryHigh=500M
+
+# Memory accounting must be enabled
+MemoryAccounting=yes

--- a/recipes-core/gadget-setup/files/gadget-setup.sh
+++ b/recipes-core/gadget-setup/files/gadget-setup.sh
@@ -235,8 +235,9 @@ log_info "USB gadget initialised"
 ip link set usb0 txqueuelen 2000 2>/dev/null || true
 
 # Pin USB IRQ to CPUs 0-3 for cache locality
-# Covers Jetson (3550000.usb / tegra-xudc) and RPi5 (fe980000.usb)
-USB_IRQ=$(grep -E "3550000\.usb|fe980000\.usb" /proc/interrupts 2>/dev/null \
+# Covers Jetson (3550000.usb / tegra-xudc), RPi3 (3f980000.usb),
+# RPi4 (fe980000.usb), and RPi5 (1000480000.usb via RP1)
+USB_IRQ=$(grep -E "3550000\.usb|3f980000\.usb|fe980000\.usb|1000480000\.usb" /proc/interrupts 2>/dev/null \
           | cut -d: -f1 | tr -d ' ' | head -1) || true
 if [ -n "$USB_IRQ" ]; then
     echo "0f" > /proc/irq/"$USB_IRQ"/smp_affinity 2>/dev/null || true

--- a/recipes-core/packagegroups/packagegroup-wendyos-base.bb
+++ b/recipes-core/packagegroups/packagegroup-wendyos-base.bb
@@ -38,6 +38,11 @@ RDEPENDS:${PN} = " \
     xdg-dbus-proxy \
     "
 
+# k3s-agent is excluded on RPi3/RPi4: those targets run containers via
+# containerd directly (e.g. nerdctl), without Kubernetes orchestration.
+RDEPENDS:${PN}:remove:raspberrypi3 = "k3s-agent"
+RDEPENDS:${PN}:remove:raspberrypi4 = "k3s-agent"
+
 RDEPENDS:${PN}:append = " \
     ${@oe.utils.ifelse( \
         d.getVar('WENDYOS_DEBUG') == '1', \


### PR DESCRIPTION
 Adds Raspberry Pi 3 (64-bit) and Raspberry Pi 4 (64-bit, SD card) as supported WendyOS targets.

  Changes
  - New machine configs: raspberrypi3-64-wendyos.conf, raspberrypi4-64-wendyos.conf
  - New board templates: conf/template/boards/rpi3-sd/, conf/template/boards/rpi4-sd/ (bootstrap with BOARD=rpi3-sd /
  BOARD=rpi4-sd)
  - RPi3/4 run containers via containerd/nerdctl directly — k3s excluded (insufficient RAM/not needed)
  - RPi3 has no USB gadget (LAN9514 hub blocks DWC2 peripheral mode); RPi4 has USB-C OTG gadget
  - RPi3 containerd memory limits capped at 600M/500M (1GB RAM device) via systemd drop-in override
  - dtoverlay=uart0 restricted to RPi5 only — prevents stealing PL011 from Bluetooth on RPi3/4
  - EEPROM config (rpi-eeprom-config) restricted to RPi5 only (BCM2712-specific)
  - LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch" required for WiFi/BT firmware (BCM43xxx, binary redistribution permitted)