### PR TITLE
conf: clear IMAGE_NAME_SUFFIX for Thor to fix deployed image filename

### DIFF
--- a/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
@@ -32,6 +32,12 @@ UBOOT_EXTLINUX = "1"
 # infrastructure.
 TEGRA_UEFI_USE_SIGNED_FILES = "false"
 
+# wrynose oe-core (image-artifact-names.bbclass) defaults IMAGE_NAME_SUFFIX to
+# ".rootfs", which would make IMAGE_LINK_NAME include ".rootfs" and produce
+# deployed symlinks like wendyos-image-${MACHINE}.rootfs.tegraflash-tar.
+# The publisher and CI scripts expect no suffix, matching scarthgap behaviour.
+IMAGE_NAME_SUFFIX = ""
+
 # Image formats: produces a one-shot flashable image only.
 # 'mender' and 'dataimg' are deliberately omitted (no A/B, no /data
 # partition layout) — those return when B2 reopens.


### PR DESCRIPTION
## Summary

- wrynose oe-core's `image-artifact-names.bbclass` defaults `IMAGE_NAME_SUFFIX` to `.rootfs`, causing `IMAGE_LINK_NAME` to become `wendyos-image-${MACHINE}.rootfs`
- This makes the deployed tegraflash-tar symlink `wendyos-image-${MACHINE}.rootfs.tegraflash-tar`, but the CI publisher expects `wendyos-image-${MACHINE}.tegraflash-tar` (no `.rootfs`)
- All other boards use scarthgap oe-core where `IMAGE_NAME_SUFFIX` defaults to `""` — Thor on wrynose needs an explicit override to match

## Fix

Set `IMAGE_NAME_SUFFIX = ""` in `conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf` to override the wrynose default and produce the correct symlink name at image deploy time.

## Test plan

- [ ] CI build for `jetson-agx-thor` completes the "Upload image and update device manifest" step without "file not found" errors
- [ ] `wendyos-image-jetson-agx-thor-devkit-nvme-wendyos.tegraflash-tar` is present in `DEPLOY_DIR_IMAGE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)