### PR TITLE
Fix host-build _check-setup and add awscli to AMI deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,23 +503,25 @@ _check-machine:
 		exit 1; \
 	fi
 
+# Each @-prefixed recipe line runs in its own shell, so a host-build "exit 0"
+# wouldn't skip subsequent Docker checks. Keep the whole branch in one block.
 _check-setup:
 	@if [ "$(WENDYOS_HOST_BUILD)" = "1" ]; then \
 		if [ ! -d "$(PROJECT_DIR)/repos/poky" ]; then \
 			printf "$(RED)Error: repos/poky not found. Run 'make setup' first.$(NC)\n"; \
 			exit 1; \
 		fi; \
-		exit 0; \
-	fi
-	@if [ ! -d "$(DOCKER_DIR)" ]; then \
-		printf "$(RED)Error: Build environment not set up.$(NC)\n"; \
-		printf "Run 'make setup' first.\n"; \
-		exit 1; \
-	fi
-	@if ! docker image inspect $(DOCKER_REPO):$(DOCKER_TAG) >/dev/null 2>&1; then \
-		printf "$(RED)Error: Docker image not found.$(NC)\n"; \
-		printf "Run 'make setup' or 'make docker-create' first.\n"; \
-		exit 1; \
+	else \
+		if [ ! -d "$(DOCKER_DIR)" ]; then \
+			printf "$(RED)Error: Build environment not set up.$(NC)\n"; \
+			printf "Run 'make setup' first.\n"; \
+			exit 1; \
+		fi; \
+		if ! docker image inspect $(DOCKER_REPO):$(DOCKER_TAG) >/dev/null 2>&1; then \
+			printf "$(RED)Error: Docker image not found.$(NC)\n"; \
+			printf "Run 'make setup' or 'make docker-create' first.\n"; \
+			exit 1; \
+		fi; \
 	fi
 
 _ensure-volumes:

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -33,7 +33,8 @@ apt-get -qy install \
     python3-gi python3-gi-cairo gir1.2-gtk-3.0 x11-apps \
     libncurses5-dev libncursesw5-dev bison flex patchutils \
     libssl-dev ca-certificates locales sudo mc quilt vim pkg-config \
-    gdisk dosfstools bmap-tools device-tree-compiler
+    gdisk dosfstools bmap-tools device-tree-compiler \
+    awscli
 
 # gcc-multilib (32-bit x86 multilib headers) is only available on amd64.
 # Skip on arm64 (e.g. Apple Silicon Docker Desktop, Graviton runners).

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -33,8 +33,7 @@ apt-get -qy install \
     python3-gi python3-gi-cairo gir1.2-gtk-3.0 x11-apps \
     libncurses5-dev libncursesw5-dev bison flex patchutils \
     libssl-dev ca-certificates locales sudo mc quilt vim pkg-config \
-    gdisk dosfstools bmap-tools device-tree-compiler \
-    awscli
+    gdisk dosfstools bmap-tools device-tree-compiler
 
 # gcc-multilib (32-bit x86 multilib headers) is only available on amd64.
 # Skip on arm64 (e.g. Apple Silicon Docker Desktop, Graviton runners).
@@ -44,6 +43,23 @@ fi
 
 apt-get -qy clean
 rm -rf /var/lib/apt/lists/*
+
+# AWS CLI v2. Ubuntu 24.04 (Noble) dropped the legacy 'awscli' apt package
+# (it was AWS CLI v1, which AWS itself deprecated). Install the official
+# bundle from awscli.amazonaws.com; idempotent thanks to '--update'.
+arch="$(dpkg --print-architecture)"
+case "${arch}" in
+    amd64) aws_arch="x86_64" ;;
+    arm64) aws_arch="aarch64" ;;
+    *)     echo "Unsupported arch for aws-cli: ${arch}" >&2; exit 1 ;;
+esac
+tmp_aws=$(mktemp -d)
+wget -qO "${tmp_aws}/awscliv2.zip" \
+    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}.zip"
+unzip -q "${tmp_aws}/awscliv2.zip" -d "${tmp_aws}"
+"${tmp_aws}/aws/install" --update -i /usr/local/aws-cli -b /usr/local/bin
+rm -rf "${tmp_aws}"
+/usr/local/bin/aws --version
 
 # Yocto requires a fully-formed UTF-8 locale. Without LANG / LC_ALL set, the
 # do_compile tasks fail on locale-sensitive scripts (e.g. perl).


### PR DESCRIPTION
## Summary

Two bugs surfaced by the first `Build WendyOS Images` run on the new AMI ([run #25133748978](https://github.com/wendylabsinc/WendyOS/actions/runs/25133748978)):

1. **`_check-setup` always ran the Docker check.** The host-build branch and Docker branch lived in two separate `@`-prefixed Make recipe lines, each its own shell. The host-build branch's `exit 0` only ended that shell; Make then proceeded to the Docker check, which failed because no `docker/` dir exists on the AMI (intentionally — host-build skips Docker). Fix is to merge the two into a single `if/else` block in one shell invocation.
2. **`awscli` was missing from the AMI.** `install-build-deps.sh` didn't install it, so the S3 sstate / downloads cache restore + save steps printed `aws: command not found`. The errors are silenced by `|| true`, so the build didn't fail on this — but caching is dead, which means full cold sstate on every run. Adding `awscli` to the apt list fixes it.

The rest of the new pipeline worked as designed: RunsOn picked up our custom AMI (`ami-03768a8d65608ef8f` / `wendyos-builder-2026-04-29-204603`), the bake-time repo prefetch produced `[ok]` for all 8 upstream layers, and bootstrap finished in 24 s.

## Test plan

- [ ] After merge + AMI rebuild, re-run `Build WendyOS Images` workflow on `main`.
- [ ] `Build image` step gets past `_check-setup` and runs `bitbake`.
- [ ] `Restore sstate-cache and downloads from S3 (L2)` and `Save sstate-cache and downloads to S3 (L2)` no longer print `aws: command not found`.

Note: needs the AMI workflow to rebuild after this merges, since `awscli` only lands in the AMI on next bake. The path filter on `scripts/install-build-deps.sh` triggers that automatically.