### PR TITLE
Replace MACHINE/BOARD with DEVICE/STORAGE in board configs and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ on:
         default: all
         options:
           - all
-          - rpi3
-          - rpi4
-          - rpi5
-          - jetson
+          - raspberry-pi-3
+          - raspberry-pi-4
+          - raspberry-pi-5
+          - jetson-orin-nano
       version:
         description: "Git ref (commit SHA, tag, or branch) to build. Empty = latest main."
         type: string
@@ -53,10 +53,10 @@ jobs:
           set -euo pipefail
 
           ALL_MATRIX='[
-            {"device":"rpi3","board":"rpi3-sd","machine":"raspberrypi3-64-wendyos","publisher_device":"raspberry-pi-3"},
-            {"device":"rpi4","board":"rpi4-sd","machine":"raspberrypi4-64-wendyos","publisher_device":"raspberry-pi-4"},
-            {"device":"rpi5","board":"rpi5-sd","machine":"raspberrypi5-wendyos","publisher_device":"raspberry-pi-5"},
-            {"device":"jetson","board":"jetson-orin-nano-nvme","machine":"jetson-orin-nano-devkit-nvme-wendyos","publisher_device":"jetson-orin-nano"}
+            {"device":"raspberry-pi-3","storage":"sd"},
+            {"device":"raspberry-pi-4","storage":"sd"},
+            {"device":"raspberry-pi-5","storage":"sd"},
+            {"device":"jetson-orin-nano","storage":"nvme"}
           ]'
           # Collapse to one line so it can be written to $GITHUB_OUTPUT, which
           # requires single-line key=value pairs (no implicit multiline support).
