### PR TITLE
Remove systemd networkd/resolved

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -23,8 +23,8 @@ require ${@'conf/distro/include/l4t-r36-4-4.conf' if 'tegra' in d.getVar('MACHIN
 DISTRO_FEATURES:append = " networkmanager"
 VIRTUAL-RUNTIME_net_manager = "networkmanager"
 
-# Optional: Use systemd-resolved for DNS (alternative to dnsmasq)
-# DISTRO_FEATURES:append = " resolved"
+# DNS is managed by NetworkManager (rc-manager=file in NetworkManager.conf);
+# systemd-resolved is disabled in recipes-core/systemd/systemd_%.bbappend.
 
 # Note: MENDER_FEATURES_ENABLE is set in mender.inc (only included for Tegra/real hardware)
 # QEMU doesn't use Mender, so this variable remains unset for QEMU builds

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -6,7 +6,8 @@
 # Note: This only disables PolicyKit integration in systemd itself. The polkit
 # daemon will still run on the target system for rtkit and other services.
 
-PACKAGECONFIG:remove = "polkit"
+# networkd: NetworkManager is the sole net manager on this distro.
+PACKAGECONFIG:remove = "polkit networkd"
 
 # Disable debug source package splitting to avoid pseudo uid lookup failures.
 # do_package hardlinks source files (owned by uid 1000 / build user) into PKGD.

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -6,8 +6,21 @@
 # Note: This only disables PolicyKit integration in systemd itself. The polkit
 # daemon will still run on the target system for rtkit and other services.
 
-# networkd: NetworkManager is the sole net manager on this distro.
-PACKAGECONFIG:remove = "polkit networkd"
+# NetworkManager is the sole net/DNS manager on this distro:
+#   - networkd: not used (no .network files, NM manages all interfaces)
+#   - resolved + nss-resolve: not used (NM owns /etc/resolv.conf via rc-manager=file)
+PACKAGECONFIG:remove = "polkit networkd resolved nss-resolve"
+
+# Strip the dangling /etc/resolv.conf symlink artefacts the upstream systemd
+# recipe injects when 'resolved' PACKAGECONFIG is disabled. The recipe assumes
+# you'll re-enable resolved later via tmpfiles; this distro doesn't — NM
+# (rc-manager=file) writes /etc/resolv.conf directly.
+do_install:append() {
+    if [ -f ${D}${exec_prefix}/lib/tmpfiles.d/etc.conf ]; then
+        sed -i '\|^L! /etc/resolv\.conf|d' ${D}${exec_prefix}/lib/tmpfiles.d/etc.conf
+    fi
+    rm -f ${D}${sysconfdir}/resolv-conf.systemd
+}
 
 # Disable debug source package splitting to avoid pseudo uid lookup failures.
 # do_package hardlinks source files (owned by uid 1000 / build user) into PKGD.

--- a/recipes-core/wendyos-motd/files/30-services
+++ b/recipes-core/wendyos-motd/files/30-services
@@ -44,7 +44,7 @@ check_dev_registry() {
 # Check critical services
 check_service "sshd" "SSH"
 check_service "ssh" "SSH"  # Some systems use 'ssh' instead of 'sshd'
-check_service "systemd-networkd" "Network"
+check_service "NetworkManager" "Network"
 check_service "systemd-resolved" "DNS"
 check_service "usb-gadget" "USB Gadget"
 check_service "avahi-daemon" "mDNS"

--- a/recipes-core/wendyos-motd/files/30-services
+++ b/recipes-core/wendyos-motd/files/30-services
@@ -45,7 +45,6 @@ check_dev_registry() {
 check_service "sshd" "SSH"
 check_service "ssh" "SSH"  # Some systems use 'ssh' instead of 'sshd'
 check_service "NetworkManager" "Network"
-check_service "systemd-resolved" "DNS"
 check_service "usb-gadget" "USB Gadget"
 check_service "avahi-daemon" "mDNS"
 check_service "systemd-timesyncd" "Time Sync"


### PR DESCRIPTION
## Description

The image previously shipped `NetworkManager` alongside `systemd-networkd` and `systemd-resolved`, even though NM was
already managing all interfaces and DNS. This PR removes the unused systemd network/DNS daemons so NetworkManager is the sole net/DNS manager.

1. **Remove `systemd-networkd`**
     - Disable the `networkd` PACKAGECONFIG in `systemd_%.bbappend`.
     - Update the MOTD service panel (`30-services`) to check `NetworkManager` instead of `systemd-networkd`.

2. **Remove `systemd-resolved`**
   - Disable the `resolved` and `nss-resolve` PACKAGECONFIG entries.
   - In `do_install:append`, strip the `L! /etc/resolv.conf …` line that upstream systemd ships in `tmpfiles.d/etc.conf` and remove the unused `resolv-conf.systemd` template. NM writes `/etc/resolv.conf` directly via `rc-manager=file`, so these would otherwise leave a dangling symlink on the target.
   - `conf/distro/wendyos.conf`: document the new DNS model.
   - Drop the `systemd-resolved` entry from `30-services`.

## Motivation

- Eliminate the conflict potential between two parallel network managers and two DNS resolvers.
- Make the DNS path explicit (NM -> `/etc/resolv.conf`).
- Reduce systemd build/install footprint.

## Testing

- [ ] DHCP / static address assignment via NM.
- [ ] DNS resolution on the target.
- [ ] SSH over the USB gadget interface still works.
- [ ] `/etc/resolv.conf` is a real file written by NM (not a broken symlink).
- [ ] MOTD service panel shows the correct entries on login.

DNS architecture decision: NM with `rc-manager=file` writes `/etc/resolv.conf` directly.
