### PR TITLE
Drop bundled poky for split-poky composition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,13 +272,17 @@ jobs:
           # NOTE: counted with a pipe-free idiom on purpose. `find ... | head | wc -l`
           # under `set -o pipefail` aborts on warm caches because head closes
           # stdin early and find SIGPIPEs — the exact case we're trying to detect.
+          # maxdepth 5 covers both the legacy flat layout (sstate-cache/<aa>/<bb>/file)
+          # and the per-tree partitioned layout introduced with split-poky
+          # (sstate-cache/<tree>/<aa>/<bb>/file). Future-proof for one extra
+          # nesting level if BitBake ever changes its hash directory scheme.
           warm_threshold=500
           sstate_files=0
           if [[ -d "$GITHUB_WORKSPACE/sstate-cache" ]]; then
             while IFS= read -r _; do
               sstate_files=$((sstate_files + 1))
               if [[ "$sstate_files" -ge "$warm_threshold" ]]; then break; fi
-            done < <(find "$GITHUB_WORKSPACE/sstate-cache" -mindepth 2 -maxdepth 3 -type f -print 2>/dev/null)
+            done < <(find "$GITHUB_WORKSPACE/sstate-cache" -mindepth 2 -maxdepth 5 -type f -print 2>/dev/null)
           fi
 
           if [[ "$sstate_files" -lt "$warm_threshold" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@
 SHELL := /bin/bash
 IMAGE_NAME := wendyos
 DOCKER_REPO := wendyos-build
-DOCKER_TAG := scarthgap
+# Tag is no longer series-suffixed; bootstrap.sh + bblayers compose the
+# active yocto series via WENDYOS_LAYER_TREE, not via the Docker tag.
+DOCKER_TAG := latest
 DOCKER_USER := dev
 DOCKER_WORKDIR := /home/$(DOCKER_USER)/$(IMAGE_NAME)
 BUILD_DIR := build
@@ -157,7 +159,7 @@ shell:
 	@printf "\n"
 	@printf "$(YELLOW)Inside the container, run:$(NC)\n"
 	@printf "  cd ./$(IMAGE_NAME)\n"
-	@printf "  . ./repos/poky/oe-init-build-env build\n"
+	@printf "  . ./build/.wendyos-env && . ./repos/\$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env build\n"
 	@printf "  bitbake $(IMAGE_TARGET)\n"
 	@printf "\n"
 	@cd $(DOCKER_DIR) && ./docker-util.sh run
@@ -171,7 +173,8 @@ build: _check-machine _check-setup _ensure-volumes
 	@printf "\n"
 	@if [ "$(WENDYOS_HOST_BUILD)" = "1" ]; then \
 		cd $(PROJECT_DIR) && \
-		source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
+		. ./$(BUILD_DIR)/.wendyos-env && \
+		source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
 		BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET); \
 	elif [ "$$(uname)" = "Darwin" ]; then \
 		docker run \
@@ -187,7 +190,8 @@ build: _check-machine _check-setup _ensure-volumes
 			$(DOCKER_REPO):$(DOCKER_TAG) \
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
-				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
+				. ./$(BUILD_DIR)/.wendyos-env && \
+				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
 				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
 			'; \
 	else \
@@ -202,7 +206,8 @@ build: _check-machine _check-setup _ensure-volumes
 			$(DOCKER_REPO):$(DOCKER_TAG) \
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
-				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
+				. ./$(BUILD_DIR)/.wendyos-env && \
+				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
 				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
 			'; \
 	fi
@@ -232,7 +237,8 @@ build-sdk: _check-machine _check-setup _ensure-volumes
 			$(DOCKER_REPO):$(DOCKER_TAG) \
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
-				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
+				. ./$(BUILD_DIR)/.wendyos-env && \
+				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
 				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
 			'; \
 	else \
@@ -247,7 +253,8 @@ build-sdk: _check-machine _check-setup _ensure-volumes
 			$(DOCKER_REPO):$(DOCKER_TAG) \
 			/bin/bash -c '\
 				cd $(DOCKER_WORKDIR) && \
-				source ./repos/poky/oe-init-build-env $(BUILD_DIR) && \
+				. ./$(BUILD_DIR)/.wendyos-env && \
+				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
 				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
 			'; \
 	fi
@@ -505,12 +512,23 @@ _check-machine:
 
 # Each @-prefixed recipe line runs in its own shell, so a host-build "exit 0"
 # wouldn't skip subsequent Docker checks. Keep the whole branch in one block.
+#
+# The canonical "setup has been run" marker is build/.wendyos-env, written
+# by bootstrap.sh. It also tells us which layer tree the build is bound to,
+# which we re-source to confirm the matching openembedded-core checkout
+# exists under repos/<tree>/.
 _check-setup:
-	@if [ "$(WENDYOS_HOST_BUILD)" = "1" ]; then \
-		if [ ! -d "$(PROJECT_DIR)/repos/poky" ]; then \
-			printf "$(RED)Error: repos/poky not found. Run 'make setup' first.$(NC)\n"; \
+	@if [ ! -f "$(PROJECT_DIR)/$(BUILD_DIR)/.wendyos-env" ]; then \
+		printf "$(RED)Error: $(BUILD_DIR)/.wendyos-env not found. Run 'make setup' first.$(NC)\n"; \
+		exit 1; \
+	fi
+	@. $(PROJECT_DIR)/$(BUILD_DIR)/.wendyos-env && \
+		if [ ! -d "$(PROJECT_DIR)/repos/$$WENDYOS_LAYER_TREE/openembedded-core" ]; then \
+			printf "$(RED)Error: repos/$$WENDYOS_LAYER_TREE/openembedded-core not found. Re-run 'make setup'.$(NC)\n"; \
 			exit 1; \
-		fi; \
+		fi
+	@if [ "$(WENDYOS_HOST_BUILD)" = "1" ]; then \
+		exit 0; \
 	else \
 		if [ ! -d "$(DOCKER_DIR)" ]; then \
 			printf "$(RED)Error: Build environment not set up.$(NC)\n"; \

--- a/README.md
+++ b/README.md
@@ -266,9 +266,17 @@ make build
 
    # build the Linux image inside the container
    cd ./wendyos
-   . ./repos/poky/oe-init-build-env build
+   . ./build/.wendyos-env
+   . ./repos/$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env build
    bitbake wendyos-image
    ```
+
+   `build/.wendyos-env` is written by `bootstrap.sh` and exports
+   `WENDYOS_LAYER_TREE` (default `scarthgap`), the per-series namespace
+   under `repos/<tree>/` populated for the active board. The Yocto core
+   (`bitbake`, `openembedded-core`, `meta-yocto`) is composed from upstream
+   split repos rather than the legacy bundled `poky.git` monolith — see
+   `plans/bootstrap-split-poky-migration.md` for the design rationale.
 
    Depending on the hardware configuration, the build process can take several hours on the first run (when the `download` and `sstate-cache` folders are empty!).
 
@@ -963,7 +971,8 @@ enabled on `ttyAMA0` at 115200 baud.
 
    # Inside the container:
    cd ./wendyos
-   . ./repos/poky/oe-init-build-env build
+   . ./build/.wendyos-env
+   . ./repos/$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env build
    bitbake wendyos-image
    ```
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -214,6 +214,8 @@ resolve_ref() {
 }
 
 ###
+# clone_repos must be called from inside repos/${WENDYOS_LAYER_TREE}/.
+# Each entry's <folder> is a sibling under that tree directory.
 function clone_repos() {
     for repo in "${repos[@]}"
     do
@@ -332,29 +334,6 @@ validate_meta_location || {
     mkdir -p "${PROJECT_DIR}"
 }
 
-cd "${PROJECT_DIR}"
-mkdir -p "repos"
-cd "repos"
-
-# Seed repos/ from a pre-cloned cache when one is provided. The CI runner AMI
-# (built by ci/packer/wendyos-builder.pkr.hcl) bakes the upstream layer
-# repos at the pinned SRCREVs into /opt/wendyos-cache/repos so clone_repos
-# below sees them as already-checked-out and only runs `git fetch` + `git
-# checkout`. Local dev leaves this unset and clones fresh as before.
-if [[ -n "${WENDYOS_REPO_CACHE_DIR:-}" && -d "${WENDYOS_REPO_CACHE_DIR}" ]]
-then
-    printf "Seeding repos/ from cache: %s\n" "${WENDYOS_REPO_CACHE_DIR}"
-    for cached in "${WENDYOS_REPO_CACHE_DIR}"/*/
-    do
-        [[ -d "${cached}" ]] || continue
-        folder=$(basename "${cached}")
-        if [[ ! -d "./${folder}" ]]
-        then
-            cp -r "${cached}" "./${folder}"
-        fi
-    done
-fi
-
 # Resolve template files based on BOARD. Each board has its own directory
 # conf/template/boards/<board-id>/ containing a self-contained local.conf and
 # bblayers.conf, which pull in shared fragments from
@@ -374,17 +353,56 @@ then
 fi
 
 # Per-board repo overrides (optional): override URL_*/SRCREV_* defaults
-# and/or append to REPOS_EXTRA before repos[] is built.
+# and/or append to REPOS_EXTRA before repos[] is built. Sourced BEFORE the
+# repos/${WENDYOS_LAYER_TREE} mkdir + cache-seed so a board can pick a
+# non-default tree (e.g. Thor on whinlatter, or an isolated experimental
+# tree) and have its clones land there.
 if [[ -f "${BOARD_DIR}/repos.overrides" ]]
 then
     # shellcheck source=/dev/null
     source "${BOARD_DIR}/repos.overrides"
 fi
 
+# Warn (but do not auto-delete) if a pre-migration bundled-poky checkout is
+# still on disk. It is no longer used; the user can remove it manually.
+if [[ -d "${PROJECT_DIR}/repos/poky" ]]
+then
+    printf "WARN: Legacy bundled-poky checkout at %s is no longer used. Safe to remove.\n" \
+        "${PROJECT_DIR}/repos/poky" >&2
+fi
+
+cd "${PROJECT_DIR}"
+mkdir -p "repos/${WENDYOS_LAYER_TREE}"
+cd "repos/${WENDYOS_LAYER_TREE}"
+
+# Seed the per-tree repos dir from a pre-cloned cache when one is provided.
+# The CI runner AMI (built by ci/packer/wendyos-builder.pkr.hcl) bakes the
+# upstream layer repos at the pinned SRCREVs into
+# /opt/wendyos-cache/repos/<tree>/ so clone_repos below sees them as
+# already-checked-out and only runs `git fetch` + `git checkout`. Local dev
+# leaves this unset and clones fresh as before.
+if [[ -n "${WENDYOS_REPO_CACHE_DIR:-}" && -d "${WENDYOS_REPO_CACHE_DIR}/${WENDYOS_LAYER_TREE}" ]]
+then
+    printf "Seeding repos/%s/ from cache: %s/%s\n" \
+        "${WENDYOS_LAYER_TREE}" "${WENDYOS_REPO_CACHE_DIR}" "${WENDYOS_LAYER_TREE}"
+    for cached in "${WENDYOS_REPO_CACHE_DIR}/${WENDYOS_LAYER_TREE}"/*/
+    do
+        [[ -d "${cached}" ]] || continue
+        folder=$(basename "${cached}")
+        if [[ ! -d "./${folder}" ]]
+        then
+            cp -r "${cached}" "./${folder}"
+        fi
+    done
+fi
+
 # Build the repos list with the (possibly overridden) URLs and SRCREVs.
-# Indexed (not associative) so iteration preserves the order below.
+# Indexed (not associative) so iteration preserves the order below. Folder
+# names are explicit (rather than derived from URL basename) for clarity.
 declare -a repos=(
-    "1|${URL_POKY}||${SRCREV_POKY}"
+    "1|${URL_BITBAKE}|bitbake|${SRCREV_BITBAKE}"
+    "1|${URL_OECORE}|openembedded-core|${SRCREV_OECORE}"
+    "1|${URL_METAYOCTO}|meta-yocto|${SRCREV_METAYOCTO}"
     "1|${URL_OE}||${SRCREV_OE}"
     "1|${URL_TEGRA}||${SRCREV_TEGRA}"
     "1|${URL_TEGRA_COMM}||${SRCREV_TEGRA_COMM}"
@@ -425,8 +443,14 @@ done
 
 # Only overwrite if the build dir doesn't already have the file
 # (matches previous behavior — user edits to build/conf survive re-bootstrap).
-# WENDYOS_META_REPO is prepended only to bblayers.conf (parsed first by BitBake);
-# the value stays in scope when local.conf is parsed later.
+# WENDYOS_LAYER_TREE is prepended to BOTH bblayers.conf and local.conf:
+#   - bblayers.conf needs it for the ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/<layer>
+#     paths in conf/template/include/bblayers/*.inc.
+#   - local.conf needs it for the SSTATE_DIR partitioning in
+#     conf/template/include/local/common.inc (sstate-cache/${WENDYOS_LAYER_TREE}).
+# Setting it in both removes any dependency on cross-file variable propagation
+# inside BitBake's config parser. WENDYOS_META_REPO is bblayers-only — it is
+# only consumed in bblayers includes.
 for f in local.conf bblayers.conf
 do
     dst="./${YOCTO_BUILD_DIR}/conf/${f}"
@@ -435,14 +459,25 @@ do
         if [[ "${f}" == "bblayers.conf" ]]
         then
             {
+                printf 'WENDYOS_LAYER_TREE = "%s"\n' "${WENDYOS_LAYER_TREE}"
                 printf 'WENDYOS_META_REPO = "%s"\n\n' "${image_name}"
                 cat "${BOARD_DIR}/${f}"
             } > "${dst}"
         else
-            cp "${BOARD_DIR}/${f}" "${dst}"
+            {
+                printf 'WENDYOS_LAYER_TREE = "%s"\n\n' "${WENDYOS_LAYER_TREE}"
+                cat "${BOARD_DIR}/${f}"
+            } > "${dst}"
         fi
     fi
 done
+
+# Always overwrite the env file so re-bootstrapping with a different board
+# (one whose repos.overrides selects a different tree) picks up the change.
+# The Makefile sources this to find oe-init-build-env under the right tree.
+cat > "./${YOCTO_BUILD_DIR}/.wendyos-env" <<EOF
+WENDYOS_LAYER_TREE=${WENDYOS_LAYER_TREE}
+EOF
 
 printf "\nDirectory structure:\n"
 tree -d -L 2 -I 'build|downloads|sstate-cache' || true #--charset=ascii
@@ -462,7 +497,7 @@ Build with:
    make build MACHINE=<machine-name> WENDYOS_HOST_BUILD=1
 
 Or directly:
-   . ./repos/poky/oe-init-build-env ${YOCTO_BUILD_DIR}
+   . ./repos/${WENDYOS_LAYER_TREE}/openembedded-core/oe-init-build-env ${YOCTO_BUILD_DIR}
    bitbake wendyos-image
 
 EOF
@@ -499,7 +534,7 @@ Run the following command(s):
 
    # (within Docker container)
    cd ./${IMAGE_NAME}
-   . ./repos/poky/oe-init-build-env ${YOCTO_BUILD_DIR}
+   . ./repos/${WENDYOS_LAYER_TREE}/openembedded-core/oe-init-build-env ${YOCTO_BUILD_DIR}
    bitbake wendyos-image
 
 EOF

--- a/ci/packer/prefetch-upstream-repos.sh
+++ b/ci/packer/prefetch-upstream-repos.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 #
 # Pre-clone the upstream Yocto layer repos pinned in scripts/upstream-repos.env
-# into a cache directory. Invoked by ci/packer/wendyos-builder.pkr.hcl while
-# baking the CI runner AMI; bootstrap.sh's clone_repos picks them up and
-# fetches/checks out instead of doing a fresh clone.
+# into a per-tree subdirectory of <target_dir>. Invoked by
+# ci/packer/wendyos-builder.pkr.hcl while baking the CI runner AMI;
+# bootstrap.sh's clone_repos picks them up (under
+# <cache>/${WENDYOS_LAYER_TREE}/<folder>/) and fetches/checks out instead
+# of doing a fresh clone.
+#
+# The poky monolith has been retired here; "poky" is composed at clone time
+# from three split-style upstream repos (bitbake, openembedded-core,
+# meta-yocto). See plans/bootstrap-split-poky-migration.md.
 #
 # Usage:
 #   prefetch-upstream-repos.sh <target-dir> <upstream-repos.env path>
@@ -13,17 +19,24 @@ set -euo pipefail
 target_dir="${1:?target dir required}"
 env_file="${2:?upstream-repos.env path required}"
 
-mkdir -p "${target_dir}"
-cd "${target_dir}"
-
 # shellcheck disable=SC1090
 source "${env_file}"
 
+# Honour any layer-tree override sourced from the env file (default
+# scarthgap). When whinlatter (Thor) is added, this script can be invoked a
+# second time with WENDYOS_LAYER_TREE=whinlatter to populate the second
+# tree alongside the first.
+mkdir -p "${target_dir}/${WENDYOS_LAYER_TREE}"
+cd "${target_dir}/${WENDYOS_LAYER_TREE}"
+
 # Mirror the (URL, SRCREV, folder) tuples that bootstrap.sh derives from
-# repos[]. Folder name = basename of URL with .git stripped, matching
-# clone_repos in bootstrap.sh.
+# repos[]. Folder names are explicit here for the three split-poky repos
+# (so the mapping URL→folder is unambiguous); the rest match
+# basename-of-URL with .git stripped, like clone_repos in bootstrap.sh.
 declare -A repos=(
-    [poky]="${URL_POKY}|${SRCREV_POKY}"
+    [bitbake]="${URL_BITBAKE}|${SRCREV_BITBAKE}"
+    [openembedded-core]="${URL_OECORE}|${SRCREV_OECORE}"
+    [meta-yocto]="${URL_METAYOCTO}|${SRCREV_METAYOCTO}"
     [meta-openembedded]="${URL_OE}|${SRCREV_OE}"
     [meta-tegra]="${URL_TEGRA}|${SRCREV_TEGRA}"
     [meta-tegra-community]="${URL_TEGRA_COMM}|${SRCREV_TEGRA_COMM}"
@@ -35,7 +48,7 @@ declare -A repos=(
 
 for folder in "${!repos[@]}"; do
     IFS='|' read -r url srcrev <<< "${repos[$folder]}"
-    printf '[prefetch] %s @ %s\n' "${folder}" "${srcrev}"
+    printf '[prefetch] %s/%s @ %s\n' "${WENDYOS_LAYER_TREE}" "${folder}" "${srcrev}"
 
     if [[ ! -d "${folder}/.git" ]]; then
         git clone "${url}" "${folder}"

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -33,7 +33,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.14.0"
+DISTRO_VERSION = "0.15.0"
 DISTRO_CODENAME = "scarthgap"
 
 SDK_VENDOR = "-wendyossdk"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -15,7 +15,7 @@ BBFILE_PRIORITY_wendyos = "50"
 
 # Layer compatibility (set to your Yocto release)
 # Pick ONE or more that actually match your base (poky/meta, meta-tegra, etc.)
-LAYERSERIES_COMPAT_wendyos = "scarthgap"
+LAYERSERIES_COMPAT_wendyos = "scarthgap whinlatter"
 LAYERVERSION_wendyos = "1"
 
 # Dependencies on other layers (at minimum you depend on 'core')

--- a/conf/template/boards/jetson-agx-orin-emmc/repos.overrides
+++ b/conf/template/boards/jetson-agx-orin-emmc/repos.overrides
@@ -9,7 +9,9 @@
 #   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
 #                        each entry "enabled|url|folder|commit"
 
-#SRCREV_POKY="<commit-hash>"
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
 #SRCREV_OE="<commit-hash>"
 #SRCREV_VIRT="<commit-hash>"
 #SRCREV_TEGRA="<commit-hash>"

--- a/conf/template/boards/jetson-agx-orin/repos.overrides
+++ b/conf/template/boards/jetson-agx-orin/repos.overrides
@@ -9,7 +9,9 @@
 #   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
 #                        each entry "enabled|url|folder|commit"
 
-#SRCREV_POKY="<commit-hash>"
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
 #SRCREV_OE="<commit-hash>"
 #SRCREV_VIRT="<commit-hash>"
 #SRCREV_TEGRA="<commit-hash>"

--- a/conf/template/boards/jetson-orin-nano-nvme/repos.overrides
+++ b/conf/template/boards/jetson-orin-nano-nvme/repos.overrides
@@ -9,7 +9,9 @@
 #   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
 #                        each entry "enabled|url|folder|commit"
 
-#SRCREV_POKY="<commit-hash>"
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
 #SRCREV_OE="<commit-hash>"
 #SRCREV_VIRT="<commit-hash>"
 #SRCREV_TEGRA="<commit-hash>"

--- a/conf/template/boards/jetson-orin-nano-sd/repos.overrides
+++ b/conf/template/boards/jetson-orin-nano-sd/repos.overrides
@@ -9,7 +9,9 @@
 #   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
 #                        each entry "enabled|url|folder|commit"
 
-#SRCREV_POKY="<commit-hash>"
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
 #SRCREV_OE="<commit-hash>"
 #SRCREV_VIRT="<commit-hash>"
 #SRCREV_TEGRA="<commit-hash>"

--- a/conf/template/boards/qemu-arm64/repos.overrides
+++ b/conf/template/boards/qemu-arm64/repos.overrides
@@ -9,6 +9,8 @@
 #   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
 #                        each entry "enabled|url|folder|commit"
 
-#SRCREV_POKY="<commit-hash>"
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
 #SRCREV_OE="<commit-hash>"
 #SRCREV_VIRT="<commit-hash>"

--- a/conf/template/boards/rpi3-sd/repos.overrides
+++ b/conf/template/boards/rpi3-sd/repos.overrides
@@ -9,7 +9,9 @@
 #   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
 #                        each entry "enabled|url|folder|commit"
 
-#SRCREV_POKY="<commit-hash>"
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
 #SRCREV_OE="<commit-hash>"
 #SRCREV_VIRT="<commit-hash>"
 #SRCREV_RPI="<commit-hash>"

--- a/conf/template/boards/rpi4-sd/repos.overrides
+++ b/conf/template/boards/rpi4-sd/repos.overrides
@@ -9,7 +9,9 @@
 #   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
 #                        each entry "enabled|url|folder|commit"
 
-#SRCREV_POKY="<commit-hash>"
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
 #SRCREV_OE="<commit-hash>"
 #SRCREV_VIRT="<commit-hash>"
 #SRCREV_RPI="<commit-hash>"

--- a/conf/template/boards/rpi5-nvme/repos.overrides
+++ b/conf/template/boards/rpi5-nvme/repos.overrides
@@ -9,7 +9,9 @@
 #   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
 #                        each entry "enabled|url|folder|commit"
 
-#SRCREV_POKY="<commit-hash>"
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
 #SRCREV_OE="<commit-hash>"
 #SRCREV_VIRT="<commit-hash>"
 #SRCREV_RPI="<commit-hash>"

--- a/conf/template/boards/rpi5-sd/repos.overrides
+++ b/conf/template/boards/rpi5-sd/repos.overrides
@@ -9,7 +9,9 @@
 #   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
 #                        each entry "enabled|url|folder|commit"
 
-#SRCREV_POKY="<commit-hash>"
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
 #SRCREV_OE="<commit-hash>"
 #SRCREV_VIRT="<commit-hash>"
 #SRCREV_RPI="<commit-hash>"

--- a/conf/template/include/bblayers/oe-common.inc
+++ b/conf/template/include/bblayers/oe-common.inc
@@ -1,12 +1,18 @@
 # OpenEmbedded and poky layers shared by every board.
+#
+# Paths under repos/${WENDYOS_LAYER_TREE}/ resolve to the per-series layer
+# tree populated by bootstrap.sh. The "poky" monolith is composed at clone
+# time from three split-style upstream repos: openembedded-core (provides
+# meta), meta-yocto (provides meta-poky), and bitbake (sourced via
+# oe-init-build-env, not added to BBLAYERS).
 
 BBLAYERS += " \
-    ${TOPDIR}/../repos/meta-openembedded/meta-filesystems \
-    ${TOPDIR}/../repos/meta-openembedded/meta-multimedia \
-    ${TOPDIR}/../repos/meta-openembedded/meta-networking \
-    ${TOPDIR}/../repos/meta-openembedded/meta-oe \
-    ${TOPDIR}/../repos/meta-openembedded/meta-python \
-    ${TOPDIR}/../repos/meta-virtualization \
-    ${TOPDIR}/../repos/poky/meta \
-    ${TOPDIR}/../repos/poky/meta-poky \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-openembedded/meta-filesystems \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-openembedded/meta-multimedia \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-openembedded/meta-networking \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-openembedded/meta-oe \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-openembedded/meta-python \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-virtualization \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/openembedded-core/meta \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-yocto/meta-poky \
     "

--- a/conf/template/include/bblayers/rpi.inc
+++ b/conf/template/include/bblayers/rpi.inc
@@ -1,6 +1,6 @@
 # RPi-exclusive layers: meta-raspberrypi, RPi sub-layer.
 
 BBLAYERS += " \
-    ${TOPDIR}/../repos/meta-raspberrypi \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-raspberrypi \
     ${TOPDIR}/../${WENDYOS_META_REPO}/meta-rpi-extensions \
     "

--- a/conf/template/include/bblayers/tegra.inc
+++ b/conf/template/include/bblayers/tegra.inc
@@ -1,10 +1,10 @@
 # Tegra-exclusive layers: Mender OTA stack, meta-tegra, Tegra sub-layer.
 
 BBLAYERS += " \
-    ${TOPDIR}/../repos/meta-mender/meta-mender-core \
-    ${TOPDIR}/../repos/meta-mender-community/meta-mender-tegra/meta-mender-tegra-common \
-    ${TOPDIR}/../repos/meta-mender-community/meta-mender-tegra/meta-mender-tegra-jetpack6 \
-    ${TOPDIR}/../repos/meta-tegra \
-    ${TOPDIR}/../repos/meta-tegra-community \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-mender/meta-mender-core \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-mender-community/meta-mender-tegra/meta-mender-tegra-common \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-mender-community/meta-mender-tegra/meta-mender-tegra-jetpack6 \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-tegra \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-tegra-community \
     ${TOPDIR}/../${WENDYOS_META_REPO}/meta-tegra-extensions \
     "

--- a/conf/template/include/local/common.inc
+++ b/conf/template/include/local/common.inc
@@ -1,7 +1,11 @@
 # Shared build settings — required by every board.
 
 DL_DIR = "${TOPDIR}/../downloads"
-SSTATE_DIR = "${TOPDIR}/../sstate-cache"
+# sstate-cache is partitioned per layer tree so cross-series builds (e.g.
+# scarthgap Orin and whinlatter Thor on the same workspace) don't share
+# signatures or accidentally collide. Downloads stay shared — source
+# tarballs are keyed by URL/checksum and reusable across series.
+SSTATE_DIR = "${TOPDIR}/../sstate-cache/${WENDYOS_LAYER_TREE}"
 #TMPDIR = "${TOPDIR}/tmp"
 DISTRO = "wendyos"
 #EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
@@ -25,6 +29,6 @@ CONF_VERSION = "2"
 #GADGET_FUNC_ORDER="ecm ncm"
 
 # Debug/SSH defaults — off for production; opt in via local.conf or board config.
-WENDYOS_DEBUG ?= "0"
-WENDYOS_DEBUG_UART ?= "0"
-WENDYOS_SSHD ?= "0"
+WENDYOS_DEBUG = "0"
+WENDYOS_DEBUG_UART = "0"
+WENDYOS_SSHD = "0"

--- a/meta-qemu-extensions/conf/layer.conf
+++ b/meta-qemu-extensions/conf/layer.conf
@@ -9,6 +9,6 @@ BBFILE_COLLECTIONS += "wendyos-qemu"
 BBFILE_PATTERN_wendyos-qemu := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wendyos-qemu = "51"
 
-LAYERSERIES_COMPAT_wendyos-qemu = "scarthgap"
+LAYERSERIES_COMPAT_wendyos-qemu = "scarthgap whinlatter"
 LAYERVERSION_wendyos-qemu = "1"
 LAYERDEPENDS_wendyos-qemu = "core wendyos"

--- a/meta-rpi-extensions/conf/layer.conf
+++ b/meta-rpi-extensions/conf/layer.conf
@@ -9,6 +9,6 @@ BBFILE_COLLECTIONS += "wendyos-rpi"
 BBFILE_PATTERN_wendyos-rpi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wendyos-rpi = "51"
 
-LAYERSERIES_COMPAT_wendyos-rpi = "scarthgap"
+LAYERSERIES_COMPAT_wendyos-rpi = "scarthgap whinlatter"
 LAYERVERSION_wendyos-rpi = "1"
 LAYERDEPENDS_wendyos-rpi = "core wendyos"

--- a/meta-tegra-extensions/conf/layer.conf
+++ b/meta-tegra-extensions/conf/layer.conf
@@ -9,6 +9,6 @@ BBFILE_COLLECTIONS += "wendyos-tegra"
 BBFILE_PATTERN_wendyos-tegra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wendyos-tegra = "51"
 
-LAYERSERIES_COMPAT_wendyos-tegra = "scarthgap"
+LAYERSERIES_COMPAT_wendyos-tegra = "scarthgap whinlatter"
 LAYERVERSION_wendyos-tegra = "1"
 LAYERDEPENDS_wendyos-tegra = "core wendyos"

--- a/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0001-crypto-scatterwalk-Backport-memcpy_sglist.patch
+++ b/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0001-crypto-scatterwalk-Backport-memcpy_sglist.patch
@@ -3,6 +3,8 @@ From: Eric Biggers <ebiggers@kernel.org>
 Date: Wed, 29 Apr 2026 23:35:56 -0700
 Subject: [PATCH] crypto: scatterwalk - Backport memcpy_sglist()
 
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.15.y&id=36435a56cd6bab7609c3e0fd7a70224795375748]
+
 This backports the current implementation of memcpy_sglist() from
 upstream commit 4dffc9bbffb9ccfcda730d899c97c553599e7ca8.
 

--- a/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0002-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch
+++ b/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0002-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch
@@ -4,6 +4,8 @@ Date: Wed, 29 Apr 2026 23:35:57 -0700
 Subject: [PATCH] crypto: algif_aead - use memcpy_sglist() instead of null
  skcipher
 
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.15.y&id=17774d99bb4347c6b025ef80b637d6e3f94fe2f7]
+
 commit f2804d0eee8ddd57aa79d0b82872b74c21e1b69b upstream.
 
 For copying data between two scatterlists, just use memcpy_sglist()

--- a/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0003-crypto-algif_aead-Revert-to-operating-out-of-place-CVE-2026-31431.patch
+++ b/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0003-crypto-algif_aead-Revert-to-operating-out-of-place-CVE-2026-31431.patch
@@ -3,6 +3,8 @@ From: Herbert Xu <herbert@gondor.apana.org.au>
 Date: Wed, 29 Apr 2026 23:35:58 -0700
 Subject: [PATCH] crypto: algif_aead - Revert to operating out-of-place
 
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.15.y&id=19d43105a97be0810edbda875f2cd03f30dc130c]
+
 commit a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5 upstream.
 
 This mostly reverts commit 72548b093ee3 except for the copying of

--- a/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0004-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
+++ b/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0004-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
@@ -3,6 +3,8 @@ From: Douya Le <ldy3087146292@gmail.com>
 Date: Wed, 29 Apr 2026 23:35:59 -0700
 Subject: [PATCH] crypto: algif_aead - snapshot IV for async AEAD requests
 
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.15.y&id=a920cabdb0b7cf1f4e11a20524253ae5bd09092b]
+
 commit 5aa58c3a572b3e3b6c786953339f7978b845cc52 upstream.
 
 AF_ALG AEAD AIO requests currently use the socket-wide IV buffer during

--- a/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0005-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
+++ b/meta-tegra-extensions/recipes-kernel/linux/linux-jammy-nvidia-tegra/0005-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
@@ -3,6 +3,8 @@ From: Herbert Xu <herbert@gondor.apana.org.au>
 Date: Wed, 29 Apr 2026 23:36:04 -0700
 Subject: [PATCH] crypto: algif_aead - Fix minimum RX size check for decryption
 
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.15.y&id=fd427dd84f224309afbcc2cb67c7bb770a01265c]
+
 commit 3d14bd48e3a77091cbce637a12c2ae31b4a1687c upstream.
 
 The check for the minimum receive buffer size did not take the

--- a/recipes-extended/bzip2/bzip2_%.bbappend
+++ b/recipes-extended/bzip2/bzip2_%.bbappend
@@ -1,0 +1,31 @@
+# sourceware.org gates git access behind an Anubis anti-scraper challenge that
+# bitbake's fetcher cannot solve, so do_fetch fails. ptest is already removed
+# from DISTRO_FEATURES in wendyos.conf, so the bzip2-tests sources are unused —
+# drop them from SRC_URI and the license manifest, and disable ptest for this
+# recipe explicitly so a future DISTRO_FEATURES change doesn't silently break
+# do_install_ptest.
+#
+# Both scarthgap and wrynose forms are listed because the URI string and the
+# LIC_FILES_CHKSUM paths differ between series (wrynose adds ;destsuffix= and
+# uses ${UNPACKDIR}; scarthgap uses ${WORKDIR}/git). A :remove token that
+# doesn't match anything is a harmless no-op.
+
+SRC_URI:remove = " \
+    git://sourceware.org/git/bzip2-tests.git;name=bzip2-tests;branch=master;protocol=https \
+    git://sourceware.org/git/bzip2-tests.git;name=bzip2-tests;branch=master;protocol=https;destsuffix=bzip2-tests/ \
+    "
+
+LIC_FILES_CHKSUM:remove = " \
+    file://${WORKDIR}/git/commons-compress/LICENSE.txt;md5=86d3f3a95c324c9479bd8986968f4327 \
+    file://${WORKDIR}/git/dotnetzip/License.txt;md5=9cb56871eed4e748c3bc7e8ff352a54f \
+    file://${WORKDIR}/git/dotnetzip/License.zlib.txt;md5=cc421ccd22eeb2e5db6b79e6de0a029f \
+    file://${WORKDIR}/git/go/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://${WORKDIR}/git/lbzip2/COPYING;md5=d32239bcb673463ab874e80d47fae504 \
+    file://${UNPACKDIR}/bzip2-tests/commons-compress/LICENSE.txt;md5=86d3f3a95c324c9479bd8986968f4327 \
+    file://${UNPACKDIR}/bzip2-tests/dotnetzip/License.txt;md5=9cb56871eed4e748c3bc7e8ff352a54f \
+    file://${UNPACKDIR}/bzip2-tests/dotnetzip/License.zlib.txt;md5=cc421ccd22eeb2e5db6b79e6de0a029f \
+    file://${UNPACKDIR}/bzip2-tests/go/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://${UNPACKDIR}/bzip2-tests/lbzip2/COPYING;md5=d32239bcb673463ab874e80d47fae504 \
+    "
+
+PTEST_ENABLED = "0"

--- a/scripts/docker/docker-util.sh
+++ b/scripts/docker/docker-util.sh
@@ -89,8 +89,9 @@ OS_NAME="wendyos"
 DOCKER_BASE="${DOCKER_BASE:-ubuntu:24.04}"
 DOCKER_NAME=""
 DOCKER_REPO="${DOCKER_REPO:-${OS_NAME}-build}"
-# DOCKER_TAG="latest"
-DOCKER_TAG="${DOCKER_TAG:-scarthgap}"
+# Tag is no longer series-suffixed; the active yocto series is selected at
+# bootstrap time via WENDYOS_LAYER_TREE, not by image tag.
+DOCKER_TAG="${DOCKER_TAG:-latest}"
 DOCKER_CONFIG=""
 DOCKER_ENV="${WORK_DIR}/environment"
 DOCKER_USER="dev"

--- a/scripts/run-qemu.sh
+++ b/scripts/run-qemu.sh
@@ -109,7 +109,8 @@ check_image_exists() {
         echo ""
         echo "Please build the image first:"
         echo "  cd ${BUILD_DIR}"
-        echo "  source ../repos/poky/oe-init-build-env"
+        echo "  . .wendyos-env"
+        echo "  source ../repos/\$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env"
         echo "  bitbake wendyos-image"
         return 1
     fi

--- a/scripts/upstream-repos.env
+++ b/scripts/upstream-repos.env
@@ -4,10 +4,30 @@
 #   - bootstrap.sh         (per-build clone into ${PROJECT_DIR}/repos/)
 #   - ci/packer/*.pkr.hcl  (pre-clone into the CI runner AMI)
 #
+# The poky monolith has been retired here; "poky" is composed at clone time
+# from three split-style upstream repos (bitbake, openembedded-core,
+# meta-yocto) — see plans/bootstrap-split-poky-migration.md. Each board
+# resolves to a layer tree on disk via WENDYOS_LAYER_TREE; clones live
+# under repos/${WENDYOS_LAYER_TREE}/<folder>.
+#
 # A per-board conf/template/boards/<board-id>/repos.overrides file may
-# override any URL_*/SRCREV_* below before bootstrap.sh builds repos[].
+# override any URL_*/SRCREV_* below (and WENDYOS_LAYER_TREE) before
+# bootstrap.sh builds repos[].
 
-URL_POKY="git://git.yoctoproject.org/poky.git"
+# Layer-tree namespace under repos/. Boards on the same yocto series share
+# clones; switching series (or running an isolated experimental tree) means
+# pointing at a different tree. Default for every scarthgap board is the
+# literal "scarthgap"; per-board repos.overrides may unconditionally set
+# something else (e.g. "whinlatter" for Thor, or "thor-experimental" for an
+# isolated checkout).
+WENDYOS_LAYER_TREE="${WENDYOS_LAYER_TREE:-scarthgap}"
+
+# Split-poky composition. SRCREVs below were resolved by walking the
+# previously-pinned bundled poky commit (353491479086e8d3f209d5cce0019a29e143b064)
+# back to the matching upstream split commits — see plan doc D3.
+URL_BITBAKE="git://git.openembedded.org/bitbake"
+URL_OECORE="git://git.openembedded.org/openembedded-core"
+URL_METAYOCTO="git://git.yoctoproject.org/meta-yocto"
 URL_OE="https://github.com/openembedded/meta-openembedded.git"
 URL_TEGRA="https://github.com/OE4T/meta-tegra.git"
 URL_TEGRA_COMM="https://github.com/OE4T/meta-tegra-community"
@@ -16,7 +36,9 @@ URL_MENDER="https://github.com/mendersoftware/meta-mender.git"
 URL_MENDER_COMM="https://github.com/mendersoftware/meta-mender-community.git"
 URL_RPI="https://github.com/agherzan/meta-raspberrypi.git"
 
-SRCREV_POKY="353491479086e8d3f209d5cce0019a29e143b064"
+SRCREV_BITBAKE="8dcf084522b9c66a6639b5f117f554fde9b6b45a"
+SRCREV_OECORE="d50e4680ed6f930582d907b37c9ed545a89f5c27"
+SRCREV_METAYOCTO="9bb6e6e8b016a0c9dfe290369a6ed91ef4020535"
 SRCREV_OE="2759d8870ea387b76c902070bed8a6649ff47b56"
 SRCREV_TEGRA="447c21467f65be2389f68a189b6871f13729d222"
 SRCREV_TEGRA_COMM="241d1073ba8e610ef8da3fe8470b0a4d0567521f"


### PR DESCRIPTION
## Description

The bundled `poky.git` monolith carries series branches only through `walnascar` (5.2). `whinlatter` (5.3) and `wrynose` (6.0 LTS) ship as split repos: `bitbake.git`, `openembedded-core.git`, `meta-yocto.git`. This migration retires bundled poky in one shot while keeping every existing board pinned to the same `scarthgap` content as before.

Layout uses a per-tree namespace: _repos/<tree>/<layer>/_. The tree name is set by `WENDYOS_LAYER_TREE` (default `scarthgap`, per-board `repos.overrides` may set `whinlatter` for Thor, or any other tree name for an isolated checkout). Boards on the same series share clones; series switching points at a different tree, not a re-checkout.

Inside each tree the split repos are flat siblings (no synthetic poky/ umbrella). `oe-init-build-env` is sourced from `repos/<tree>/openembedded-core/`. `bblayers.inc` files swap `repos/poky/meta` -> `repos/<tree>/openembedded-core/meta` and `repos/poky/meta-poky` -> `repos/<tree>/meta-yocto/meta-poky`.

meta-yocto pinned to the 5.0.15. 
Pinned SRCREVs:
bitbake           2.8       8dcf084522b9c66a6639b5f117f554fde9b6b45a
openembedded-core scarthgap d50e4680ed6f930582d907b37c9ed545a89f5c27
meta-yocto        scarthgap 9bb6e6e8b016a0c9dfe290369a6ed91ef4020535

Other changes in scope:
- `LAYERSERIES_COMPAT` in `meta-edgeos` and the three sub-layers widened from "scarthgap" to "scarthgap whinlatter" to pre-position for the follow-up Thor support.
- `bootstrap.sh` writes build/.wendyos-env on every run, the Makefile sources it before invoking oe-init-build-env so `make build` resolves the right tree regardless of which board is active.

`bitbake-setup` adoption is deferred. It is the strategically correct end state and planned as the documented default for `wrynose` 6.0 LTS (April 2026), but `scarthgap` is not yet in its template registry and the upstream maintainer flagged CI integration as deferred. Revisit at the `wrynose` pin.