@@ -64,7 +64,7 @@ jobs:
 
           emit_all() {
             echo "matrix={\"include\":${ALL_MATRIX}}" >> "$GITHUB_OUTPUT"
-            echo "devices=rpi3 rpi4 rpi5 jetson"      >> "$GITHUB_OUTPUT"
+            echo "devices=raspberry-pi-3 raspberry-pi-4 raspberry-pi-5 jetson-orin-nano" >> "$GITHUB_OUTPUT"
           }
 
           emit_one() {
@@ -110,15 +110,15 @@ jobs:
           # Per-device path patterns. meta-rpi-extensions affects every Pi;
           # meta-tegra-extensions affects Jetson only.
           declare -A DEV_RE=(
-            [rpi3]='(^conf/template/boards/rpi3-sd/|^conf/machine/raspberrypi3-64-wendyos\.conf$|^meta-rpi-extensions/)'
-            [rpi4]='(^conf/template/boards/rpi4-sd/|^conf/machine/raspberrypi4-64-wendyos\.conf$|^meta-rpi-extensions/)'
-            [rpi5]='(^conf/template/boards/rpi5-sd/|^conf/machine/raspberrypi5-wendyos\.conf$|^meta-rpi-extensions/)'
-            [jetson]='(^conf/template/boards/jetson-orin-nano-nvme/|^conf/machine/jetson-orin-nano-devkit-nvme-wendyos\.conf$|^meta-tegra-extensions/)'
+            [raspberry-pi-3]='(^conf/template/boards/rpi3-sd/|^conf/machine/raspberrypi3-64-wendyos\.conf$|^meta-rpi-extensions/)'
+            [raspberry-pi-4]='(^conf/template/boards/rpi4-sd/|^conf/machine/raspberrypi4-64-wendyos\.conf$|^meta-rpi-extensions/)'
+            [raspberry-pi-5]='(^conf/template/boards/rpi5-sd/|^conf/machine/raspberrypi5-wendyos\.conf$|^meta-rpi-extensions/)'
+            [jetson-orin-nano]='(^conf/template/boards/jetson-orin-nano-nvme/|^conf/machine/jetson-orin-nano-devkit-nvme-wendyos\.conf$|^meta-tegra-extensions/)'
           )
 
           INCLUDED=()
           DEVICES=()
-          for dev in rpi3 rpi4 rpi5 jetson; do
+          for dev in raspberry-pi-3 raspberry-pi-4 raspberry-pi-5 jetson-orin-nano; do
             if echo "${CHANGED}" | grep -Eq "${DEV_RE[$dev]}"; then
               INCLUDED+=("$(echo "${ALL_MATRIX}" | jq -c ".[] | select(.device == \"${dev}\")")")
               DEVICES+=("${dev}")
@@ -143,7 +143,7 @@ jobs:
   # bump into EBS storage throughput caps.
   # ---------------------------------------------------------------------------
   build:
-    name: Build ${{ matrix.device }}
+    name: Build ${{ matrix.device }} (${{ matrix.storage }})
     needs: detect-changes
     if: needs.detect-changes.outputs.devices != ''
     permissions:
@@ -153,7 +153,7 @@ jobs:
       - runs-on
       - family=c8id.8xlarge
       - spot=false
-      - run-id=${{ github.run_id }}-${{ matrix.device }}
+      - run-id=${{ github.run_id }}-${{ matrix.device }}-${{ matrix.storage }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
@@ -218,10 +218,29 @@ jobs:
 
       # ---------- Build ----------
 
+      - name: Derive build variables
+        id: vars
+        env:
+          DEVICE: ${{ matrix.device }}
+          STORAGE: ${{ matrix.storage }}
+        run: |
+          case "$DEVICE:$STORAGE" in
+            raspberry-pi-3:sd)    BOARD=rpi3-sd;               MACHINE=raspberrypi3-64-wendyos ;;
+            raspberry-pi-4:sd)    BOARD=rpi4-sd;               MACHINE=raspberrypi4-64-wendyos ;;
+            raspberry-pi-5:sd)    BOARD=rpi5-sd;               MACHINE=raspberrypi5-wendyos ;;
+            raspberry-pi-5:nvme)  BOARD=rpi5-nvme;             MACHINE=raspberrypi5-nvme-wendyos ;;
+            jetson-agx-orin:nvme) BOARD=jetson-agx-orin;       MACHINE=jetson-agx-orin-devkit-nvme-wendyos ;;
+            jetson-orin-nano:nvme) BOARD=jetson-orin-nano-nvme; MACHINE=jetson-orin-nano-devkit-nvme-wendyos ;;
+            jetson-orin-nano:sd)  BOARD=jetson-orin-nano-sd;   MACHINE=jetson-orin-nano-devkit-wendyos ;;
+            *) echo "Unknown device/storage: $DEVICE/$STORAGE"; exit 1 ;;
+          esac
+          echo "board=$BOARD" >> "$GITHUB_OUTPUT"
+          echo "machine=$MACHINE" >> "$GITHUB_OUTPUT"
+
       - name: Bootstrap build environment
         working-directory: ${{ github.workspace }}
         env:
-          BOARD: ${{ matrix.board }}
+          BOARD: ${{ steps.vars.outputs.board }}
         run: BOARD="$BOARD" ./wendyos/bootstrap.sh
 
       # Note: SSTATE_DIR / DL_DIR are pinned to ${TOPDIR}/../{sstate-cache,downloads}
@@ -234,7 +253,7 @@ jobs:
       - name: Build image
         working-directory: ${{ github.workspace }}/wendyos
         env:
-          MACHINE: ${{ matrix.machine }}
+          MACHINE: ${{ steps.vars.outputs.machine }}
         run: make build MACHINE="$MACHINE"
 
       - name: Fix deploy directory permissions
@@ -288,14 +307,14 @@ jobs:
           go-version-file: wendy-os-publisher/go.mod
 
       - name: Install flashable image dependencies (Jetson only)
-        if: github.event_name != 'pull_request' && matrix.device == 'jetson'
+        if: github.event_name != 'pull_request' && matrix.device == 'jetson-orin-nano'
         run: sudo apt-get update && sudo apt-get install -y device-tree-compiler
 
       - name: Generate flashable image (Jetson only)
-        if: github.event_name != 'pull_request' && matrix.device == 'jetson'
+        if: github.event_name != 'pull_request' && matrix.device == 'jetson-orin-nano'
         env:
