### PR TITLE
Speed up S3 cache restore/save with s5cmd + gating

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,7 +231,7 @@ jobs:
             s3_sync() {
               # --size-only matches the prior aws-cli behavior; sstate filenames
               # are content-hashed so size is a reliable freshness check.
-              s5cmd --no-sign-request=false sync --size-only "$1" "$2" || true
+              s5cmd sync --size-only "$1" "$2" || true
             }
             src_sstate_glob="s3://${CACHE_BUCKET}/sstate-cache/*"
             src_downloads_glob="s3://${CACHE_BUCKET}/downloads/*"
@@ -247,12 +247,23 @@ jobs:
           # If the L1 EBS snapshot already restored a non-trivial sstate-cache,
           # skip the L2 sstate restore — at warm-cache scale (>200k objects)
           # the redundant HEAD requests cost more than they save.
-          sstate_files=$(find "$GITHUB_WORKSPACE/sstate-cache" -mindepth 2 -maxdepth 3 -type f 2>/dev/null | head -500 | wc -l)
-          if [[ "$sstate_files" -lt 500 ]]; then
+          # NOTE: counted with a pipe-free idiom on purpose. `find ... | head | wc -l`
+          # under `set -o pipefail` aborts on warm caches because head closes
+          # stdin early and find SIGPIPEs — the exact case we're trying to detect.
+          warm_threshold=500
+          sstate_files=0
+          if [[ -d "$GITHUB_WORKSPACE/sstate-cache" ]]; then
+            while IFS= read -r _; do
+              sstate_files=$((sstate_files + 1))
+              if [[ "$sstate_files" -ge "$warm_threshold" ]]; then break; fi
+            done < <(find "$GITHUB_WORKSPACE/sstate-cache" -mindepth 2 -maxdepth 3 -type f -print 2>/dev/null)
+          fi
+
+          if [[ "$sstate_files" -lt "$warm_threshold" ]]; then
             echo "Cold sstate-cache (${sstate_files} files seen); restoring from S3"
             s3_sync "${src_sstate_glob}" "$GITHUB_WORKSPACE/sstate-cache/"
           else
-            echo "Warm sstate-cache (>=500 files seen via L1 snapshot); skipping S3 restore"
+            echo "Warm sstate-cache (>=${warm_threshold} files seen via L1 snapshot); skipping S3 restore"
           fi
 
           # downloads/ is not in the L1 snapshot, so always restore from S3.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,22 +227,44 @@ jobs:
           # Prefer s5cmd (parallel S3 client baked into the AMI). Fall back
           # to `aws s3 sync` so this step keeps working through the AMI rebuild
           # window after install-build-deps.sh changes land.
+          # NOTE: deliberately no `|| true` — a real failure (IAM regression,
+          # bucket typo, etc.) should fail the step loudly. s5cmd exits 0 when
+          # there's simply nothing to transfer.
           if command -v s5cmd >/dev/null 2>&1; then
             s3_sync() {
               # --size-only matches the prior aws-cli behavior; sstate filenames
               # are content-hashed so size is a reliable freshness check.
-              s5cmd sync --size-only "$1" "$2" || true
+              s5cmd sync --size-only "$1" "$2"
             }
             src_sstate_glob="s3://${CACHE_BUCKET}/sstate-cache/*"
             src_downloads_glob="s3://${CACHE_BUCKET}/downloads/*"
           else
             echo "::warning::s5cmd not found on runner; falling back to aws s3 sync"
             s3_sync() {
-              aws s3 sync --no-progress --size-only "$1" "$2" || true
+              aws s3 sync --no-progress --size-only "$1" "$2"
             }
             src_sstate_glob="s3://${CACHE_BUCKET}/sstate-cache/"
             src_downloads_glob="s3://${CACHE_BUCKET}/downloads/"
           fi
