### PR TITLE
Use ASCII-only AMI description in Packer template

### DIFF
--- a/ci/packer/wendyos-builder.pkr.hcl
+++ b/ci/packer/wendyos-builder.pkr.hcl
@@ -96,7 +96,8 @@ source "amazon-ebs" "wendyos_builder" {
   ssh_username = "ubuntu"
 
   ami_name        = local.ami_name
-  ami_description = "WendyOS Yocto build runner — Ubuntu 24.04 + Yocto deps (Scarthgap)"
+  # AWS rejects non-ASCII in this field; keep it plain ASCII.
+  ami_description = "WendyOS Yocto build runner - Ubuntu 24.04 + Yocto deps (Scarthgap)"
   ami_virtualization_type = "hvm"
 
   # Plenty of headroom for the bake-time repo prefetch and apt cache.


### PR DESCRIPTION
## Summary

The previous \`ami_description\` value contained an em-dash (U+2014). AWS \`ModifyImageAttribute\` rejects non-ASCII in the Description parameter, which made the Packer build fail at the very last step — *after* spending ~17 minutes on apt + repo prefetching, taking the snapshot, and registering the AMI. Packer then rolled the AMI/snapshot back, leaving us with no usable artifact.

Fix is to swap the em-dash for a plain ASCII hyphen.

## Test plan

- [ ] Re-run the \`Build CI Runner AMI\` workflow on \`main\` after merge — should now reach the \`Modifying: description\` step without errors and produce a usable \`wendyos-builder-*\` AMI.