### PR TITLE
Make rootfs package management optional (off by default)

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -110,6 +110,17 @@ VOLATILE_LOG_DIR = "${@'no' if d.getVar('WENDYOS_PERSIST_JOURNAL_LOGS') == '1' e
 PACKAGE_CLASSES ?= "package_rpm"
 # PACKAGE_CLASSES = "package_ipk"
 
+# Runtime package management policy.
+# "0" = no package manager binaries in the rootfs (default; image is updated
+#       atomically via Mender A/B).
+# "1" = include rpm/dnf for runtime package operations on the device.
+WENDYOS_ENABLE_PACKAGE_MANAGEMENT ?= "0"
+
+# When disabled, suppress the OE-core backfill that would otherwise add
+# 'package-management' to IMAGE_FEATURES (see IMAGE_FEATURES_BACKFILL in
+# poky's conf/bitbake.conf).
+IMAGE_FEATURES_BACKFILL_CONSIDERED += "${@bb.utils.contains('WENDYOS_ENABLE_PACKAGE_MANAGEMENT', '1', '', 'package-management', d)}"
+
 SANITY_TESTED_DISTROS ?= " \
     ubuntu-20.04 \n\
     ubuntu-22.04 \n\

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -33,8 +33,12 @@ MENDER_CONNECT_ENABLE = "1"
 IMAGE_FEATURES += " \
     ssh-server-openssh \
     debug-tweaks \
-    package-management \
     "
+
+# Optional runtime package management (rpm/dnf in the rootfs).
+# Disabled by default — image is updated atomically via Mender A/B.
+# Set WENDYOS_ENABLE_PACKAGE_MANAGEMENT = "1" in local.conf or distro to enable.
+IMAGE_FEATURES += "${@bb.utils.contains('WENDYOS_ENABLE_PACKAGE_MANAGEMENT', '1', 'package-management', '', d)}"
 
 # Common packages for all machines (real hardware and QEMU)
 IMAGE_INSTALL:append = " \


### PR DESCRIPTION
## Description

Drop 'package-management' from the unconditional `IMAGE_FEATURES` list and gate it on a new distro variable `WENDYOS_ENABLE_PACKAGE_MANAGEMENT`, defaulting to "0". Set it to "1" (in local.conf or a distro override) to restore rpm/dnf in the rootfs for debug images.

Poky's `conf/bitbake.conf` lists 'package-management' in `IMAGE_FEATURES_BACKFILL`, so leaving it out of `IMAGE_FEATURES` isn't enough — OE-core would silently add it back. When the flag is "0", add 'package-management' to `IMAGE_FEATURES_BACKFILL_CONSIDERED` to suppress the backfill. `PACKAGE_CLASSES = "package_rpm"` is left alone, it only controls the build-time package format and has no effect on what lands in the rootfs.