### PR TITLE
Fix duplicate MOTD on login

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -24,6 +24,11 @@ do_install:append() {
     # Install sysctl config to quiet console (reduce kernel/audit messages)
     install -d ${D}${sysconfdir}/sysctl.d
     install -m 0644 ${WORKDIR}/sysctl.d/99-quiet-console.conf ${D}${sysconfdir}/sysctl.d/
+
+    # Suppress the upstream Poky /etc/motd disclaimer.
+    # Dynamic MOTD comes from update-motd via /etc/profile.d/motd.sh
+    # (see recipes-core/wendyos-motd).
+    : > ${D}${sysconfdir}/motd
 }
 
 # Make it a config file so local edits survive upgrades

--- a/recipes-core/wendyos-motd/files/20-system-info
+++ b/recipes-core/wendyos-motd/files/20-system-info
@@ -53,9 +53,12 @@ fi
 echo -e "  Disk: ${DISK_COLOR}${DISK_USAGE}${NC}"
 
 # Network information
-PRIMARY_IP=$(ip -4 addr show scope global | grep inet | head -1 | awk '{print $2}' | cut -d/ -f1)
+IP_BIN="$(command -v ip || echo /usr/sbin/ip)"
+PRIMARY_IP="$("$IP_BIN" -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n1)"
 if [ -n "$PRIMARY_IP" ]; then
     echo "  IP Address: ${PRIMARY_IP}"
+else
+    echo "  IP Address: pending"
 fi
 
 # Uptime

--- a/recipes-extended/wendyos-user/files/wendyos-user-setup.service
+++ b/recipes-extended/wendyos-user/files/wendyos-user-setup.service
@@ -6,8 +6,6 @@ RequiresMountsFor=/data /home
 After=data.mount home.mount
 # Run before user sessions start
 Before=systemd-user-sessions.service
-# Only run once (script checks for flag file)
-ConditionPathExists=!/data/.wendyos-user-setup-done
 
 [Service]
 Type=oneshot

--- a/recipes-extended/wendyos-user/files/wendyos-user-setup.sh
+++ b/recipes-extended/wendyos-user/files/wendyos-user-setup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# WendyOS User Setup - First Boot Service
-# This script runs once on first boot to initialize user home directories
-# on the persistent data partition.
+# WendyOS User Setup
+# - On every boot: applies idempotent dotfile migrations.
+# - On first boot only: initializes user home directories on /data
+#   (gated by /data/.wendyos-user-setup-done).
 
 set -e
 
@@ -11,19 +12,31 @@ WENDY_HOME="/data/home/wendy"
 WENDY_UID=1000
 WENDY_GID=1000
 
-# Check if already run
-if [ -f "$SETUP_FLAG" ]; then
-    echo "WendyOS user setup already completed. Skipping."
-    exit 0
-fi
-
-echo "Running WendyOS user setup (first boot)..."
-
 # Ensure /data is mounted
 if ! mountpoint -q /data; then
     echo "ERROR: /data is not mounted. Cannot proceed."
     exit 1
 fi
+
+# Dotfile migration (run on every boot, idempotent)
+# Drop the legacy ~/.bashrc block that re-sourced /etc/profile,
+# which caused the dynamic MOTD to print twice on SSH login. Existing
+# devices skip first-boot init via SETUP_FLAG, so this migration is the
+# only thing that fixes them on the next OTA.
+if [ -f "$WENDY_HOME/.bashrc" ] && \
+   grep -q '^# Source global profile if available' "$WENDY_HOME/.bashrc"
+then
+    echo "Removing legacy /etc/profile re-source block from $WENDY_HOME/.bashrc"
+    sed -i '/^# Source global profile if available/,/^fi$/d' "$WENDY_HOME/.bashrc"
+fi
+
+# Check if already run
+if [ -f "$SETUP_FLAG" ]; then
+    echo "WendyOS user setup already completed. Skipping first-boot init."
+    exit 0
+fi
+
+echo "Running WendyOS user setup (first boot)..."
 
 # Create /data/home if it doesn't exist
 if [ ! -d "$DATA_HOME" ]; then
@@ -45,13 +58,8 @@ if [ ! -d "$WENDY_HOME" ]; then
     # Create minimal .bashrc that sources system profiles
     cat > "$WENDY_HOME/.bashrc" << 'EOF'
 # WendyOS User Environment
-# System defaults are in /etc/profile.d/ and update via OTA
-# Add your personal customizations below
-
-# Source global profile if available
-if [ -f /etc/profile ]; then
-    . /etc/profile
-fi
+# System defaults are in /etc/profile.d/ (sourced by /etc/profile on login).
+# Add your personal customizations below.
 
 # User's personal customizations below this line
 # These will persist across OTA updates


### PR DESCRIPTION
## Description

The dynamic MOTD printed twice on every interactive login on already-provisioned devices, with a stale "_Poky reference distribution_" warning banner ahead of it. This PR fixes both issues, lets the dotfile migration actually run on upgraded devices, and hardens the MOTD's IP-lookup against PATH and timing edge cases.

## Changes
1. **Stop the duplicate MOTD.**
2. **Let the migration run on upgraded devices.**
    Allow applying the fix on existing devices in the field.
4. **Suppress the upstream Poky warning banner.**
     This removes the "_WARNING: Poky is a reference Yocto Project distribution …_"
5. **Harden the MOTD network-info line.**
    Resolve `ip` via `command -v` with a `/usr/sbin/ip` fallback so the MOTD does not silently break if `usrmerge` is ever dropped.
 When no global IPv4 address is present (common during NetworkManager startup with `method=auto`), print `IP Address: pending` instead of skipping the line silently.

## Motivation

- Users see a clean, single MOTD on login.
- The Poky reference distribution warning is misleading on a production-targeted image and should not ship.
- Existing devices in the field need the OTA path to be able to apply dotfile fixes — that was not possible until now because
the unit-level `ConditionPathExists` blocked the service.

