### PR TITLE
fix RPi3 boot by switching to MBR disk layout

### DIFF
--- a/conf/machine/raspberrypi3-64-wendyos.conf
+++ b/conf/machine/raspberrypi3-64-wendyos.conf
@@ -1,11 +1,13 @@
 MACHINEOVERRIDES =. "rpi:raspberrypi3-64:"
 require conf/machine/raspberrypi3-64.conf
 
-# WIC GPT image — no Mender, no tegraflash
+# WIC MBR image — no Mender, no tegraflash. The BCM2837 GPU bootrom on the
+# Pi 3 can only read MBR-partitioned FAT32; the GPT layout used on Pi 4/5
+# (rpi-partuuid.wks) leaves the board unable to find bootcode.bin and the
+# system never boots.
 IMAGE_FSTYPES = "wic wic.bmap"
 IMAGE_FSTYPES:remove = "tegraflash dataimg mender uefiimg uefiimg.bmap uefiimg.bz2"
-WKS_FILE = "rpi-partuuid.wks"
-WKS_FILE_DEPENDS += "gptfdisk"
+WKS_FILE = "rpi-mbr.wks"
 LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
 
 # No Mender, no UEFI capsule updates

--- a/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,6 +1,15 @@
 inherit partuuid-rpi
 
 CMDLINE_ROOT_PARTITION:rpi = "PARTUUID=${WENDYOS_ROOT_PARTUUID}"
+# RPi3 boots from an MBR-partitioned card; the kernel reports MBR PARTUUIDs as
+# <disksig>-<partno>, not as the UUIDv4 we generate, so reference root by its
+# filesystem label (set in wic/rpi-mbr.wks) instead.
+#
+# Override is pinned to :raspberrypi3-64 (not :raspberrypi3) on purpose: with
+# MACHINEOVERRIDES "raspberrypi3:rpi:raspberrypi3-64:..." the rightmost match
+# wins, so :raspberrypi3 would lose to :rpi above. :raspberrypi3-64 sits after
+# :rpi and overrides it.
+CMDLINE_ROOT_PARTITION:raspberrypi3-64 = "LABEL=root"
 CMDLINE_ROOTFS:rpi = "console=serial0,115200 root=${CMDLINE_ROOT_PARTITION} rootfstype=ext4 fsck.repair=yes rootwait"
 CMDLINE_ROOTFS:append:rpi = "${@' modules-load=dwc2' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
 do_deploy[depends] += "${PN}:do_generate_partuuids"

--- a/meta-rpi-extensions/recipes-support/expand-rootfs-rpi/files/expand-rootfs.sh
+++ b/meta-rpi-extensions/recipes-support/expand-rootfs-rpi/files/expand-rootfs.sh
@@ -36,8 +36,11 @@ if lsblk -rno PARTLABEL "$DISK" 2>/dev/null | grep -qiE 'root[a-b]'; then
   mkdir -p "$(dirname "$STAMP")"; touch "$STAMP"; exit 0
 fi
 
-# GPT backup header when image is flashed to a larger card
-if command -v sgdisk >/dev/null 2>&1; then
+# Fix GPT backup header when image is flashed to a larger card.
+# Skip on MBR-partitioned disks — sgdisk -e on MBR can write GPT structures
+# and corrupt the partition table before exiting.
+PTTYPE="$(blkid -o value -s PTTYPE "$DISK" 2>/dev/null || true)"
+if [[ "$PTTYPE" == "gpt" ]] && command -v sgdisk >/dev/null 2>&1; then
   echo "[expand-rootfs] sgdisk -e $DISK (fix GPT backup at end)"
   sgdisk -e "$DISK" || true
   command -v partprobe >/dev/null 2>&1 && partprobe "$DISK" || true

--- a/recipes-core/base-files/files/rpi-mbr-fstab
+++ b/recipes-core/base-files/files/rpi-mbr-fstab
@@ -1,0 +1,3 @@
+LABEL=boot    /boot    vfat   defaults          0 2
+LABEL=root    /        ext4   defaults,noatime  0 1
+LABEL=config  /config  vfat   defaults,nofail   0 0

