### PR TITLE
Install wendy-agent binary to /usr/local/bin

### DIFF
--- a/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
+++ b/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
@@ -75,9 +75,10 @@ do_compile() {
 }
 
 do_install() {
-    # Install the pre-downloaded binary
-    install -d ${D}${bindir}
-    install -m 0755 ${B}/wendy-agent ${D}${bindir}/wendy-agent
+    # Install the pre-downloaded binary into /usr/local/bin so it lives
+    # alongside runtime updates written by wendyos-agent-updater.sh.
+    install -d ${D}/usr/local/bin
+    install -m 0755 ${B}/wendy-agent ${D}/usr/local/bin/wendy-agent
 
     # Install systemd services
     install -d ${D}${systemd_system_unitdir}
@@ -96,7 +97,7 @@ do_install() {
     install -d ${D}/opt/wendy
 }
 
-FILES:${PN} = "${bindir}/* \
+FILES:${PN} = "/usr/local/bin/wendy-agent \
                /opt/wendyos/bin/* \
                /opt/wendy \
                ${systemd_system_unitdir}/* \


### PR DESCRIPTION
## Summary
- Fixes wendyos-agent failing to start on boot with `status=203/EXEC` on freshly flashed 0.13.2 nightly images across all platforms (RPi, Jetson, qemu).
- Updates the Yocto recipe `wendyos-agent_1.0.bb` to install the pre-downloaded `wendy-agent` binary at `/usr/local/bin/wendy-agent` (matching prior WendyOS releases) instead of `${bindir}` (`/usr/bin`).

## Root cause
Commit 75273f5 ("Update agent install dir") moved the runtime install dir to `/usr/local/bin` in three places — `wendyos-agent.service` (`ExecStart`), `download-wendyos-agent.sh`, and `wendyos-agent-updater.sh` — but did not update the Yocto recipe. The recipe continued installing the binary to `${bindir}` (`/usr/bin`), so the base image shipped the binary at a path the unit no longer references. systemd raised `203/EXEC` because `/usr/local/bin/wendy-agent` did not exist on the rootfs. The agent only recovered later, after `wendyos-agent-updater.timer` fired and wrote the binary to the expected location — and only on devices with network connectivity at first boot.

## Test plan
- [ ] Build a 0.13.x image and confirm `/usr/local/bin/wendy-agent` is present in the rootfs (and `/usr/bin/wendy-agent` is not).
- [ ] Flash the image to a Raspberry Pi and verify `systemctl status wendyos-agent` is `active (running)` from first boot, with no `203/EXEC` in `journalctl -u wendyos-agent`.
- [ ] Repeat the flash + boot check on a Jetson target.
- [ ] Confirm `wendyos-agent-updater.timer` continues to update the binary in place at `/usr/local/bin/wendy-agent` without permission errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)