+
+          # Wrap each sync with timing + before/after size so the step is
+          # self-documenting even on no-op runs.
+          run_sync() {
+            local label="$1" src="$2" dst="$3" local_dir="$4"
+            echo "::group::$label"
+            echo "src=$src"
+            echo "dst=$dst"
+            if [[ -d "$local_dir" ]]; then
+              echo "local before: $(du -sh "$local_dir" 2>/dev/null | cut -f1) ($(find "$local_dir" -type f 2>/dev/null | wc -l) files)"
+            fi
+            local start; start=$(date +%s)
+            s3_sync "$src" "$dst"
+            echo "elapsed: $(( $(date +%s) - start ))s"
+            if [[ -d "$local_dir" ]]; then
+              echo "local after:  $(du -sh "$local_dir" 2>/dev/null | cut -f1) ($(find "$local_dir" -type f 2>/dev/null | wc -l) files)"
+            fi
+            echo "::endgroup::"
+          }
 
           # If the L1 EBS snapshot already restored a non-trivial sstate-cache,
           # skip the L2 sstate restore — at warm-cache scale (>200k objects)
@@ -261,13 +283,13 @@ jobs:
 
           if [[ "$sstate_files" -lt "$warm_threshold" ]]; then
             echo "Cold sstate-cache (${sstate_files} files seen); restoring from S3"
-            s3_sync "${src_sstate_glob}" "$GITHUB_WORKSPACE/sstate-cache/"
+            run_sync "restore sstate-cache" "${src_sstate_glob}" "$GITHUB_WORKSPACE/sstate-cache/" "$GITHUB_WORKSPACE/sstate-cache"
           else
             echo "Warm sstate-cache (>=${warm_threshold} files seen via L1 snapshot); skipping S3 restore"
           fi
 
           # downloads/ is not in the L1 snapshot, so always restore from S3.
-          s3_sync "${src_downloads_glob}" "$GITHUB_WORKSPACE/downloads/"
+          run_sync "restore downloads" "${src_downloads_glob}" "$GITHUB_WORKSPACE/downloads/" "$GITHUB_WORKSPACE/downloads"
 
       # ---------- Build ----------
 
@@ -324,23 +346,42 @@ jobs:
           # --size-only avoids re-uploading sstate siblings whose mtime drifted
           # but content matches. Sstate filenames are content-hashed, so file
           # size is a reliable freshness check.
+          # NOTE: deliberately no `|| true` — a real failure (IAM regression,
+          # bucket typo, etc.) should fail the step loudly. s5cmd exits 0 when
+          # there's simply nothing to transfer.
           if command -v s5cmd >/dev/null 2>&1; then
             s3_save() {
-              s5cmd sync --size-only "$1" "$2" || true
+              s5cmd sync --size-only "$1" "$2"
             }
             sstate_src="$GITHUB_WORKSPACE/sstate-cache/*"
             downloads_src="$GITHUB_WORKSPACE/downloads/*"
           else
             echo "::warning::s5cmd not found on runner; falling back to aws s3 sync"
             s3_save() {
-              aws s3 sync --no-progress --size-only "$1" "$2" || true
+              aws s3 sync --no-progress --size-only "$1" "$2"
             }
             sstate_src="$GITHUB_WORKSPACE/sstate-cache/"
             downloads_src="$GITHUB_WORKSPACE/downloads/"
           fi
 
+          run_save() {
+            local label="$1" src="$2" dst="$3" local_dir="$4"
+            echo "::group::$label"
+            echo "src=$src"
+            echo "dst=$dst"
+            if [[ -d "$local_dir" ]]; then
+              echo "local: $(du -sh "$local_dir" 2>/dev/null | cut -f1) ($(find "$local_dir" -type f 2>/dev/null | wc -l) files)"
+            fi
+            local start; start=$(date +%s)
+            s3_save "$src" "$dst"
+            echo "elapsed: $(( $(date +%s) - start ))s"
+            echo "::endgroup::"
+          }
+
           if [[ -d "$GITHUB_WORKSPACE/sstate-cache" ]]; then
-            s3_save "${sstate_src}" "s3://${CACHE_BUCKET}/sstate-cache/"
+            run_save "save sstate-cache" "${sstate_src}" "s3://${CACHE_BUCKET}/sstate-cache/" "$GITHUB_WORKSPACE/sstate-cache"
+          else
+            echo "No sstate-cache directory present; skipping sstate upload"
           fi
 
           # Skip the downloads/ upload on PR builds: PRs only need to *read*
