### PR TITLE
 WDY-1124: add GStreamer plugins for camera streaming

### DIFF
--- a/conf/distro/include/tegra-image.inc
+++ b/conf/distro/include/tegra-image.inc
@@ -11,6 +11,7 @@ TEGRA_BOOTCONTROL_OVERLAYS += "boot-priority.dtbo"
 IMAGE_INSTALL:append = " \
     mender-esp \
     packagegroup-wendyos-tegra \
+    gstreamer1.0-plugins-nvvideo4linux2 \
     "
 
 # Enable DeepStream SDK support (optional - adds ~1GB to image)

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -55,6 +55,9 @@ DISTRO_FEATURES:remove = " \
 # Add OpenGL support for TensorRT
 DISTRO_FEATURES:append = " opengl"
 
+# Accept commercial LICENSE_FLAGS for gstreamer1.0-plugins-ugly (x264enc/x264)
+LICENSE_FLAGS_ACCEPTED += "commercial"
+
 # Add virtualization support for NVIDIA Container Toolkit
 DISTRO_FEATURES:append = " virtualization"
 

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -57,6 +57,11 @@ IMAGE_INSTALL:append = " \
     pipewire-alsa \
     rtkit \
     audio-config \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
     "
 
 # Mender packages (only for real hardware, not QEMU or RPi)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,3 @@
+# vulkan is auto-included via DISTRO_FEATURES but vulkansink requires a windowing
+# system (x11 or wayland). WendyOS disables both, so meson hard-errors at configure.
+PACKAGECONFIG:remove = "vulkan"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,0 +1,3 @@
+# Enable vp8enc + webmmux (VP8 fallback) required by wendy-agent video streaming.
+# libvpx is available from meta-openembedded/meta-oe.
+PACKAGECONFIG:append = " vpx"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_%.bbappend
@@ -1,0 +1,3 @@
+# Enable x264enc (H.264 software encoder) required by wendy-agent video streaming fallback.
+# x264 has a commercial LICENSE_FLAGS; accepted globally in wendyos.conf.
+PACKAGECONFIG:append = " x264"


### PR DESCRIPTION
- Add gstreamer1.0-plugins-base/good/bad/ugly/libav to IMAGE_INSTALL
- Add gstreamer1.0-plugins-nvvideo4linux2 to tegra-image.inc (nvv4l2h264enc)
- Enable x264 PACKAGECONFIG in gst-plugins-ugly (x264enc)
- Enable vpx PACKAGECONFIG in gst-plugins-good (vp8enc)
- Disable vulkan PACKAGECONFIG in gst-plugins-bad (no windowing system)
- Accept commercial LICENSE_FLAGS for x264