### PR TITLE
avahi: disable reflector to fix startup stall on avahi 0.8

### DIFF
--- a/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/recipes-connectivity/avahi/avahi_%.bbappend
@@ -54,8 +54,10 @@ do_install:append() {
         # Enable D-Bus support for proper service publishing
         sed -i 's/^#*enable-dbus=.*/enable-dbus=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
 
-        # Enable mDNS reflector for cross-interface discovery
-        sed -i 's/^#*enable-reflector=.*/enable-reflector=yes/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
+        # Reflector bridges mDNS across interfaces. In avahi 0.8 it prevents
+        # the daemon from completing startup regardless of interface count,
+        # so services never get published. Keep it disabled.
+        sed -i 's/^#*enable-reflector=.*/enable-reflector=no/' "${D}${sysconfdir}/avahi/avahi-daemon.conf"
 
         # Restrict Avahi to specific interfaces if configured
         # Empty WENDYOS_MDNS_INTERFACES means all interfaces (no restriction)


### PR DESCRIPTION
 ## Problem

  Avahi's WendyOS TXT records (`id`, `name`, `fqdn`, `displayname`) were not  visible via mDNS after a recent build. `avahi-browse -at` returned nothing 

  Root cause: `enable-reflector=yes` prevents avahi-daemon 0.8 from completing startup when the daemon has a single interface in scope. The daemon starts but  never reaches "Server startup complete", so no services are published.

  ## Fix

  Unconditionally set `enable-reflector=no`.

  Avahi is configured to listen on all interfaces following the latest main chanes.
 Each connected client discovers the device on its own link directly — no cross-interface bridging is needed. The reflector serves no  purpose for WendyOS targets, which are endpoints, not mDNS bridges.

  ## Testing

  Verified on Jetson Orin Nano (NVMe) — `avahi-browse -r _wendyos._udp` shows
  all four TXT records (`id`, `name`, `fqdn`, `displayname`) after fix is applied