### PR TITLE
Fix bogus $PATH literal string in `wendy-agent` environment

### DIFF
--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/files/generate-cuda-env.sh
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/files/generate-cuda-env.sh
@@ -60,7 +60,7 @@ main() {
 
 CUDA_VER=$cuda_ver
 CUDA_HOME=/usr/local/cuda-$cuda_ver
-PATH=/usr/local/cuda-$cuda_ver/bin:\$PATH
+PATH=/usr/local/cuda-$cuda_ver/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 LD_LIBRARY_PATH=/usr/local/cuda-$cuda_ver/lib:/usr/lib
 EOF
 


### PR DESCRIPTION
This PR resolves [WDY-976](https://linear.app/wendylabsinc/issue/WDY-976/wendy-agent-systemd-path-is-broken-dollarpath-set-as-literal-string) by applying a one line fix to the PATH variable assigned to the `wendy-agent`.

## Context
On running WendyOS devices, `wendy-agent` is launched by systemd with a malformed PATH whose value is `/usr/local/cuda-12.6/bin:$PATH` — where `$PATH` is the literal five-character string, not an expanded value. systemd EnvironmentFile= parsing does not perform shell-style variable expansion, so the agent ends up with PATH containing exactly two entries: a real CUDA dir, plus a bogus directory literally named $PATH.

Can be confirmed by checking the `environ` of the `wendy-agent` process on any current WendyOS version:
```
root@wendyos-fearless-stint:~# cat /proc/$(pidof wendy-agent)/environ | tr '\0' '\n' | grep PATH
PATH=/usr/local/cuda-12.6/bin:$PATH
LD_LIBRARY_PATH=/usr/local/cuda-12.6/lib:/usr/lib
```

## Effect
Go's `exec.LookPath` in the agent fails for every standard binary (nmcli, systemctl, gst-launch-1.0, generate-hostname.sh, etc.). Today this is masked by per-callsite fallbacks (`internal/agent/network/networkmanager.go`, `internal/agent/configpartition/apply.go`, `internal/agent/services/video_service.go`), but new agent code that simply trusts PATH breaks immediately, requiring another callsite fallback. Fixing this issue would allow these per-site fallbacks to be removed, and any future callsites can properly perform binary searches by respecting PATH.

## Cause
`generate-cuda-env.sh` runs at boot via `wendyos-cuda-detect.service` and writes `/etc/default/wendyos-cuda`. `wendy-agent.service` loads that file via `EnvironmentFile=-/etc/default/wendyos-cuda`. The heredoc at line 56 uses an unquoted EOF (so $cuda_ver correctly expands at script time) but line 63 escapes $PATH to defer expansion to the consumer:

`PATH=/usr/local/cuda-$cuda_ver/bin:\$PATH`

systemd does not expand $PATH when reading the env file (and there is no inherited PATH for system services anyway). The literal $PATH is written into the file and treated as a directory name.

## Fix
The fix is to simply provide the default system PATH alongside cuda:

`PATH=/usr/local/cuda-$cuda_ver/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`

`$cuda_ver` continues to expand at script time as the heredoc terminator stays unquoted.

## Verification
After building and flashing a WendyOS image:
       - SSH to the device.
       - `cat /etc/default/wendyos-cuda` - confirm `PATH=/usr/local/cuda-<ver>/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
       - `cat /proc/$(pidof wendy-agent)/environ | tr '\0' '\n' | grep PATH` - confirm same value, no literal $PATH.
       - Confirm prior agent-side callsites no longer require fallbacks and can properly utilize the PATH