-          DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ matrix.machine }}
-          MACHINE: ${{ matrix.machine }}
+          DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
+          MACHINE: ${{ steps.vars.outputs.machine }}
         run: |
           TEGRAFLASH_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz"
           FLASH_WORKDIR="$GITHUB_WORKSPACE/flash-work"
@@ -307,9 +326,9 @@ jobs:
       - name: Upload image and update device manifest
         if: github.event_name != 'pull_request'
         env:
-          DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ matrix.machine }}
-          MACHINE: ${{ matrix.machine }}
-          PUBLISHER_DEVICE: ${{ matrix.publisher_device }}
+          DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
+          MACHINE: ${{ steps.vars.outputs.machine }}
+          DEVICE: ${{ matrix.device }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
         run: |
           VERSION=$(grep 'DISTRO_VERSION' "$GITHUB_WORKSPACE/wendyos/conf/distro/wendyos.conf" | head -1 | sed 's/.*"\(.*\)"/\1/')
@@ -322,7 +341,7 @@ jobs:
           fi
 
           ARGS=(
-            --device "$PUBLISHER_DEVICE"
+            --device "$DEVICE"
             --version "${VERSION}-nightly"
             --file "$IMAGE_FILE"
             --nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build ${{ matrix.device }}
+    name: Build ${{ matrix.device }} (${{ matrix.storage }})
     permissions:
       contents: read
       id-token: write
@@ -16,27 +16,19 @@ jobs:
       - family=c7i-flex.8xlarge
       - spot=false
       - volume=400gb:gp3
-      - run-id=${{ github.run_id }}-${{ matrix.device }}
+      - run-id=${{ github.run_id }}-${{ matrix.device }}-${{ matrix.storage }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - device: rpi3
-            board: rpi3-sd
-            machine: raspberrypi3-64-wendyos
-            publisher_device: raspberry-pi-3
-          - device: rpi4
-            board: rpi4-sd
-            machine: raspberrypi4-64-wendyos
-            publisher_device: raspberry-pi-4
-          - device: rpi5
-            board: rpi5-sd
-            machine: raspberrypi5-wendyos
-            publisher_device: raspberry-pi-5
-          - device: jetson
-            board: jetson-orin-nano-nvme
-            machine: jetson-orin-nano-devkit-nvme-wendyos
-            publisher_device: jetson-orin-nano
+          - device: raspberry-pi-3
+            storage: sd
+          - device: raspberry-pi-4
+            storage: sd
+          - device: raspberry-pi-5
+            storage: sd
+          - device: jetson-orin-nano
+            storage: nvme
 
     steps:
       # Disabled: build caching is flaky for mender builds
@@ -54,16 +46,39 @@ jobs:
         with:
           path: wendyos
 
+      - name: Derive build variables
+        id: vars
+        env:
+          DEVICE: ${{ matrix.device }}
+          STORAGE: ${{ matrix.storage }}
+        run: |
+          case "$DEVICE:$STORAGE" in
+            raspberry-pi-3:sd)    BOARD=rpi3-sd;               MACHINE=raspberrypi3-64-wendyos ;;
+            raspberry-pi-4:sd)    BOARD=rpi4-sd;               MACHINE=raspberrypi4-64-wendyos ;;
+            raspberry-pi-5:sd)    BOARD=rpi5-sd;               MACHINE=raspberrypi5-wendyos ;;
+            raspberry-pi-5:nvme)  BOARD=rpi5-nvme;             MACHINE=raspberrypi5-nvme-wendyos ;;
+            jetson-agx-orin:nvme) BOARD=jetson-agx-orin;       MACHINE=jetson-agx-orin-devkit-nvme-wendyos ;;
+            jetson-orin-nano:nvme) BOARD=jetson-orin-nano-nvme; MACHINE=jetson-orin-nano-devkit-nvme-wendyos ;;
+            jetson-orin-nano:sd)  BOARD=jetson-orin-nano-sd;   MACHINE=jetson-orin-nano-devkit-wendyos ;;
+            *) echo "Unknown device/storage: $DEVICE/$STORAGE"; exit 1 ;;
+          esac
+          echo "board=$BOARD" >> "$GITHUB_OUTPUT"
+          echo "machine=$MACHINE" >> "$GITHUB_OUTPUT"
+
       - name: Bootstrap build environment
         working-directory: ${{ github.workspace }}
