### PR TITLE
fix: align WENDYOS_BOARD_ID with canonical device-type names

### DIFF
--- a/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
@@ -56,4 +56,4 @@ IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INIT
 EMMC_SIZE = "0"
 
 # Stable board identity written to /etc/wendyos/device-type
-WENDYOS_BOARD_ID = "jetson-orin-nano-nvme"
+WENDYOS_BOARD_ID = "jetson-orin-nano"

--- a/conf/machine/jetson-orin-nano-devkit-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-wendyos.conf
@@ -54,4 +54,4 @@ IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INIT
 EMMC_SIZE = "0"
 
 # Stable board identity written to /etc/wendyos/device-type
-WENDYOS_BOARD_ID = "jetson-orin-nano-sd"
+WENDYOS_BOARD_ID = "jetson-orin-nano"

--- a/conf/machine/raspberrypi3-64-wendyos.conf
+++ b/conf/machine/raspberrypi3-64-wendyos.conf
@@ -41,4 +41,4 @@ MACHINE_FEATURES:append = " wifi bluetooth"
 EXTRADEPS = ""
 
 # Stable board identity written to /etc/wendyos/device-type
-WENDYOS_BOARD_ID = "rpi3-sd"
+WENDYOS_BOARD_ID = "raspberry-pi-3"

--- a/conf/machine/raspberrypi4-64-wendyos.conf
+++ b/conf/machine/raspberrypi4-64-wendyos.conf
@@ -40,4 +40,4 @@ MACHINE_FEATURES:append = " wifi bluetooth usbgadget"
 EXTRADEPS = ""
 
 # Stable board identity written to /etc/wendyos/device-type
-WENDYOS_BOARD_ID = "rpi4-sd"
+WENDYOS_BOARD_ID = "raspberry-pi-4"

--- a/conf/machine/raspberrypi5-nvme-wendyos.conf
+++ b/conf/machine/raspberrypi5-nvme-wendyos.conf
@@ -10,5 +10,4 @@ WKS_FILE = "rpi-nvme-partuuid.wks"
 #RPI_EXTRA_CONFIG = "dtparam=pciex1\n"
 
 # Stable board identity written to /etc/wendyos/device-type
-# (overrides the rpi5-sd value set in raspberrypi5-wendyos.conf above)
-WENDYOS_BOARD_ID = "rpi5-nvme"
+WENDYOS_BOARD_ID = "raspberry-pi-5"

--- a/conf/machine/raspberrypi5-wendyos.conf
+++ b/conf/machine/raspberrypi5-wendyos.conf
@@ -36,4 +36,4 @@ MACHINE_FEATURES:append = " wifi bluetooth usbgadget"
 EXTRADEPS = ""
 
 # Stable board identity written to /etc/wendyos/device-type
-WENDYOS_BOARD_ID = "rpi5-sd"
+WENDYOS_BOARD_ID = "raspberry-pi-5"


### PR DESCRIPTION
## Summary
- RPi boards (3/4/5) now use `raspberry-pi-3`, `raspberry-pi-4`, `raspberry-pi-5` instead of `rpi3-sd`, `rpi4-sd`, `rpi5-sd`/`rpi5-nvme`
- Jetson Orin Nano (SD and NVMe) now uses `jetson-orin-nano` instead of `jetson-orin-nano-sd`/`jetson-orin-nano-nvme`
- All values now match the `DEVICE` variable in `conf/template/boards/*/local.conf`, which is what the wendy agent expects as the device type

## Test plan
- [ ] Build a raspberry-pi-4 image and verify `/etc/wendyos/device-type` contains `BOARD=raspberry-pi-4`
- [ ] Confirm wendy agent reports the correct Device Type after flashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)