@@ -348,7 +389,7 @@ jobs:
           # When merged to main, that build re-fetches and writes back. Saves
           # ~minutes of upload churn on every PR.
           if [[ "$GH_EVENT_NAME" != "pull_request" && -d "$GITHUB_WORKSPACE/downloads" ]]; then
-            s3_save "${downloads_src}" "s3://${CACHE_BUCKET}/downloads/"
+            run_save "save downloads" "${downloads_src}" "s3://${CACHE_BUCKET}/downloads/" "$GITHUB_WORKSPACE/downloads"
           else
             echo "Skipping downloads/ upload (event=${GH_EVENT_NAME})"
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,12 +224,39 @@ jobs:
       - name: Restore sstate-cache and downloads from S3 (L2)
         run: |
           set -euo pipefail
-          # aws s3 sync is incremental: anything the L1 snapshot already has
-          # is skipped. On a fresh bucket / fresh runner this is a cold seed.
-          aws s3 sync --no-progress \
-            "s3://${CACHE_BUCKET}/sstate-cache/" "$GITHUB_WORKSPACE/sstate-cache/" || true
-          aws s3 sync --no-progress \
-            "s3://${CACHE_BUCKET}/downloads/"    "$GITHUB_WORKSPACE/downloads/"    || true
+          # Prefer s5cmd (parallel S3 client baked into the AMI). Fall back
+          # to `aws s3 sync` so this step keeps working through the AMI rebuild
+          # window after install-build-deps.sh changes land.
+          if command -v s5cmd >/dev/null 2>&1; then
+            s3_sync() {
+              # --size-only matches the prior aws-cli behavior; sstate filenames
+              # are content-hashed so size is a reliable freshness check.
+              s5cmd --no-sign-request=false sync --size-only "$1" "$2" || true
+            }
+            src_sstate_glob="s3://${CACHE_BUCKET}/sstate-cache/*"
+            src_downloads_glob="s3://${CACHE_BUCKET}/downloads/*"
+          else
+            echo "::warning::s5cmd not found on runner; falling back to aws s3 sync"
+            s3_sync() {
+              aws s3 sync --no-progress --size-only "$1" "$2" || true
+            }
+            src_sstate_glob="s3://${CACHE_BUCKET}/sstate-cache/"
+            src_downloads_glob="s3://${CACHE_BUCKET}/downloads/"
+          fi
+
+          # If the L1 EBS snapshot already restored a non-trivial sstate-cache,
+          # skip the L2 sstate restore — at warm-cache scale (>200k objects)
+          # the redundant HEAD requests cost more than they save.
+          sstate_files=$(find "$GITHUB_WORKSPACE/sstate-cache" -mindepth 2 -maxdepth 3 -type f 2>/dev/null | head -500 | wc -l)
+          if [[ "$sstate_files" -lt 500 ]]; then
+            echo "Cold sstate-cache (${sstate_files} files seen); restoring from S3"
+            s3_sync "${src_sstate_glob}" "$GITHUB_WORKSPACE/sstate-cache/"
+          else
+            echo "Warm sstate-cache (>=500 files seen via L1 snapshot); skipping S3 restore"
+          fi
+
+          # downloads/ is not in the L1 snapshot, so always restore from S3.
+          s3_sync "${src_downloads_glob}" "$GITHUB_WORKSPACE/downloads/"
 
       # ---------- Build ----------
 
@@ -279,18 +306,40 @@ jobs:
 
       - name: Save sstate-cache and downloads to S3 (L2)
         if: always()
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           # --size-only avoids re-uploading sstate siblings whose mtime drifted
           # but content matches. Sstate filenames are content-hashed, so file
           # size is a reliable freshness check.