-        run: BOARD=${{ matrix.board }} ./wendyos/bootstrap.sh
+        env:
+          BOARD: ${{ steps.vars.outputs.board }}
+        run: BOARD=$BOARD ./wendyos/bootstrap.sh
 
       - name: Fix workspace permissions for Docker
         run: chmod -R a+rwX ${{ github.workspace }} 2>/dev/null || true
 
       - name: Build image
         working-directory: ${{ github.workspace }}/wendyos
-        run: make build MACHINE=${{ matrix.machine }}
+        env:
+          MACHINE: ${{ steps.vars.outputs.machine }}
+        run: make build MACHINE=$MACHINE
 
       - name: Fix deploy directory permissions
         run: sudo chown -R "$(id -u):$(id -g)" "${{ github.workspace }}/build/tmp/deploy" 2>/dev/null || true
@@ -91,10 +106,10 @@ jobs:
           go-version-file: wendy-os-publisher/go.mod
 
       - name: Generate flashable image (Jetson only)
-        if: matrix.device == 'jetson'
+        if: matrix.device == 'jetson-orin-nano'
         env:
-          DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ matrix.machine }}
-          MACHINE: ${{ matrix.machine }}
+          DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
+          MACHINE: ${{ steps.vars.outputs.machine }}
         run: |
           TEGRAFLASH_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz"
           FLASH_WORKDIR="$GITHUB_WORKSPACE/flash-work"
@@ -105,9 +120,9 @@ jobs:
 
       - name: Publish release to GCS
         env:
