### PR TITLE
WDY-977: make OpenSSH server configurable via WENDYOS_SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,8 +833,9 @@ You can modify these variables in `bootstrap.sh` before running:
 
 In `build/conf/local.conf`:
 - `WENDYOS_FLASH_IMAGE_SIZE` - Flash image size: "4GB", "8GB", "16GB", "32GB", "64GB" (default: "64GB" — set per-board in `conf/template/boards/<id>/local.conf`; Tegra only)
-- `WENDYOS_DEBUG` - Enable debug packages (default: 0)
+- `WENDYOS_DEBUG` - Enable debug packages and `debug-tweaks` (empty root password, passwordless root SSH) (default: 0)
 - `WENDYOS_DEBUG_UART` - Enable UART debug output (default: 0)
+- `WENDYOS_SSHD` - Include OpenSSH server (`sshd`) in the image (default: 0; set to `1` to enable sshd)
 - `WENDYOS_USB_GADGET` - Enable USB gadget mode (default: 0)
 - `WENDYOS_PERSIST_JOURNAL_LOGS` - Persist logs to storage (default: 0)
 

--- a/conf/template/include/local/common.inc
+++ b/conf/template/include/local/common.inc
@@ -24,6 +24,7 @@ CONF_VERSION = "2"
 # USB gadget function ordering (only effective when WENDYOS_USB_GADGET = "1")
 #GADGET_FUNC_ORDER="ecm ncm"
 
-# Debug features - can be overridden in local.conf or machine config
-WENDYOS_DEBUG = "1"
-WENDYOS_DEBUG_UART = "1"
+# Debug/SSH defaults — off for production; opt in via local.conf or board config.
+WENDYOS_DEBUG ?= "0"
+WENDYOS_DEBUG_UART ?= "0"
+WENDYOS_SSHD ?= "0"

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -30,15 +30,18 @@ MENDER_RETRY_POLL_INTERVAL_SECONDS     = "300"
 MENDER_SYSTEMD_AUTO_ENABLE = "1"
 MENDER_CONNECT_ENABLE = "1"
 
-IMAGE_FEATURES += " \
-    ssh-server-openssh \
-    debug-tweaks \
-    "
+# debug-tweaks: empty root password, PermitEmptyPasswords, PermitRootLogin.
+# Controlled by WENDYOS_DEBUG (default: "0"). Set to "1" for development builds.
+IMAGE_FEATURES += "${@oe.utils.ifelse(d.getVar('WENDYOS_DEBUG') == '1', 'debug-tweaks', '')}"
 
 # Optional runtime package management (rpm/dnf in the rootfs).
 # Disabled by default — image is updated atomically via Mender A/B.
 # Set WENDYOS_ENABLE_PACKAGE_MANAGEMENT = "1" in local.conf or distro to enable.
 IMAGE_FEATURES += "${@bb.utils.contains('WENDYOS_ENABLE_PACKAGE_MANAGEMENT', '1', 'package-management', '', d)}"
+
+# OpenSSH server (sshd). Controlled by WENDYOS_SSHD (default: "0").
+# Set WENDYOS_SSHD = "1" in local.conf to include sshd in the image.
+IMAGE_FEATURES += "${@oe.utils.ifelse(d.getVar('WENDYOS_SSHD') == '1', 'ssh-server-openssh', '')}"
 
 # Common packages for all machines (real hardware and QEMU)
 IMAGE_INSTALL:append = " \
@@ -95,6 +98,7 @@ IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "syst
 BUILDCFG_VARS += " \
     WENDYOS_DEBUG \
     WENDYOS_DEBUG_UART \
+    WENDYOS_SSHD \
     WENDYOS_USB_GADGET \
     WENDYOS_USB_NET_MODE \
     WENDYOS_MDNS_INTERFACES \


### PR DESCRIPTION
WDY-977: Added WENDYOS_SSHD option to enable/disable sshd. Default behavior is unchanged (sshd still ships in the image). Set `WENDYOS_SSHD = "0"` in local.conf to drop sshd from the build.