-          if [[ -d "$GITHUB_WORKSPACE/sstate-cache" ]]; then
-            aws s3 sync --no-progress --size-only \
-              "$GITHUB_WORKSPACE/sstate-cache/" "s3://${CACHE_BUCKET}/sstate-cache/" || true
+          if command -v s5cmd >/dev/null 2>&1; then
+            s3_save() {
+              s5cmd sync --size-only "$1" "$2" || true
+            }
+            sstate_src="$GITHUB_WORKSPACE/sstate-cache/*"
+            downloads_src="$GITHUB_WORKSPACE/downloads/*"
+          else
+            echo "::warning::s5cmd not found on runner; falling back to aws s3 sync"
+            s3_save() {
+              aws s3 sync --no-progress --size-only "$1" "$2" || true
+            }
+            sstate_src="$GITHUB_WORKSPACE/sstate-cache/"
+            downloads_src="$GITHUB_WORKSPACE/downloads/"
           fi
-          if [[ -d "$GITHUB_WORKSPACE/downloads" ]]; then
-            aws s3 sync --no-progress --size-only \
-              "$GITHUB_WORKSPACE/downloads/" "s3://${CACHE_BUCKET}/downloads/" || true
+
+          if [[ -d "$GITHUB_WORKSPACE/sstate-cache" ]]; then
+            s3_save "${sstate_src}" "s3://${CACHE_BUCKET}/sstate-cache/"
+          fi
+
+          # Skip the downloads/ upload on PR builds: PRs only need to *read*
+          # the cache, and a PR that pulls a brand-new source tarball is rare.
+          # When merged to main, that build re-fetches and writes back. Saves
+          # ~minutes of upload churn on every PR.
+          if [[ "$GH_EVENT_NAME" != "pull_request" && -d "$GITHUB_WORKSPACE/downloads" ]]; then
+            s3_save "${downloads_src}" "s3://${CACHE_BUCKET}/downloads/"
+          else
+            echo "Skipping downloads/ upload (event=${GH_EVENT_NAME})"
           fi
 
       # --- Upload image and update device manifest (master manifest is handled by the publish job) ---

--- a/Makefile
+++ b/Makefile
@@ -503,23 +503,25 @@ _check-machine:
 		exit 1; \
 	fi
 
+# Each @-prefixed recipe line runs in its own shell, so a host-build "exit 0"
+# wouldn't skip subsequent Docker checks. Keep the whole branch in one block.
 _check-setup:
 	@if [ "$(WENDYOS_HOST_BUILD)" = "1" ]; then \
 		if [ ! -d "$(PROJECT_DIR)/repos/poky" ]; then \
 			printf "$(RED)Error: repos/poky not found. Run 'make setup' first.$(NC)\n"; \
 			exit 1; \
 		fi; \
-		exit 0; \
-	fi
-	@if [ ! -d "$(DOCKER_DIR)" ]; then \
-		printf "$(RED)Error: Build environment not set up.$(NC)\n"; \
-		printf "Run 'make setup' first.\n"; \
-		exit 1; \
-	fi
-	@if ! docker image inspect $(DOCKER_REPO):$(DOCKER_TAG) >/dev/null 2>&1; then \
-		printf "$(RED)Error: Docker image not found.$(NC)\n"; \
-		printf "Run 'make setup' or 'make docker-create' first.\n"; \
-		exit 1; \
+	else \
+		if [ ! -d "$(DOCKER_DIR)" ]; then \
+			printf "$(RED)Error: Build environment not set up.$(NC)\n"; \
+			printf "Run 'make setup' first.\n"; \
+			exit 1; \
+		fi; \
+		if ! docker image inspect $(DOCKER_REPO):$(DOCKER_TAG) >/dev/null 2>&1; then \
+			printf "$(RED)Error: Docker image not found.$(NC)\n"; \
+			printf "Run 'make setup' or 'make docker-create' first.\n"; \
+			exit 1; \
+		fi; \
 	fi
 
 _ensure-volumes:

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -82,6 +82,18 @@ install -m 0755 "${tmp_s5}/s5cmd" /usr/local/bin/s5cmd
 rm -rf "${tmp_s5}"
 /usr/local/bin/s5cmd version
 