--- a/recipes-core/base-files/rpi-base-files.inc
+++ b/recipes-core/base-files/rpi-base-files.inc
@@ -1,20 +1,31 @@
-# RPi5-specific base-files extensions.
+# RPi base-files extensions.
 # Included conditionally from base-files_%.bbappend — safe for non-RPi machines.
 
 inherit partuuid-rpi
 inherit journal-persist-rpi
 
-SRC_URI:append = " file://rpi-fstab"
+SRC_URI:append = " file://rpi-fstab file://rpi-mbr-fstab"
+
+# RPi4/5 boot from a GPT image and reference partitions by PARTUUID (rpi-fstab,
+# placeholders RPI_BOOT_UUID / RPI_ROOT_UUID get substituted below).
+# RPi3 boots from MBR (BCM2837 GPU bootrom limitation) and references
+# partitions by filesystem label; the MBR template has no placeholders, so the
+# substitution sed lines below are no-ops on that path.
+#
+# Pinned to :raspberrypi3-64 to mirror the override used in rpi-cmdline.bbappend
+# (see comment there). WendyOS only ships the 64-bit RPi3 image; if a 32-bit
+# variant is ever added, both overrides will need a matching :raspberrypi3 entry.
+RPI_FSTAB_TEMPLATE = "rpi-fstab"
+RPI_FSTAB_TEMPLATE:raspberrypi3-64 = "rpi-mbr-fstab"
 
 do_install:append() {
-    # Install PARTUUID-templated fstab and substitute the actual UUIDs
-    install -m 0644 ${WORKDIR}/rpi-fstab ${D}${sysconfdir}/fstab
+    install -m 0644 ${WORKDIR}/${RPI_FSTAB_TEMPLATE} ${D}${sysconfdir}/fstab
     sed -i "s/RPI_BOOT_UUID/${WENDYOS_BOOT_PARTUUID}/g" ${D}${sysconfdir}/fstab
     sed -i "s/RPI_ROOT_UUID/${WENDYOS_ROOT_PARTUUID}/g" ${D}${sysconfdir}/fstab
 }
 
-# Trigger a rebuild whenever the PARTUUIDs change
-do_install[vardeps] += " WENDYOS_BOOT_PARTUUID WENDYOS_ROOT_PARTUUID"
+# Trigger a rebuild whenever the PARTUUIDs or selected template change
+do_install[vardeps] += " WENDYOS_BOOT_PARTUUID WENDYOS_ROOT_PARTUUID RPI_FSTAB_TEMPLATE"
 
 # systemd persistent log
 # If /var/log is a symlink into /var/volatile/log, journald cannot persist logs

--- a/wic/rpi-mbr.wks
+++ b/wic/rpi-mbr.wks
@@ -1,0 +1,12 @@
+# RPi3 MBR layout. The BCM2837 GPU bootrom can only read MBR-partitioned
+# FAT32 — GPT support landed later in the Pi 4 EEPROM bootloader, so the
+# shared rpi-partuuid.wks is not usable on Pi 3.
+#
+# Partitions are referenced by filesystem label: under MBR the kernel exposes
+# PARTUUIDs as <disk-signature>-<partno>, not as UUIDv4, so the values from
+# partuuid-rpi.bbclass would never resolve in cmdline.txt or fstab. See
+# rpi-cmdline.bbappend and rpi-mbr-fstab for the matching consumers.
+bootloader --ptable msdos
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 128M
+part --ondisk mmcblk0 --fstype=vfat --label config --align 4096 --size ${WENDYOS_CONFIG_PART_SIZE_MB}M
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096 --size 8192M


### PR DESCRIPTION
  The BCM2837 GPU bootrom can only read MBR-partitioned FAT32, not GPT.
  Add rpi-mbr.wks with MBR layout and filesystem labels, a matching fstab
  template, and update cmdline.txt to use root=LABEL=root instead of PARTUUID