-          DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ matrix.machine }}
-          MACHINE: ${{ matrix.machine }}
-          PUBLISHER_DEVICE: ${{ matrix.publisher_device }}
+          DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
+          MACHINE: ${{ steps.vars.outputs.machine }}
+          DEVICE: ${{ matrix.device }}
           RELEASE_VERSION: ${{ github.ref_name }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
         run: |
@@ -120,7 +135,7 @@ jobs:
           fi
 
           ARGS=(
-            --device "$PUBLISHER_DEVICE"
+            --device "$DEVICE"
             --version "$RELEASE_VERSION"
             --file "$IMAGE_FILE"
             --access-token "$TOKEN"

--- a/conf/template/boards/jetson-agx-orin/local.conf
+++ b/conf/template/boards/jetson-agx-orin/local.conf
@@ -4,7 +4,9 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
 
-MACHINE = "jetson-agx-orin-devkit-nvme-wendyos"
+DEVICE = "jetson-agx-orin"
+STORAGE = "nvme"
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
 
 # Flash image size - sets MENDER_STORAGE_TOTAL_SIZE_MB via flash-image-sizes.inc
 # Supported: "4GB", "8GB", "16GB", "32GB", "64GB"

--- a/conf/template/boards/jetson-agx-orin/local.conf
+++ b/conf/template/boards/jetson-agx-orin/local.conf
@@ -4,9 +4,9 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
 
-DEVICE = "jetson-agx-orin"
+DEVICE  = "jetson-agx-orin"
 STORAGE = "nvme"
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
+MACHINE = "jetson-agx-orin-devkit-nvme-wendyos"
 
 # Flash image size - sets MENDER_STORAGE_TOTAL_SIZE_MB via flash-image-sizes.inc
 # Supported: "4GB", "8GB", "16GB", "32GB", "64GB"

--- a/conf/template/boards/jetson-orin-nano-nvme/local.conf
+++ b/conf/template/boards/jetson-orin-nano-nvme/local.conf
@@ -4,9 +4,9 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
 
-DEVICE = "jetson-orin-nano"
+DEVICE  = "jetson-orin-nano"
 STORAGE = "nvme"
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
+MACHINE = "jetson-orin-nano-devkit-nvme-wendyos"
 
 # Flash image size - sets MENDER_STORAGE_TOTAL_SIZE_MB via flash-image-sizes.inc
 # Supported: "4GB", "8GB", "16GB", "32GB", "64GB"

--- a/conf/template/boards/jetson-orin-nano-nvme/local.conf
+++ b/conf/template/boards/jetson-orin-nano-nvme/local.conf
@@ -4,7 +4,9 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
 
-MACHINE = "jetson-orin-nano-devkit-nvme-wendyos"
+DEVICE = "jetson-orin-nano"
+STORAGE = "nvme"
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
 
 # Flash image size - sets MENDER_STORAGE_TOTAL_SIZE_MB via flash-image-sizes.inc
 # Supported: "4GB", "8GB", "16GB", "32GB", "64GB"

--- a/conf/template/boards/jetson-orin-nano-sd/local.conf
+++ b/conf/template/boards/jetson-orin-nano-sd/local.conf
@@ -4,9 +4,9 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
 
-DEVICE = "jetson-orin-nano"
+DEVICE  = "jetson-orin-nano"
 STORAGE = "sd"
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
+MACHINE = "jetson-orin-nano-devkit-wendyos"
 
 # Flash image size - sets MENDER_STORAGE_TOTAL_SIZE_MB via flash-image-sizes.inc
 # Supported: "4GB", "8GB", "16GB", "32GB", "64GB"

--- a/conf/template/boards/jetson-orin-nano-sd/local.conf
+++ b/conf/template/boards/jetson-orin-nano-sd/local.conf
@@ -4,7 +4,9 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
 
-MACHINE = "jetson-orin-nano-devkit-wendyos"
+DEVICE = "jetson-orin-nano"
+STORAGE = "sd"
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
 
 # Flash image size - sets MENDER_STORAGE_TOTAL_SIZE_MB via flash-image-sizes.inc
 # Supported: "4GB", "8GB", "16GB", "32GB", "64GB"

--- a/conf/template/boards/qemu-arm64/local.conf
+++ b/conf/template/boards/qemu-arm64/local.conf
@@ -3,6 +3,7 @@
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/qemu.inc
 
+DEVICE  = "qemu-arm64"
 MACHINE = "qemuarm64-wendyos"
 
 # QEMU rootfs size in KB (used by qemu-image.inc):

--- a/conf/template/boards/rpi3-sd/local.conf
+++ b/conf/template/boards/rpi3-sd/local.conf
@@ -6,6 +6,6 @@
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
 
-DEVICE = "raspberry-pi-3"
+DEVICE  = "raspberry-pi-3"
 STORAGE = "sd"
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
+MACHINE = "raspberrypi3-64-wendyos"

--- a/conf/template/boards/rpi3-sd/local.conf
+++ b/conf/template/boards/rpi3-sd/local.conf
@@ -6,4 +6,6 @@
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
 
-MACHINE = "raspberrypi3-64-wendyos"
+DEVICE = "raspberry-pi-3"
+STORAGE = "sd"
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc

--- a/conf/template/boards/rpi4-sd/local.conf
+++ b/conf/template/boards/rpi4-sd/local.conf
@@ -4,4 +4,6 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
 
-MACHINE = "raspberrypi4-64-wendyos"
+DEVICE = "raspberry-pi-4"
+STORAGE = "sd"
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc

--- a/conf/template/boards/rpi4-sd/local.conf
+++ b/conf/template/boards/rpi4-sd/local.conf
@@ -4,6 +4,6 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
 
-DEVICE = "raspberry-pi-4"
+DEVICE  = "raspberry-pi-4"
 STORAGE = "sd"
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
+MACHINE = "raspberrypi4-64-wendyos"

--- a/conf/template/boards/rpi5-nvme/local.conf
+++ b/conf/template/boards/rpi5-nvme/local.conf
@@ -4,4 +4,6 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
 
-MACHINE = "raspberrypi5-nvme-wendyos"
+DEVICE = "raspberry-pi-5"
+STORAGE = "nvme"
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc

--- a/conf/template/boards/rpi5-nvme/local.conf
+++ b/conf/template/boards/rpi5-nvme/local.conf
@@ -4,6 +4,6 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
 
-DEVICE = "raspberry-pi-5"
+DEVICE  = "raspberry-pi-5"
 STORAGE = "nvme"
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
+MACHINE = "raspberrypi5-nvme-wendyos"

--- a/conf/template/boards/rpi5-sd/local.conf
+++ b/conf/template/boards/rpi5-sd/local.conf
@@ -4,4 +4,6 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
 
-MACHINE = "raspberrypi5-wendyos"
+DEVICE = "raspberry-pi-5"
+STORAGE = "sd"
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc

--- a/conf/template/boards/rpi5-sd/local.conf
+++ b/conf/template/boards/rpi5-sd/local.conf
@@ -4,6 +4,6 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/rpi.inc
 
-DEVICE = "raspberry-pi-5"
+DEVICE  = "raspberry-pi-5"
 STORAGE = "sd"
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/machine-map.inc
+MACHINE = "raspberrypi5-wendyos"

--- a/conf/template/include/local/machine-map.inc
+++ b/conf/template/include/local/machine-map.inc
@@ -1,4 +1,0 @@
-# Maps DEVICE + STORAGE to the Yocto MACHINE name.
-# Require this file after setting DEVICE and STORAGE in your board's local.conf.
-
-MACHINE = "${@{'raspberry-pi-3:sd': 'raspberrypi3-64-wendyos', 'raspberry-pi-4:sd': 'raspberrypi4-64-wendyos', 'raspberry-pi-5:sd': 'raspberrypi5-wendyos', 'raspberry-pi-5:nvme': 'raspberrypi5-nvme-wendyos', 'jetson-agx-orin:nvme': 'jetson-agx-orin-devkit-nvme-wendyos', 'jetson-orin-nano:nvme': 'jetson-orin-nano-devkit-nvme-wendyos', 'jetson-orin-nano:sd': 'jetson-orin-nano-devkit-wendyos'}.get((d.getVar('DEVICE') or '') + ':' + (d.getVar('STORAGE') or ''), '')}"

--- a/conf/template/include/local/machine-map.inc
+++ b/conf/template/include/local/machine-map.inc
@@ -1,0 +1,4 @@
+# Maps DEVICE + STORAGE to the Yocto MACHINE name.
+# Require this file after setting DEVICE and STORAGE in your board's local.conf.
+
+MACHINE = "${@{'raspberry-pi-3:sd': 'raspberrypi3-64-wendyos', 'raspberry-pi-4:sd': 'raspberrypi4-64-wendyos', 'raspberry-pi-5:sd': 'raspberrypi5-wendyos', 'raspberry-pi-5:nvme': 'raspberrypi5-nvme-wendyos', 'jetson-agx-orin:nvme': 'jetson-agx-orin-devkit-nvme-wendyos', 'jetson-orin-nano:nvme': 'jetson-orin-nano-devkit-nvme-wendyos', 'jetson-orin-nano:sd': 'jetson-orin-nano-devkit-wendyos'}.get((d.getVar('DEVICE') or '') + ':' + (d.getVar('STORAGE') or ''), '')}"


### PR DESCRIPTION
## Summary

- Board `local.conf` templates now use `DEVICE` (matching the publisher identifier, e.g. `raspberry-pi-5`) and `STORAGE` (`sd` or `nvme`) instead of the internal Yocto `MACHINE` name
- New `machine-map.inc` derives the Yocto `MACHINE` from `DEVICE+STORAGE` so BitBake still works transparently
- CI matrices simplified from 4 fields (`device`, `board`, `machine`, `publisher_device`) to 2 (`device`, `storage`); a **Derive build variables** step resolves `BOARD` and `MACHINE` for downstream steps
- QEMU board left unchanged (no sd/nvme concept applies)

## Test plan

- [ ] Verify bootstrap works: `BOARD=rpi5-nvme ./bootstrap.sh`
- [ ] Verify BitBake picks up the correct machine via `machine-map.inc` (check `MACHINE` in `build/conf/local.conf` after bootstrap)
- [ ] Confirm CI build matrix jobs appear as `raspberry-pi-5 (sd)` etc.
- [ ] Confirm publisher `--device` flag still receives `raspberry-pi-5` / `jetson-orin-nano`

🤖 Generated with [Claude Code](https://claude.com/claude-code)