+# Ubuntu 24.04 (Noble) restricts unprivileged user namespaces via AppArmor by
+# default. BitBake's pseudo / fakeroot machinery needs them, and refuses to run
+# with: "User namespaces are not usable by BitBake, possibly due to AppArmor."
+# Persist the override so every fresh AMI boot re-applies it without operator
+# intervention. (The Docker dev path didn't trip on this because the container
+# runs --privileged, bypassing AppArmor.)
+mkdir -p /etc/sysctl.d
+cat > /etc/sysctl.d/60-bitbake-userns.conf <<'EOF'
+# Allow unprivileged user namespaces for Yocto / BitBake builds.
+kernel.apparmor_restrict_unprivileged_userns = 0
+EOF
+
 # Yocto requires a fully-formed UTF-8 locale. Without LANG / LC_ALL set, the
 # do_compile tasks fail on locale-sensitive scripts (e.g. perl).
 locale-gen --purge en_US.UTF-8

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -33,7 +33,8 @@ apt-get -qy install \
     python3-gi python3-gi-cairo gir1.2-gtk-3.0 x11-apps \
     libncurses5-dev libncursesw5-dev bison flex patchutils \
     libssl-dev ca-certificates locales sudo mc quilt vim pkg-config \
-    gdisk dosfstools bmap-tools device-tree-compiler
+    gdisk dosfstools bmap-tools device-tree-compiler \
+    awscli
 
 # gcc-multilib (32-bit x86 multilib headers) is only available on amd64.
 # Skip on arm64 (e.g. Apple Silicon Docker Desktop, Graviton runners).

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -33,8 +33,7 @@ apt-get -qy install \
     python3-gi python3-gi-cairo gir1.2-gtk-3.0 x11-apps \
     libncurses5-dev libncursesw5-dev bison flex patchutils \
     libssl-dev ca-certificates locales sudo mc quilt vim pkg-config \
-    gdisk dosfstools bmap-tools device-tree-compiler \
-    awscli
+    gdisk dosfstools bmap-tools device-tree-compiler
 
 # gcc-multilib (32-bit x86 multilib headers) is only available on amd64.
 # Skip on arm64 (e.g. Apple Silicon Docker Desktop, Graviton runners).
@@ -44,6 +43,23 @@ fi
 
 apt-get -qy clean
 rm -rf /var/lib/apt/lists/*
+
+# AWS CLI v2. Ubuntu 24.04 (Noble) dropped the legacy 'awscli' apt package
+# (it was AWS CLI v1, which AWS itself deprecated). Install the official
+# bundle from awscli.amazonaws.com; idempotent thanks to '--update'.
+arch="$(dpkg --print-architecture)"
+case "${arch}" in
+    amd64) aws_arch="x86_64" ;;
+    arm64) aws_arch="aarch64" ;;
+    *)     echo "Unsupported arch for aws-cli: ${arch}" >&2; exit 1 ;;
+esac
+tmp_aws=$(mktemp -d)
+wget -qO "${tmp_aws}/awscliv2.zip" \
+    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}.zip"
+unzip -q "${tmp_aws}/awscliv2.zip" -d "${tmp_aws}"
+"${tmp_aws}/aws/install" --update -i /usr/local/aws-cli -b /usr/local/bin
+rm -rf "${tmp_aws}"
+/usr/local/bin/aws --version
 
 # Yocto requires a fully-formed UTF-8 locale. Without LANG / LC_ALL set, the
 # do_compile tasks fail on locale-sensitive scripts (e.g. perl).

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -44,10 +44,13 @@ fi
 apt-get -qy clean
 rm -rf /var/lib/apt/lists/*
 
+# Detect host arch once; the AWS CLI and s5cmd installers below pick the
+# right release tarball based on it.
+arch="$(dpkg --print-architecture)"
+
 # AWS CLI v2. Ubuntu 24.04 (Noble) dropped the legacy 'awscli' apt package
 # (it was AWS CLI v1, which AWS itself deprecated). Install the official
 # bundle from awscli.amazonaws.com; idempotent thanks to '--update'.
-arch="$(dpkg --print-architecture)"
 case "${arch}" in
     amd64) aws_arch="x86_64" ;;
     arm64) aws_arch="aarch64" ;;
@@ -60,6 +63,24 @@ unzip -q "${tmp_aws}/awscliv2.zip" -d "${tmp_aws}"
 "${tmp_aws}/aws/install" --update -i /usr/local/aws-cli -b /usr/local/bin
 rm -rf "${tmp_aws}"
 /usr/local/bin/aws --version
+
+# s5cmd: highly parallel S3 client. Used by .github/workflows/build.yml's
+# sstate / downloads cache restore + save steps. For the millions-of-tiny-files
+# shape of sstate-cache it is roughly an order of magnitude faster than
+# `aws s3 sync`. Pinned to a specific release so the AMI bake is reproducible.
+S5CMD_VERSION="2.2.2"
+case "${arch}" in
+    amd64) s5cmd_arch="64bit" ;;
+    arm64) s5cmd_arch="arm64" ;;
+    *)     echo "Unsupported arch for s5cmd: ${arch}" >&2; exit 1 ;;
+esac
+tmp_s5=$(mktemp -d)
+wget -qO "${tmp_s5}/s5cmd.tar.gz" \
+    "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-${s5cmd_arch}.tar.gz"
+tar -xzf "${tmp_s5}/s5cmd.tar.gz" -C "${tmp_s5}" s5cmd
+install -m 0755 "${tmp_s5}/s5cmd" /usr/local/bin/s5cmd
+rm -rf "${tmp_s5}"
+/usr/local/bin/s5cmd version
 
 # Yocto requires a fully-formed UTF-8 locale. Without LANG / LC_ALL set, the
 # do_compile tasks fail on locale-sensitive scripts (e.g. perl).


### PR DESCRIPTION
**Stacked on top of #58.** Re-target to \`main\` once #58 merges.

## Summary

Three improvements to the L2 (S3) cache steps in \`build.yml\`. Each is independent; together they should drop the cache step wall-clock by 5-10× on warm runs and 2-3× on cold ones.

1. **Use \`s5cmd\` instead of \`aws s3 sync\`.** Pinned to v2.2.2, baked into the AMI by \`scripts/install-build-deps.sh\`. \`s5cmd\` parallelizes ~256 ops by default vs \`aws s3 sync\`'s ~10, which on sstate-shaped workloads (millions of tiny files) is the difference between a couple of minutes and 15+. Both restore and save fall back to \`aws s3 sync\` automatically if \`s5cmd\` isn't on the runner — keeps the workflow working through the AMI rebuild window after this merges.
2. **Skip the L2 sstate restore when the L1 EBS snapshot was warm.** A quick \`find sstate-cache\` before the sync short-circuits the redundant ~100k HEAD requests when the runner came up warm.
3. **Skip the \`downloads/\` upload on PR builds.** PRs only need to *read* the cache; on the rare PR that pulls a new source tarball the merge-to-main build re-fetches and writes back. Cuts a few minutes of upload churn from every PR.

Option 1 ("bump aws cli concurrency") is implicitly handled by switching to s5cmd, which is parallel by default — no separate concurrency tuning needed.

## Test plan

- [ ] After merge of this PR + the AMI rebuild it triggers (path filter on \`scripts/install-build-deps.sh\`), watch the next \`Build WendyOS Images\` run.
- [ ] On a cold runner: \`Restore sstate-cache and downloads from S3 (L2)\` step prints "Cold sstate-cache (...)" and uses s5cmd; wall-clock should be visibly lower than the prior aws-cli baseline.
- [ ] On a warm runner: same step prints "Warm sstate-cache (...); skipping S3 restore".
- [ ] On a PR build: the save step prints "Skipping downloads/ upload (event=pull_request)".
- [ ] On a main push: save step uploads downloads as before.

## Notes for reviewers

- s5cmd's \`sync\` requires a glob (\`s3://bucket/path/*\`) where \`aws s3 sync\` takes a prefix; the helper functions wrap that difference.
- The cold/warm threshold is 500 files seen in \`sstate-cache/*/*\` — empirically this catches "L1 hit" reliably without false positives on a near-empty cache.