### PR TITLE
Feat/wdy-983: Mender OTA for RPi3/4 (& 5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,15 +360,20 @@ flash-to-external: _check-machine
 		IMG_SIZE=$$(ls -lh "$(PROJECT_DIR)/deploy/wendyos.img" | awk '{print $$5}'); \
 		printf "Using existing image: $(PROJECT_DIR)/deploy/wendyos.img ($$IMG_SIZE)\n\n"; \
 	elif echo "$(MACHINE)" | grep -q "raspberrypi"; then \
+		SDIMG="$(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/$(IMAGE_TARGET)-$(MACHINE).sdimg"; \
 		WIC_IMG="$(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/$(IMAGE_TARGET)-$(MACHINE).rootfs.wic"; \
-		if [ ! -f "$$WIC_IMG" ]; then \
-			printf "$(RED)Error: WIC image not found: $$WIC_IMG$(NC)\n"; \
+		if [ -f "$$SDIMG" ]; then \
+			SRC="$$SDIMG"; KIND="Mender sdimg"; \
+		elif [ -f "$$WIC_IMG" ]; then \
+			SRC="$$WIC_IMG"; KIND="wic"; \
+		else \
+			printf "$(RED)Error: neither sdimg nor wic image found in $(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/$(NC)\n"; \
 			printf "Run 'make build MACHINE=$(MACHINE)' first.\n"; \
 			exit 1; \
 		fi; \
 		mkdir -p "$(PROJECT_DIR)/deploy"; \
-		cp "$$WIC_IMG" "$(PROJECT_DIR)/deploy/wendyos.img"; \
-		printf "$(GREEN)RPi5 WIC image ready: $(PROJECT_DIR)/deploy/wendyos.img$(NC)\n\n"; \
+		cp "$$SRC" "$(PROJECT_DIR)/deploy/wendyos.img"; \
+		printf "$(GREEN)RPi $$KIND image ready: $(PROJECT_DIR)/deploy/wendyos.img$(NC)\n\n"; \
 	else \
 		if [ "$$OS_TYPE" = "Darwin" ]; then \
 			if [ ! -f "$(PROJECT_DIR)/deploy/$(IMAGE_TARGET)-$(MACHINE).tegraflash.tar.gz" ]; then \
@@ -416,7 +421,7 @@ flash-to-external: _check-machine
 		if [ "$$OS_TYPE" = "Darwin" ]; then \
 			diskutil list external physical 2>/dev/null || printf "No external disks found.\n"; \
 		else \
-			lsblk -d -o NAME,SIZE,MODEL,TRAN 2>/dev/null | grep -E "usb|sata|nvme" || \
+			lsblk -d -o NAME,SIZE,MODEL,TRAN 2>/dev/null | grep -E "usb|sata|nvme|mmc" || \
 			lsblk -d -o NAME,SIZE,MODEL 2>/dev/null | grep -vE "^(loop|sr|ram)" | head -20; \
 		fi; \
 		printf "\n"; \
@@ -427,7 +432,7 @@ flash-to-external: _check-machine
 		if [ "$$OS_TYPE" = "Darwin" ]; then \
 			printf "$(YELLOW)Enter the disk to flash (e.g., disk42) or 'q' to quit:$(NC) "; \
 		else \
-			printf "$(YELLOW)Enter the disk to flash (e.g., sdb, nvme0n1) or 'q' to quit:$(NC) "; \
+			printf "$(YELLOW)Enter the disk to flash (e.g., sdb, nvme0n1, mmcblk0) or 'q' to quit:$(NC) "; \
 		fi; \
 		read device_input; \
 		if [ "$$device_input" = "q" ] || [ "$$device_input" = "Q" ]; then \
@@ -442,9 +447,9 @@ flash-to-external: _check-machine
 			esac; \
 		else \
 			case "$$device_input" in \
-				sd[a-z]|sd[a-z][a-z]|nvme[0-9]n[0-9]|nvme[0-9][0-9]n[0-9]) DEVICE="/dev/$$device_input" ;; \
-				/dev/sd[a-z]*|/dev/nvme*) DEVICE="$$device_input" ;; \
-				*) printf "$(RED)Error: Invalid disk name '$$device_input'. Must be like 'sdb', 'nvme0n1', or '/dev/sdb'$(NC)\n"; exit 1 ;; \
+				sd[a-z]|sd[a-z][a-z]|nvme[0-9]n[0-9]|nvme[0-9][0-9]n[0-9]|mmcblk[0-9]|mmcblk[0-9][0-9]) DEVICE="/dev/$$device_input" ;; \
+				/dev/sd[a-z]*|/dev/nvme*|/dev/mmcblk*) DEVICE="$$device_input" ;; \
+				*) printf "$(RED)Error: Invalid disk name '$$device_input'. Must be like 'sdb', 'nvme0n1', 'mmcblk0', or '/dev/sdb'$(NC)\n"; exit 1 ;; \
 			esac; \
 		fi; \
 	fi; \
@@ -480,7 +485,7 @@ flash-to-external: _check-machine
 		if sudo dd if=$(PROJECT_DIR)/deploy/wendyos.img of="$$RAW_DEVICE" bs=$$DD_BS status=progress; then \
 			sync; \
 			printf "\n$(GREEN)Flash complete!$(NC)\n"; \
-			printf "You can now safely eject the drive and insert it into your Jetson.\n"; \
+			printf "You can now safely eject the drive and insert it into your target board.\n"; \
 			if [ "$$OS_TYPE" = "Darwin" ]; then \
 				diskutil eject "$$DEVICE" 2>/dev/null || true; \
 			else \

--- a/Makefile
+++ b/Makefile
@@ -356,10 +356,7 @@ flash-to-external: _check-machine
 	@printf "$(CYAN)==================$(NC)\n\n"
 	@OS_TYPE=$$(uname); \
 	if [ "$$OS_TYPE" = "Darwin" ]; then DD_BS="4m"; else DD_BS="4M"; fi; \
-	if [ -f "$(PROJECT_DIR)/deploy/wendyos.img" ]; then \
-		IMG_SIZE=$$(ls -lh "$(PROJECT_DIR)/deploy/wendyos.img" | awk '{print $$5}'); \
-		printf "Using existing image: $(PROJECT_DIR)/deploy/wendyos.img ($$IMG_SIZE)\n\n"; \
-	elif echo "$(MACHINE)" | grep -q "raspberrypi"; then \
+	if echo "$(MACHINE)" | grep -q "raspberrypi"; then \
 		SDIMG="$(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/$(IMAGE_TARGET)-$(MACHINE).sdimg"; \
 		WIC_IMG="$(PROJECT_DIR)/build/tmp/deploy/images/$(MACHINE)/$(IMAGE_TARGET)-$(MACHINE).rootfs.wic"; \
 		if [ -f "$$SDIMG" ]; then \
@@ -374,6 +371,9 @@ flash-to-external: _check-machine
 		mkdir -p "$(PROJECT_DIR)/deploy"; \
 		cp "$$SRC" "$(PROJECT_DIR)/deploy/wendyos.img"; \
 		printf "$(GREEN)RPi $$KIND image ready: $(PROJECT_DIR)/deploy/wendyos.img$(NC)\n\n"; \
+	elif [ -f "$(PROJECT_DIR)/deploy/wendyos.img" ]; then \
+		IMG_SIZE=$$(ls -lh "$(PROJECT_DIR)/deploy/wendyos.img" | awk '{print $$5}'); \
+		printf "Using existing tegraflash image: $(PROJECT_DIR)/deploy/wendyos.img ($$IMG_SIZE)\n\n"; \
 	else \
 		if [ "$$OS_TYPE" = "Darwin" ]; then \
 			if [ ! -f "$(PROJECT_DIR)/deploy/$(IMAGE_TARGET)-$(MACHINE).tegraflash.tar.gz" ]; then \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -437,6 +437,7 @@ declare -a repos=(
     "1|${URL_MENDER}||${SRCREV_MENDER}"
     "1|${URL_MENDER_COMM}||${SRCREV_MENDER_COMM}"
     "1|${URL_RPI}||${SRCREV_RPI}"
+    "1|${URL_LTS_MIXINS}||${SRCREV_LTS_MIXINS}"
 )
 
 # Append any extras declared by the override file.

--- a/conf/distro/include/mender.inc
+++ b/conf/distro/include/mender.inc
@@ -26,6 +26,16 @@ MENDER_CONNECT_ENABLE = "1"
 # when inherited in the OE4t setup-env.sh-style environment (they modify
 # bblayers.conf and expect host info we don't provide). Removing them is
 # a no-op on machines that don't inherit them, so this is safe to apply
-# universally. tegra-mender-setup is Tegra-specific and lives in
-# conf/distro/include/tegra-image.inc.
+# universally.
 INHERIT:remove = "tegra-support-sanity distro_layer_buildinfo"
+
+# tegra-mender-setup is Tegra-only (l4t-mender override injection,
+# tegraflash artifact type, NVIDIA partition table). It must be inherited
+# at config-parse time — bitbake reads INHERIT exactly once, at the end
+# of global config parsing, before any recipe is read. mender.inc is
+# required from wendyos.conf (distro scope) so this line takes effect;
+# putting the same line in a recipe-included .inc (e.g. tegra-image.inc
+# required from wendyos-image.bb) would be a silent no-op.
+# Lazy Python expansion gates the inherit on a Tegra MACHINEOVERRIDE so
+# non-Tegra builds don't try to load the class.
+INHERIT += "${@'tegra-mender-setup' if 'tegra' in d.getVar('MACHINEOVERRIDES').split(':') else ''}"

--- a/conf/distro/include/mender.inc
+++ b/conf/distro/include/mender.inc
@@ -22,9 +22,10 @@ MENDER_RETRY_POLL_INTERVAL_SECONDS     = "300"
 MENDER_SYSTEMD_AUTO_ENABLE = "1"
 MENDER_CONNECT_ENABLE = "1"
 
-# tegra
-# these two classes only work as intended when being inherited in the
-# OE4t setup-env.sh style environment, as they modify bblayers.conf
-# and expect additional information on the host.
+# tegra-support-sanity and distro_layer_buildinfo only work as intended
+# when inherited in the OE4t setup-env.sh-style environment (they modify
+# bblayers.conf and expect host info we don't provide). Removing them is
+# a no-op on machines that don't inherit them, so this is safe to apply
+# universally. tegra-mender-setup is Tegra-specific and lives in
+# conf/distro/include/tegra-image.inc.
 INHERIT:remove = "tegra-support-sanity distro_layer_buildinfo"
-INHERIT += "tegra-mender-setup"

--- a/conf/distro/include/rpi-distro.inc
+++ b/conf/distro/include/rpi-distro.inc
@@ -1,9 +1,10 @@
-# RPi5-specific distro configuration
-# This file is included when building for RPi machines
+# RPi-specific distro configuration
+# This file is included when building for RPi machines (MACHINEOVERRIDES
+# contains 'rpi'). Mender is enabled per-machine via IMAGE_FSTYPES — RPi3
+# remains non-Mender (MBR boot vs Mender-sdimg GPT default), RPi4 and RPi5
+# get Mender artifact emission.
 
-# No Mender for RPi5
-MENDER_CONNECT_ENABLE = "0"
-# No EFI/UEFI on RPi5
+# No EFI/UEFI on RPi
 WENDYOS_UPDATE_BOOTLOADER ?= "0"
 WENDYOS_EFI_DEBUG ?= "0"
 WENDYOS_DEEPSTREAM ?= "0"

--- a/conf/distro/include/rpi-distro.inc
+++ b/conf/distro/include/rpi-distro.inc
@@ -1,8 +1,7 @@
 # RPi-specific distro configuration
 # This file is included when building for RPi machines (MACHINEOVERRIDES
-# contains 'rpi'). Mender is enabled per-machine via IMAGE_FSTYPES — RPi3
-# remains non-Mender (MBR boot vs Mender-sdimg GPT default), RPi4 and RPi5
-# get Mender artifact emission.
+# contains 'rpi'). All non-QEMU RPi machines (RPi3/4/5) emit Mender
+# artifacts via mender-image-sd; storage geometry is set per-machine.
 
 # No EFI/UEFI on RPi
 WENDYOS_UPDATE_BOOTLOADER ?= "0"

--- a/conf/distro/include/rpi-image.inc
+++ b/conf/distro/include/rpi-image.inc
@@ -1,15 +1,16 @@
-# RPi5-specific image configuration
+# RPi-specific image configuration
 # This file is included when building for RPi machines (MACHINEOVERRIDES contains 'rpi')
 
 inherit partuuid-rpi
 
-# RPi5-specific packages
+# RPi-specific packages
 IMAGE_INSTALL:append = " \
     packagegroup-wendyos-rpi \
     "
 
-# wendyos-image.bb appends ext4 unconditionally; RPi5 only needs wic
-IMAGE_FSTYPES:remove = "ext4"
+# Note: ext4 is kept in IMAGE_FSTYPES because Mender's mender-image-sd
+# needs an ext4 rootfs for the A/B slot layout. RPi3 stays on wic-only
+# via its machine-conf IMAGE_FSTYPES override.
 
 # Remove Tegra-only packages added by tegra-image.inc or wendyos-image.bb.
 # Layer separation removes these recipes from the parse tree, but IMAGE_INSTALL

--- a/conf/distro/include/tegra-image.inc
+++ b/conf/distro/include/tegra-image.inc
@@ -1,6 +1,12 @@
 # Tegra/Jetson-specific image configuration
 # This file is included when building for Tegra machines (MACHINEOVERRIDES contains 'tegra')
 
+# Tegra Mender wiring: l4t-mender override injection, tegraflash artifact
+# type, NVIDIA partition table. Only safe to inherit on Tegra targets;
+# kept here (gated by the tegra MACHINEOVERRIDE on this file's require)
+# rather than in the BSP-neutral mender.inc.
+INHERIT += "tegra-mender-setup"
+
 # Apply our UEFI boot-priority overlay during flash
 TEGRA_BOOTCONTROL_OVERLAYS += "boot-priority.dtbo"
 

--- a/conf/distro/include/tegra-image.inc
+++ b/conf/distro/include/tegra-image.inc
@@ -1,11 +1,10 @@
 # Tegra/Jetson-specific image configuration
 # This file is included when building for Tegra machines (MACHINEOVERRIDES contains 'tegra')
 
-# Tegra Mender wiring: l4t-mender override injection, tegraflash artifact
-# type, NVIDIA partition table. Only safe to inherit on Tegra targets;
-# kept here (gated by the tegra MACHINEOVERRIDE on this file's require)
-# rather than in the BSP-neutral mender.inc.
-INHERIT += "tegra-mender-setup"
+# Note: tegra-mender-setup inheritance lives in conf/distro/include/mender.inc
+# (gated on MACHINEOVERRIDES containing 'tegra'). INHERIT must be set at
+# config-parse time; this file is required from wendyos-image.bb (recipe
+# parse), which is too late.
 
 # Apply our UEFI boot-priority overlay during flash
 TEGRA_BOOTCONTROL_OVERLAYS += "boot-priority.dtbo"

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -7,7 +7,9 @@
 # swapfile-setup, wendyos-etc-binds, wendyos-user-data-setup, etc.).
 # Default: enabled for real Jetson hardware (Orin tegra234), disabled for
 # QEMU, RPi, and Thor (tegra264 — Mender deferred). Override per-machine
-# or in local.conf to opt in/out independently of the SoC.
+# or in local.conf to opt in/out independently of the SoC. RPi machine
+# confs set WENDYOS_MENDER = "1" individually now that RPi3/4/5 OTA is
+# hardware-verified.
 WENDYOS_MENDER ?= "${@'0' if any(t in d.getVar('MACHINEOVERRIDES').split(':') for t in ('qemuall', 'rpi', 'tegra264')) else '1'}"
 
 # Mender configuration (only used when WENDYOS_MENDER = "1")
@@ -32,8 +34,12 @@ require systemd.conf
 # partition. Gated on WENDYOS_MENDER (defined above). To re-enable
 # Mender on Thor in Phase 4, override WENDYOS_MENDER = "1" in Thor's
 # machine.conf or in the smart default expression above.
+# flash-image-sizes.inc is additionally gated on 'tegra' — it sets
+# TEGRA_EXTERNAL_DEVICE_SECTORS and a Mender storage total tuned to the
+# Tegra partition overhead; RPi machines set MENDER_STORAGE_TOTAL_SIZE_MB
+# directly in their machine conf.
 require ${@'conf/distro/include/mender.inc'              if d.getVar('WENDYOS_MENDER') == '1' else ''}
-require ${@'conf/distro/include/flash-image-sizes.inc'   if d.getVar('WENDYOS_MENDER') == '1' else ''}
+require ${@'conf/distro/include/flash-image-sizes.inc'   if d.getVar('WENDYOS_MENDER') == '1' and 'tegra' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 
 # Conditionally require L4T configuration only for Tegra machines.
 # Thor (tegra264) pins L4T 38.4.0 (JetPack 7.1); Orin (tegra234) stays on
@@ -114,8 +120,9 @@ WENDYOS_EFI_DEBUG ?= "0"
 
 # Enable persistent journal logs on /data partition.
 # Default tracks WENDYOS_MENDER: when Mender provides /data we persist
-# logs there; when there's no /data partition (QEMU, RPi, Thor Phase 1)
-# logs are volatile. Override per-machine or in local.conf to decouple.
+# logs there; when there's no /data partition (QEMU, Thor Phase 1, RPi
+# machines that haven't opted in) logs are volatile. Override per-machine
+# or in local.conf to decouple.
 WENDYOS_PERSIST_JOURNAL_LOGS ?= "${WENDYOS_MENDER}"
 
 # Config partition (FAT32, mountable on Linux/macOS/Windows)
@@ -186,5 +193,5 @@ INHERIT += " \
 # (from meta-mender layer.conf) based on MENDER_FEATURES_ENABLE being set.
 # WENDYOS_MENDER (defined above) gates the require of mender.inc, which in
 # turn sets MENDER_FEATURES_ENABLE via mender-full. So:
-#   WENDYOS_MENDER=1 (default for Orin tegra234)  -> mender.inc loaded -> Mender on
-#   WENDYOS_MENDER=0 (QEMU, RPi, Thor tegra264)   -> mender.inc skipped -> Mender off
+#   WENDYOS_MENDER=1 (default for Orin tegra234, opt-in per RPi machine)  -> mender.inc loaded -> Mender on
+#   WENDYOS_MENDER=0 (QEMU, Thor tegra264, RPi default)                    -> mender.inc skipped -> Mender off

--- a/conf/machine/include/raspberrypi-common-wendyos.inc
+++ b/conf/machine/include/raspberrypi-common-wendyos.inc
@@ -1,0 +1,50 @@
+# Common WendyOS settings for all 64-bit RPi machines (RPi3/4/5).
+# Required after the upstream raspberrypiN-64.conf include in each
+# machine conf so machine-specific overrides come last where needed.
+
+# Mender's mender-image-sd handles the sdimg layout; rpi-sdimg from
+# meta-raspberrypi would compete with it. Tegra/UEFI types don't apply.
+IMAGE_FSTYPES:remove = "tegraflash dataimg uefiimg uefiimg.bmap uefiimg.bz2 rpi-sdimg"
+
+LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
+
+# Mender opt-in (wendyos.conf default is off for RPi).
+WENDYOS_MENDER = "1"
+
+# U-Boot is on by default (Mender's upstream-supported path).
+WENDYOS_RPI_UBOOT ?= "1"
+RPI_USE_U_BOOT = "${@'1' if d.getVar('WENDYOS_RPI_UBOOT') == '1' else '0'}"
+
+# Mender storage geometry. SD card on /dev/mmcblk0 with partition suffix
+# 'p' (e.g. /dev/mmcblk0p2). 7400 MiB fits a nominal 8 GB SD card
+# (~7629 MiB usable); raspberrypi5-nvme-wendyos.conf overrides
+# MENDER_STORAGE_DEVICE and MENDER_STORAGE_TOTAL_SIZE_MB for NVMe.
+# MENDER_STORAGE_DEVICE_BASE uses lazy expansion so the NVMe override of
+# MENDER_STORAGE_DEVICE alone is enough to derive /dev/nvme0n1p* names.
+MENDER_STORAGE_DEVICE        = "/dev/mmcblk0"
+MENDER_STORAGE_DEVICE_BASE   = "${MENDER_STORAGE_DEVICE}p"
+MENDER_BOOT_PART_SIZE_MB     = "100"
+MENDER_DATA_PART_SIZE_MB     = "256"
+MENDER_STORAGE_TOTAL_SIZE_MB = "7400"
+
+# No UEFI capsule on RPi (Mender handles rootfs A/B; firmware blobs are
+# staged best-effort by meta-mender-raspberrypi's
+# update-firmware-state-script).
+WENDYOS_UPDATE_BOOTLOADER ?= "0"
+WENDYOS_EFI_DEBUG ?= "0"
+WENDYOS_DEEPSTREAM ?= "0"
+# Persistent journal can be turned on once /data is verified to be mounted
+# correctly post-Mender; default off for now to preserve existing behavior.
+WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
+WENDYOS_MDNS_INTERFACES ?= ""
+WENDYOS_DEBUG ?= "0"
+
+# RPi boot config (consumed by rpi-config_%.bbappend)
+ENABLE_UART = "1"
+ENABLE_DWC2_PERIPHERAL = "${@oe.utils.ifelse(d.getVar('WENDYOS_USB_GADGET') == '1', '1', '0')}"
+DISABLE_RPI_BOOT_LOGO = "1"
+DISABLE_SPLASH = "1"
+DISABLE_OVERSCAN = "1"
+
+SERIAL_CONSOLES_CHECK = ""
+EXTRADEPS = ""

--- a/conf/machine/raspberrypi3-64-wendyos.conf
+++ b/conf/machine/raspberrypi3-64-wendyos.conf
@@ -1,28 +1,38 @@
 MACHINEOVERRIDES =. "rpi:raspberrypi3-64:"
 require conf/machine/raspberrypi3-64.conf
 
-# WIC MBR image — Mender intentionally NOT enabled here. Two blockers:
-# (1) BCM2837 GPU bootrom only reads MBR-partitioned FAT32, while Mender's
-#     mender-image-sd defaults to GPT. (2) RPi3's 1 GB RAM and typical 4 GB
-#     SD card leave too little headroom for A/B rootfs partitions.
-# Mender layers parse from bblayers/rpi.inc but emit no artifact because
-# 'mender'/'sdimg' aren't in IMAGE_FSTYPES; that's the intended no-op.
-IMAGE_FSTYPES = "wic wic.bmap"
-IMAGE_FSTYPES:remove = "tegraflash dataimg mender uefiimg uefiimg.bmap uefiimg.bz2 sdimg sdimg.bmap rpi-sdimg"
-WKS_FILE = "rpi-mbr.wks"
-
-# Mender client packages are installed image-wide by wendyos-image.bb for
-# every non-QEMU machine, but on RPi3 Mender never runs (no A/B partitions,
-# no /data), so the client would just fail-loop into the journal. Drop the
-# packages explicitly here.
-IMAGE_INSTALL:remove = "mender-configure mender-connect"
+# Mender emits the disk image (sdimg) and OTA artifact (.mender) via
+# mender-image-sd + mender-full from meta-mender-raspberrypi. Drop
+# rpi-sdimg (the legacy meta-raspberrypi single-rootfs image) so it
+# doesn't compete with Mender's sdimg, plus the Tegra/UEFI types that
+# don't apply here. BCM2837 GPU bootrom reads MBR FAT32, which is what
+# mender-image-sd produces by default.
+IMAGE_FSTYPES:remove = "tegraflash dataimg uefiimg uefiimg.bmap uefiimg.bz2 rpi-sdimg"
 LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
 
-# No Mender, no UEFI capsule updates
+# Mender opt-in (wendyos.conf default is off for RPi).
+WENDYOS_MENDER = "1"
+
+# U-Boot is on by default for RPi3 (Mender's upstream-supported path).
+WENDYOS_RPI_UBOOT ?= "1"
+RPI_USE_U_BOOT = "${@'1' if d.getVar('WENDYOS_RPI_UBOOT') == '1' else '0'}"
+
+# Mender storage geometry. SD card on /dev/mmcblk0 with partition suffix 'p'
+# (e.g. /dev/mmcblk0p2). 7400 MiB fits a real 8 GB SD card (~7629 MiB
+# usable); 4 GB cards are not supported.
+MENDER_STORAGE_DEVICE        = "/dev/mmcblk0"
+MENDER_STORAGE_DEVICE_BASE   = "${MENDER_STORAGE_DEVICE}p"
+MENDER_BOOT_PART_SIZE_MB     = "100"
+MENDER_DATA_PART_SIZE_MB     = "256"
+MENDER_STORAGE_TOTAL_SIZE_MB = "7400"
+
+# No UEFI capsule on RPi (Mender handles rootfs A/B; firmware blobs are
+# staged best-effort by meta-mender-raspberrypi's update-firmware-state-script).
 WENDYOS_UPDATE_BOOTLOADER ?= "0"
 WENDYOS_EFI_DEBUG ?= "0"
 WENDYOS_DEEPSTREAM ?= "0"
-# Default persist=off; single partition, no /data
+# Persistent journal can be turned on once /data is verified to be mounted
+# correctly post-Mender; default off for now to preserve existing behavior.
 WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
 # RPi3 B/B+ cannot do USB gadget (LAN9514 hub blocks DWC2 peripheral mode)
 # RPi3 A+ technically can, but requires non-standard cable + external power

--- a/conf/machine/raspberrypi3-64-wendyos.conf
+++ b/conf/machine/raspberrypi3-64-wendyos.conf
@@ -1,13 +1,21 @@
 MACHINEOVERRIDES =. "rpi:raspberrypi3-64:"
 require conf/machine/raspberrypi3-64.conf
 
-# WIC MBR image — no Mender, no tegraflash. The BCM2837 GPU bootrom on the
-# Pi 3 can only read MBR-partitioned FAT32; the GPT layout used on Pi 4/5
-# (rpi-partuuid.wks) leaves the board unable to find bootcode.bin and the
-# system never boots.
+# WIC MBR image — Mender intentionally NOT enabled here. Two blockers:
+# (1) BCM2837 GPU bootrom only reads MBR-partitioned FAT32, while Mender's
+#     mender-image-sd defaults to GPT. (2) RPi3's 1 GB RAM and typical 4 GB
+#     SD card leave too little headroom for A/B rootfs partitions.
+# Mender layers parse from bblayers/rpi.inc but emit no artifact because
+# 'mender'/'sdimg' aren't in IMAGE_FSTYPES; that's the intended no-op.
 IMAGE_FSTYPES = "wic wic.bmap"
-IMAGE_FSTYPES:remove = "tegraflash dataimg mender uefiimg uefiimg.bmap uefiimg.bz2"
+IMAGE_FSTYPES:remove = "tegraflash dataimg mender uefiimg uefiimg.bmap uefiimg.bz2 sdimg sdimg.bmap rpi-sdimg"
 WKS_FILE = "rpi-mbr.wks"
+
+# Mender client packages are installed image-wide by wendyos-image.bb for
+# every non-QEMU machine, but on RPi3 Mender never runs (no A/B partitions,
+# no /data), so the client would just fail-loop into the journal. Drop the
+# packages explicitly here.
+IMAGE_INSTALL:remove = "mender-configure mender-connect"
 LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
 
 # No Mender, no UEFI capsule updates

--- a/conf/machine/raspberrypi3-64-wendyos.conf
+++ b/conf/machine/raspberrypi3-64-wendyos.conf
@@ -1,64 +1,21 @@
 MACHINEOVERRIDES =. "rpi:raspberrypi3-64:"
 require conf/machine/raspberrypi3-64.conf
+require conf/machine/include/raspberrypi-common-wendyos.inc
 
-# Mender emits the disk image (sdimg) and OTA artifact (.mender) via
-# mender-image-sd + mender-full from meta-mender-raspberrypi. Drop
-# rpi-sdimg (the legacy meta-raspberrypi single-rootfs image) so it
-# doesn't compete with Mender's sdimg, plus the Tegra/UEFI types that
-# don't apply here. BCM2837 GPU bootrom reads MBR FAT32, which is what
-# mender-image-sd produces by default.
-IMAGE_FSTYPES:remove = "tegraflash dataimg uefiimg uefiimg.bmap uefiimg.bz2 rpi-sdimg"
-LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
-
-# Mender opt-in (wendyos.conf default is off for RPi).
-WENDYOS_MENDER = "1"
-
-# U-Boot is on by default for RPi3 (Mender's upstream-supported path).
-WENDYOS_RPI_UBOOT ?= "1"
-RPI_USE_U_BOOT = "${@'1' if d.getVar('WENDYOS_RPI_UBOOT') == '1' else '0'}"
-
-# Mender storage geometry. SD card on /dev/mmcblk0 with partition suffix 'p'
-# (e.g. /dev/mmcblk0p2). 7400 MiB fits a real 8 GB SD card (~7629 MiB
-# usable); 4 GB cards are not supported.
-MENDER_STORAGE_DEVICE        = "/dev/mmcblk0"
-MENDER_STORAGE_DEVICE_BASE   = "${MENDER_STORAGE_DEVICE}p"
-MENDER_BOOT_PART_SIZE_MB     = "100"
-MENDER_DATA_PART_SIZE_MB     = "256"
-MENDER_STORAGE_TOTAL_SIZE_MB = "7400"
-
-# No UEFI capsule on RPi (Mender handles rootfs A/B; firmware blobs are
-# staged best-effort by meta-mender-raspberrypi's update-firmware-state-script).
-WENDYOS_UPDATE_BOOTLOADER ?= "0"
-WENDYOS_EFI_DEBUG ?= "0"
-WENDYOS_DEEPSTREAM ?= "0"
-# Persistent journal can be turned on once /data is verified to be mounted
-# correctly post-Mender; default off for now to preserve existing behavior.
-WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
-# RPi3 B/B+ cannot do USB gadget (LAN9514 hub blocks DWC2 peripheral mode)
-# RPi3 A+ technically can, but requires non-standard cable + external power
+# RPi3 B/B+ cannot do USB gadget (LAN9514 hub blocks DWC2 peripheral mode).
+# RPi3 A+ technically can, but requires non-standard cable + external power,
+# so the default stays off.
 WENDYOS_USB_GADGET ?= "0"
-# No usb0 interface on RPi3 — allow mDNS on all interfaces (WiFi/Ethernet)
-WENDYOS_MDNS_INTERFACES ?= ""
-WENDYOS_DEBUG ?= "0"
 
-# RPi3 boot config (consumed by rpi-config_%.bbappend)
-# No dtparam=pciex1 — RPi3 has no PCIe.
-# No UART overlay — Bluetooth stays on PL011 (ttyAMA0), serial console uses the
-# mini UART (ttyS0) on GPIO 14/15. Mini UART baud rate can drift under heavy
-# CPU load (its clock is derived from the VPU clock), so serial output may
-# occasionally garble during boot or under sustained load. Acceptable trade-off
-# for keeping onboard Bluetooth available.
-ENABLE_UART = "1"
-ENABLE_DWC2_PERIPHERAL = "${@oe.utils.ifelse(d.getVar('WENDYOS_USB_GADGET') == '1', '1', '0')}"
-DISABLE_RPI_BOOT_LOGO = "1"
-DISABLE_SPLASH = "1"
-DISABLE_OVERSCAN = "1"
-
-# Mini UART on GPIO 14/15 (upstream default for RPi3)
+# Mini UART on GPIO 14/15 (upstream default for RPi3): Bluetooth keeps the
+# PL011 (ttyAMA0), serial console runs on ttyS0. Mini-UART baud rate is
+# derived from the VPU clock and can drift under heavy CPU load, so serial
+# output may occasionally garble — acceptable trade-off for onboard BT.
 SERIAL_CONSOLES = "115200;ttyS0"
-SERIAL_CONSOLES_CHECK = ""
+
+# No usb0 interface on RPi3 — leave WENDYOS_MDNS_INTERFACES empty so mDNS
+# advertises on all interfaces (WiFi/Ethernet).
 MACHINE_FEATURES:append = " wifi bluetooth"
-EXTRADEPS = ""
 
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "raspberry-pi-3"

--- a/conf/machine/raspberrypi4-64-wendyos.conf
+++ b/conf/machine/raspberrypi4-64-wendyos.conf
@@ -1,63 +1,17 @@
 MACHINEOVERRIDES =. "rpi:raspberrypi4-64:"
 require conf/machine/raspberrypi4-64.conf
+require conf/machine/include/raspberrypi-common-wendyos.inc
 
-# Mender emits the disk image (sdimg) and OTA artifact (.mender) via
-# mender-image-sd + mender-full from meta-mender-raspberrypi. Drop
-# rpi-sdimg (the legacy meta-raspberrypi single-rootfs image) so it
-# doesn't compete with Mender's sdimg, and drop Tegra/UEFI types that
-# don't apply here.
-IMAGE_FSTYPES:remove = "tegraflash dataimg uefiimg uefiimg.bmap uefiimg.bz2 rpi-sdimg"
-LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
-
-# Mender opt-in (wendyos.conf default is off for RPi).
-WENDYOS_MENDER = "1"
-
-# U-Boot is on by default for RPi4 (Mender's upstream-supported path).
-WENDYOS_RPI_UBOOT ?= "1"
-RPI_USE_U_BOOT = "${@'1' if d.getVar('WENDYOS_RPI_UBOOT') == '1' else '0'}"
-
-# Mender storage geometry. SD card on /dev/mmcblk0 with partition suffix 'p'
-# (e.g. /dev/mmcblk0p2). 7400 MiB fits a nominal 8 GB SD card (which is
-# 7629 MiB usable); A and B rootfs partitions split (total - boot - data)
-# ≈ 3.5 GiB each.
-MENDER_STORAGE_DEVICE        = "/dev/mmcblk0"
-MENDER_STORAGE_DEVICE_BASE   = "${MENDER_STORAGE_DEVICE}p"
-MENDER_BOOT_PART_SIZE_MB     = "100"
-MENDER_DATA_PART_SIZE_MB     = "256"
-MENDER_STORAGE_TOTAL_SIZE_MB = "7400"
-
-# No UEFI capsule on RPi (Mender handles rootfs A/B; firmware blobs are
-# staged best-effort by meta-mender-raspberrypi's update-firmware-state-script).
-WENDYOS_UPDATE_BOOTLOADER ?= "0"
-WENDYOS_EFI_DEBUG ?= "0"
-WENDYOS_DEEPSTREAM ?= "0"
-# Persistent journal can be turned on once /data is verified to be mounted
-# correctly post-Mender; default off for now to preserve existing behavior.
-WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
-# RPi4 has an OTG-capable USB-C port — enable gadget by default
+# RPi4 has an OTG-capable USB-C port — enable gadget by default.
 WENDYOS_USB_GADGET ?= "1"
-# Advertise mDNS on both USB gadget and WiFi interfaces
-WENDYOS_MDNS_INTERFACES ?= ""
-WENDYOS_DEBUG ?= "0"
 
-# RPi4 boot config (consumed by rpi-config_%.bbappend)
-# No dtparam=pciex1 — RPi4 has no user-facing PCIe lane.
-# No UART overlay — Bluetooth stays on PL011 (ttyAMA0), serial console uses the
-# mini UART (ttyS0) on GPIO 14/15. Mini UART baud rate can drift under heavy
-# CPU load (its clock is derived from the VPU clock), so serial output may
-# occasionally garble during boot or under sustained load. Acceptable trade-off
-# for keeping onboard Bluetooth available.
-ENABLE_UART = "1"
-ENABLE_DWC2_PERIPHERAL = "${@oe.utils.ifelse(d.getVar('WENDYOS_USB_GADGET') == '1', '1', '0')}"
-DISABLE_RPI_BOOT_LOGO = "1"
-DISABLE_SPLASH = "1"
-DISABLE_OVERSCAN = "1"
-
-# Mini UART on GPIO 14/15 (upstream default for RPi4)
+# Mini UART on GPIO 14/15 (upstream default for RPi4): Bluetooth keeps the
+# PL011 (ttyAMA0), serial console runs on ttyS0. Mini-UART baud rate is
+# derived from the VPU clock and can drift under heavy CPU load, so serial
+# output may occasionally garble — acceptable trade-off for onboard BT.
 SERIAL_CONSOLES = "115200;ttyS0"
-SERIAL_CONSOLES_CHECK = ""
+
 MACHINE_FEATURES:append = " wifi bluetooth usbgadget"
-EXTRADEPS = ""
 
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "raspberry-pi-4"

--- a/conf/machine/raspberrypi4-64-wendyos.conf
+++ b/conf/machine/raspberrypi4-64-wendyos.conf
@@ -1,18 +1,40 @@
 MACHINEOVERRIDES =. "rpi:raspberrypi4-64:"
 require conf/machine/raspberrypi4-64.conf
 
-# WIC GPT image — no Mender, no tegraflash
-IMAGE_FSTYPES = "wic wic.bmap"
-IMAGE_FSTYPES:remove = "tegraflash dataimg mender uefiimg uefiimg.bmap uefiimg.bz2"
-WKS_FILE = "rpi-partuuid.wks"
-WKS_FILE_DEPENDS += "gptfdisk"
+# Mender emits the disk image (sdimg) and OTA artifact (.mender) via
+# mender-image-sd + mender-full from meta-mender-raspberrypi. Drop
+# rpi-sdimg (the legacy meta-raspberrypi single-rootfs image) so it
+# doesn't compete with Mender's sdimg, and drop Tegra/UEFI types that
+# don't apply here.
+IMAGE_FSTYPES:remove = "tegraflash dataimg uefiimg uefiimg.bmap uefiimg.bz2 rpi-sdimg"
 LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
 
-# No Mender, no UEFI capsule updates
+# Mender opt-in (wendyos.conf default is off for RPi).
+WENDYOS_MENDER = "1"
+
+# U-Boot is on by default for RPi4 (Mender's upstream-supported path).
+# Override WENDYOS_RPI_UBOOT="0" in local.conf to fall back to the
+# firmware-only boot used by RPi3.
+WENDYOS_RPI_UBOOT ?= "1"
+RPI_USE_U_BOOT = "${@'1' if d.getVar('WENDYOS_RPI_UBOOT') == '1' else '0'}"
+
+# Mender storage geometry. SD card on /dev/mmcblk0 with partition suffix 'p'
+# (e.g. /dev/mmcblk0p2). 7400 MiB fits a nominal 8 GB SD card (which is
+# 7629 MiB usable); A and B rootfs partitions split (total - boot - data)
+# ≈ 3.5 GiB each.
+MENDER_STORAGE_DEVICE        = "/dev/mmcblk0"
+MENDER_STORAGE_DEVICE_BASE   = "${MENDER_STORAGE_DEVICE}p"
+MENDER_BOOT_PART_SIZE_MB     = "100"
+MENDER_DATA_PART_SIZE_MB     = "256"
+MENDER_STORAGE_TOTAL_SIZE_MB = "7400"
+
+# No UEFI capsule on RPi (Mender handles rootfs A/B; firmware blobs are
+# staged best-effort by meta-mender-raspberrypi's update-firmware-state-script).
 WENDYOS_UPDATE_BOOTLOADER ?= "0"
 WENDYOS_EFI_DEBUG ?= "0"
 WENDYOS_DEEPSTREAM ?= "0"
-# Default persist=off; single partition, no /data
+# Persistent journal can be turned on once /data is verified to be mounted
+# correctly post-Mender; default off for now to preserve existing behavior.
 WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
 # RPi4 has an OTG-capable USB-C port — enable gadget by default
 WENDYOS_USB_GADGET ?= "1"

--- a/conf/machine/raspberrypi4-64-wendyos.conf
+++ b/conf/machine/raspberrypi4-64-wendyos.conf
@@ -13,8 +13,6 @@ LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
 WENDYOS_MENDER = "1"
 
 # U-Boot is on by default for RPi4 (Mender's upstream-supported path).
-# Override WENDYOS_RPI_UBOOT="0" in local.conf to fall back to the
-# firmware-only boot used by RPi3.
 WENDYOS_RPI_UBOOT ?= "1"
 RPI_USE_U_BOOT = "${@'1' if d.getVar('WENDYOS_RPI_UBOOT') == '1' else '0'}"
 

--- a/conf/machine/raspberrypi5-nvme-wendyos.conf
+++ b/conf/machine/raspberrypi5-nvme-wendyos.conf
@@ -1,12 +1,26 @@
 MACHINEOVERRIDES =. "rpi:raspberrypi5-nvme:raspberrypi5:"
 require conf/machine/raspberrypi5-wendyos.conf
 
-# NVMe WKS layout (SD card base uses rpi-partuuid.wks)
-WKS_FILE = "rpi-nvme-partuuid.wks"
+# Override the SD storage geometry inherited from raspberrypi5-wendyos.conf.
+# The parent sets MENDER_STORAGE_DEVICE_BASE = "${MENDER_STORAGE_DEVICE}p"
+# with lazy (deferred) expansion, so overriding MENDER_STORAGE_DEVICE here
+# is enough — NVMe partitions become /dev/nvme0n1p1, /dev/nvme0n1p2, etc.
+# 32000 MiB fits inside any common consumer NVMe (typically 256 GB+).
+MENDER_STORAGE_DEVICE        = "/dev/nvme0n1"
+MENDER_STORAGE_TOTAL_SIZE_MB = "32000"
 
-# dtparam=pciex1 is now inherited from raspberrypi5-wendyos.conf (set there so
-# the SD image can also access the NVMe for SSH-based flashing workflows).
-# Uncomment to override independently if the SD and NVMe configs need to diverge.
+# Mender's get_uboot_interface_from_device helper (in meta-mender-core's
+# mender-helpers.bbclass) only maps /dev/mmcblk* -> "mmc" and bberrors on
+# anything else, so the u-boot do_provide_mender_defines task can't
+# auto-derive the interface for NVMe. Provide the U-Boot interface and
+# device explicitly to skip the autodetect — these end up as the
+# "nvme 0:<hex-part>" prefix in the generated mender_uboot_boot env.
+MENDER_UBOOT_STORAGE_INTERFACE = "nvme"
+MENDER_UBOOT_STORAGE_DEVICE    = "0"
+
+# dtparam=pciex1 is inherited from raspberrypi5-wendyos.conf (set there
+# so the SD image can also access the NVMe for SSH-based flashing
+# workflows). Uncomment to override independently if needed.
 #RPI_EXTRA_CONFIG = "dtparam=pciex1\n"
 
 # Stable board identity written to /etc/wendyos/device-type

--- a/conf/machine/raspberrypi5-wendyos.conf
+++ b/conf/machine/raspberrypi5-wendyos.conf
@@ -1,61 +1,26 @@
 MACHINEOVERRIDES =. "rpi:raspberrypi5:"
 require conf/machine/raspberrypi5.conf
+require conf/machine/include/raspberrypi-common-wendyos.inc
 
-# Mender emits the disk image (sdimg) and OTA artifact (.mender) via
-# mender-image-sd + mender-full from meta-mender-raspberrypi. Drop
-# rpi-sdimg (the legacy meta-raspberrypi single-rootfs image) so it
-# doesn't compete with Mender's sdimg, and drop Tegra/UEFI types that
-# don't apply here.
-IMAGE_FSTYPES:remove = "tegraflash dataimg uefiimg uefiimg.bmap uefiimg.bz2 rpi-sdimg"
-LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
-
-# Mender opt-in (wendyos.conf default is off for RPi).
-WENDYOS_MENDER = "1"
-
-# No UEFI capsule on RPi (Mender handles rootfs A/B; firmware blobs are
-# staged best-effort by meta-mender-raspberrypi's update-firmware-state-script).
-WENDYOS_UPDATE_BOOTLOADER ?= "0"
-WENDYOS_EFI_DEBUG ?= "0"
-WENDYOS_DEEPSTREAM ?= "0"
-# Persistent journal can be turned on once /data is verified to be mounted
-# correctly post-Mender; default off for now to preserve existing behavior.
-WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
+# RPi5 has a dedicated USB-C peripheral controller (BCM2712 dwc2 at
+# /sys/class/udc/1000480000.usb, separate from the RP1 xHCI host ports
+# on USB-A). Enable gadget by default. See
+# meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend and
+# the BCM2712 g_dma=false kernel patch for the full RPi5 gadget story.
 WENDYOS_USB_GADGET ?= "1"
-# Advertise mDNS on both USB gadget and WiFi interfaces
-WENDYOS_MDNS_INTERFACES ?= ""
-WENDYOS_DEBUG ?= "0"
 
-# RPi5 boot config (consumed by rpi-config_%.bbappend)
-# Enable PCIe x1 lane in the kernel device tree.
-# Required for the kernel to access the NVMe drive (e.g. when booting from SD and
-# flashing the NVMe over SSH, or for any data-only NVMe use from the SD image).
+# RPi5 boot config (consumed by rpi-config_%.bbappend):
+# Enable PCIe x1 lane in the kernel device tree. Required for the kernel
+# to access the NVMe drive (e.g. when booting from SD and flashing the
+# NVMe over SSH, or for any data-only NVMe use from the SD image).
 RPI_EXTRA_CONFIG = "dtparam=pciex1\n"
-ENABLE_UART = "1"
-ENABLE_DWC2_PERIPHERAL = "${@oe.utils.ifelse(d.getVar('WENDYOS_USB_GADGET') == '1', '1', '0')}"
-DISABLE_RPI_BOOT_LOGO = "1"
-DISABLE_SPLASH = "1"
-DISABLE_OVERSCAN = "1"
 
+# PL011 is mapped to GPIO 14/15 via dtoverlay=uart0 (see
+# meta-rpi-extensions/recipes-bsp/bootfiles/rpi-config_%.bbappend) so the
+# serial console lands on ttyAMA0, not the mini UART.
 SERIAL_CONSOLES = "115200;ttyAMA0"
-SERIAL_CONSOLES_CHECK = ""
+
 MACHINE_FEATURES:append = " wifi bluetooth usbgadget"
-EXTRADEPS = ""
 
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "raspberry-pi-5"
-
-# U-Boot is on by default for RPi5 (Mender's upstream-supported path).
-# Stock scarthgap U-Boot has no BCM2712 support, so the meta-lts-mixins
-# layer (added in bblayers/rpi.inc) provides u-boot_2025.04.
-WENDYOS_RPI_UBOOT ?= "1"
-RPI_USE_U_BOOT = "${@'1' if d.getVar('WENDYOS_RPI_UBOOT') == '1' else '0'}"
-
-# Mender storage geometry. SD card on /dev/mmcblk0 with partition suffix 'p'
-# (e.g. /dev/mmcblk0p2). 7400 MiB fits a nominal 8 GB SD card (which is
-# 7629 MiB usable); raspberrypi5-nvme-wendyos.conf overrides the device
-# and total size for NVMe.
-MENDER_STORAGE_DEVICE        = "/dev/mmcblk0"
-MENDER_STORAGE_DEVICE_BASE   = "${MENDER_STORAGE_DEVICE}p"
-MENDER_BOOT_PART_SIZE_MB     = "100"
-MENDER_DATA_PART_SIZE_MB     = "256"
-MENDER_STORAGE_TOTAL_SIZE_MB = "7400"

--- a/conf/machine/raspberrypi5-wendyos.conf
+++ b/conf/machine/raspberrypi5-wendyos.conf
@@ -1,18 +1,24 @@
 MACHINEOVERRIDES =. "rpi:raspberrypi5:"
 require conf/machine/raspberrypi5.conf
 
-# WIC GPT image — no Mender, no tegraflash
-IMAGE_FSTYPES = "wic wic.bmap"
-IMAGE_FSTYPES:remove = "tegraflash dataimg mender uefiimg uefiimg.bmap uefiimg.bz2"
-WKS_FILE = "rpi-partuuid.wks"
-WKS_FILE_DEPENDS += "gptfdisk"
+# Mender emits the disk image (sdimg) and OTA artifact (.mender) via
+# mender-image-sd + mender-full from meta-mender-raspberrypi. Drop
+# rpi-sdimg (the legacy meta-raspberrypi single-rootfs image) so it
+# doesn't compete with Mender's sdimg, and drop Tegra/UEFI types that
+# don't apply here.
+IMAGE_FSTYPES:remove = "tegraflash dataimg uefiimg uefiimg.bmap uefiimg.bz2 rpi-sdimg"
 LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
 
-# No Mender, no UEFI capsule updates
+# Mender opt-in (wendyos.conf default is off for RPi).
+WENDYOS_MENDER = "1"
+
+# No UEFI capsule on RPi (Mender handles rootfs A/B; firmware blobs are
+# staged best-effort by meta-mender-raspberrypi's update-firmware-state-script).
 WENDYOS_UPDATE_BOOTLOADER ?= "0"
 WENDYOS_EFI_DEBUG ?= "0"
 WENDYOS_DEEPSTREAM ?= "0"
-# Default persist=off; single partition, no /data
+# Persistent journal can be turned on once /data is verified to be mounted
+# correctly post-Mender; default off for now to preserve existing behavior.
 WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
 WENDYOS_USB_GADGET ?= "1"
 # Advertise mDNS on both USB gadget and WiFi interfaces
@@ -37,3 +43,20 @@ EXTRADEPS = ""
 
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "raspberry-pi-5"
+
+# U-Boot is on by default for RPi5 (Mender's upstream-supported path).
+# Override WENDYOS_RPI_UBOOT="0" in local.conf for a firmware-only-boot
+# debug image. Stock scarthgap U-Boot has no BCM2712 support, so the
+# meta-lts-mixins layer (added in bblayers/rpi.inc) provides u-boot_2025.04.
+WENDYOS_RPI_UBOOT ?= "1"
+RPI_USE_U_BOOT = "${@'1' if d.getVar('WENDYOS_RPI_UBOOT') == '1' else '0'}"
+
+# Mender storage geometry. SD card on /dev/mmcblk0 with partition suffix 'p'
+# (e.g. /dev/mmcblk0p2). 7400 MiB fits a nominal 8 GB SD card (which is
+# 7629 MiB usable); raspberrypi5-nvme-wendyos.conf overrides the device
+# and total size for NVMe.
+MENDER_STORAGE_DEVICE        = "/dev/mmcblk0"
+MENDER_STORAGE_DEVICE_BASE   = "${MENDER_STORAGE_DEVICE}p"
+MENDER_BOOT_PART_SIZE_MB     = "100"
+MENDER_DATA_PART_SIZE_MB     = "256"
+MENDER_STORAGE_TOTAL_SIZE_MB = "7400"

--- a/conf/machine/raspberrypi5-wendyos.conf
+++ b/conf/machine/raspberrypi5-wendyos.conf
@@ -45,9 +45,8 @@ EXTRADEPS = ""
 WENDYOS_BOARD_ID = "raspberry-pi-5"
 
 # U-Boot is on by default for RPi5 (Mender's upstream-supported path).
-# Override WENDYOS_RPI_UBOOT="0" in local.conf for a firmware-only-boot
-# debug image. Stock scarthgap U-Boot has no BCM2712 support, so the
-# meta-lts-mixins layer (added in bblayers/rpi.inc) provides u-boot_2025.04.
+# Stock scarthgap U-Boot has no BCM2712 support, so the meta-lts-mixins
+# layer (added in bblayers/rpi.inc) provides u-boot_2025.04.
 WENDYOS_RPI_UBOOT ?= "1"
 RPI_USE_U_BOOT = "${@'1' if d.getVar('WENDYOS_RPI_UBOOT') == '1' else '0'}"
 

--- a/conf/template/include/bblayers/rpi.inc
+++ b/conf/template/include/bblayers/rpi.inc
@@ -1,13 +1,26 @@
-# RPi-exclusive layers: meta-raspberrypi base, our extensions, and
-# meta-lts-mixins for a backported U-Boot.
+# RPi-exclusive layers: meta-raspberrypi base, our extensions, the
+# upstream Mender layers, and meta-lts-mixins for a backported U-Boot.
 #
-# scarthgap-stock U-Boot has no BCM2712 (RPi5) support. meta-lts-mixins
-# ships u-boot_2025.04.bb which wins over poky-scarthgap's 2024.01.bb
-# by version selection — its scarthgap/u-boot branch is what
-# meta-mender-community's kas integration pulls for every RPi target.
+# meta-lts-mixins ships u-boot_2025.04.bb which wins over
+# poky-scarthgap's u-boot_2024.01.bb by version selection. We need 2025.04
+# for two reasons:
+#   - RPi5 (BCM2712) is unsupported in poky's u-boot_2024.01.bb.
+#   - meta-mender-raspberrypi's U-Boot patches are authored against
+#     2025.04 defconfigs and fail to apply on 2024.01.
+# This mirrors upstream meta-mender-community/kas/include/raspberrypi.yml
+# which pulls meta-lts-mixins for every RPi target (rpi0..rpi5).
+#
+# Mender artifact emission is gated per-machine: RPi3 sets
+# IMAGE_FSTYPES:remove = "... mender ..." in its machine conf (MBR boot
+# is incompatible with Mender's mender-image-sd default), so parsing the
+# Mender recipes is a harmless no-op for RPi3 builds (u-boot likewise
+# parses but doesn't compile because upstream meta-raspberrypi defaults
+# RPI_USE_U_BOOT to "0" when no machine conf opts in).
 
 BBLAYERS += " \
     ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-raspberrypi \
     ${TOPDIR}/../${WENDYOS_META_REPO}/meta-rpi-extensions \
+    ${TOPDIR}/../repos/meta-mender/meta-mender-core \
+    ${TOPDIR}/../repos/meta-mender-community/meta-mender-raspberrypi \
     ${TOPDIR}/../repos/meta-lts-mixins \
     "

--- a/conf/template/include/bblayers/rpi.inc
+++ b/conf/template/include/bblayers/rpi.inc
@@ -1,6 +1,13 @@
-# RPi-exclusive layers: meta-raspberrypi, RPi sub-layer.
+# RPi-exclusive layers: meta-raspberrypi base, our extensions, and
+# meta-lts-mixins for a backported U-Boot.
+#
+# scarthgap-stock U-Boot has no BCM2712 (RPi5) support. meta-lts-mixins
+# ships u-boot_2025.04.bb which wins over poky-scarthgap's 2024.01.bb
+# by version selection — its scarthgap/u-boot branch is what
+# meta-mender-community's kas integration pulls for every RPi target.
 
 BBLAYERS += " \
     ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-raspberrypi \
     ${TOPDIR}/../${WENDYOS_META_REPO}/meta-rpi-extensions \
+    ${TOPDIR}/../repos/meta-lts-mixins \
     "

--- a/conf/template/include/bblayers/rpi.inc
+++ b/conf/template/include/bblayers/rpi.inc
@@ -10,12 +10,11 @@
 # This mirrors upstream meta-mender-community/kas/include/raspberrypi.yml
 # which pulls meta-lts-mixins for every RPi target (rpi0..rpi5).
 #
-# Mender artifact emission is gated per-machine: RPi3 sets
-# IMAGE_FSTYPES:remove = "... mender ..." in its machine conf (MBR boot
-# is incompatible with Mender's mender-image-sd default), so parsing the
-# Mender recipes is a harmless no-op for RPi3 builds (u-boot likewise
-# parses but doesn't compile because upstream meta-raspberrypi defaults
-# RPI_USE_U_BOOT to "0" when no machine conf opts in).
+# All 64-bit RPi machines (RPi3/4/5) share UBOOT_MACHINE = "rpi_arm64_config"
+# upstream, so meta-mender-raspberrypi's U-Boot patches apply identically
+# to each. Per-machine Mender storage geometry lives in the machine confs
+# (RPi3/4 and RPi5-SD use 7400 MiB total; RPi5-NVMe overrides to 32 GiB).
+# All three default WENDYOS_RPI_UBOOT="1".
 
 BBLAYERS += " \
     ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-raspberrypi \

--- a/conf/template/include/bblayers/rpi.inc
+++ b/conf/template/include/bblayers/rpi.inc
@@ -19,7 +19,7 @@
 BBLAYERS += " \
     ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-raspberrypi \
     ${TOPDIR}/../${WENDYOS_META_REPO}/meta-rpi-extensions \
-    ${TOPDIR}/../repos/meta-mender/meta-mender-core \
-    ${TOPDIR}/../repos/meta-mender-community/meta-mender-raspberrypi \
-    ${TOPDIR}/../repos/meta-lts-mixins \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-mender/meta-mender-core \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-mender-community/meta-mender-raspberrypi \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-lts-mixins \
     "

--- a/conf/template/include/local/rpi.inc
+++ b/conf/template/include/local/rpi.inc
@@ -1,2 +1,10 @@
 # RPi defaults: volatile journal logs in tmpfs (no /data partition).
 WENDYOS_PERSIST_JOURNAL_LOGS = "0"
+
+# Pin U-Boot to the meta-lts-mixins backport (u-boot_2025.04.bb). The
+# poky-scarthgap recipe (u-boot_2024.01.bb) has no BCM2712 support and
+# meta-mender-raspberrypi's U-Boot patches are authored against 2025.04
+# defconfigs. Without this pin we would rely on PV-comparison alone,
+# which silently flips if poky later bumps its bundled U-Boot.
+PREFERRED_VERSION_u-boot = "2025.04%"
+PREFERRED_VERSION_u-boot-tools = "2025.04%"

--- a/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,15 +1,27 @@
 inherit partuuid-rpi
 
-CMDLINE_ROOT_PARTITION:rpi = "PARTUUID=${WENDYOS_ROOT_PARTUUID}"
-# RPi3 boots from an MBR-partitioned card; the kernel reports MBR PARTUUIDs as
-# <disksig>-<partno>, not as the UUIDv4 we generate, so reference root by its
-# filesystem label (set in wic/rpi-mbr.wks) instead.
+# RPi3 (MBR-partitioned card): the kernel reports MBR PARTUUIDs as
+# <disksig>-<partno>, not as the UUIDv4 we generate, so reference root
+# by its filesystem label (set in wic/rpi-mbr.wks).
 #
-# Override is pinned to :raspberrypi3-64 (not :raspberrypi3) on purpose: with
-# MACHINEOVERRIDES "raspberrypi3:rpi:raspberrypi3-64:..." the rightmost match
-# wins, so :raspberrypi3 would lose to :rpi above. :raspberrypi3-64 sits after
-# :rpi and overrides it.
+# Override is pinned to :raspberrypi3-64 (not :raspberrypi3) on purpose:
+# MACHINEOVERRIDES "raspberrypi3:rpi:raspberrypi3-64:..." has rightmost
+# match winning, so :raspberrypi3-64 sits after :rpi defaults.
 CMDLINE_ROOT_PARTITION:raspberrypi3-64 = "LABEL=root"
-CMDLINE_ROOTFS:rpi = "console=serial0,115200 root=${CMDLINE_ROOT_PARTITION} rootfstype=ext4 fsck.repair=yes rootwait"
-CMDLINE_ROOTFS:append:rpi = "${@' modules-load=dwc2' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
+CMDLINE_ROOTFS:raspberrypi3-64 = "console=serial0,115200 root=${CMDLINE_ROOT_PARTITION} rootfstype=ext4 fsck.repair=yes rootwait"
+
+# RPi4 and RPi5 use Mender's U-Boot path. The bbappend in
+# meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+# conditionally includes rpi-cmdline-mender.inc, which removes the
+# upstream "root=/dev/mmcblk0p2" default and appends
+# "root=${mender_kernel_root}" — U-Boot resolves that at boot to the
+# active A/B slot. We only contribute the WendyOS console + USB-gadget
+# additions so two `root=` arguments don't end up on the cmdline.
+WENDYOS_RPI_CMDLINE_EXTRAS = " console=serial0,115200${@' modules-load=dwc2' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
+CMDLINE_ROOTFS:append:raspberrypi4-64 = "${WENDYOS_RPI_CMDLINE_EXTRAS}"
+# raspberrypi5-nvme inherits the :raspberrypi5 append via MACHINEOVERRIDES
+# (=. "rpi:raspberrypi5-nvme:raspberrypi5:") — no separate :raspberrypi5-nvme
+# entry needed (and adding one would double the extras on the cmdline).
+CMDLINE_ROOTFS:append:raspberrypi5 = "${WENDYOS_RPI_CMDLINE_EXTRAS}"
+
 do_deploy[depends] += "${PN}:do_generate_partuuids"

--- a/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -3,9 +3,26 @@ inherit partuuid-rpi
 # All Mender-enabled RPi machines (RPi3/4/5) let meta-mender-raspberrypi's
 # rpi-cmdline.bbappend manage `root=` via ${mender_kernel_root} (U-Boot
 # resolves it at boot to the active A/B slot). We only contribute WendyOS
-# console + USB-gadget additions via :append:rpi, which fires once for any
-# RPi machine — future RPi variants pick this up automatically without
-# enumerating them here.
+# console + USB-gadget additions via :append:rpi.
+#
+# `modules-load=dwc2` is correct for every WendyOS RPi target that opts
+# into USB gadget mode:
+#   - RPi3 A+ (and Zero 2 W / CM3+): BCM283x dwc2 peripheral controller.
+#   - RPi4:                          BCM2711 dwc2 controller (USB-C OTG).
+#   - RPi5:                          BCM2712 has its own dwc2 IP block at
+#                                    /sys/class/udc/1000480000.usb, wired
+#                                    to the USB-C port. This is separate
+#                                    from the RP1 southbridge's xHCI host
+#                                    controllers driving the USB-A ports.
+# A separate BCM2712-specific patch in this layer
+# (0001-dwc2-force-g_dma-false-for-BCM2712-in-peripheral-mod.patch) forces
+# PIO mode so gadget DMA actually works on RPi5.
+#
+# RPi3 B/B+ has WENDYOS_USB_GADGET=0 (LAN9514 hub blocks dwc2 peripheral
+# mode), so the modules-load clause is inert there.
+#
+# A hypothetical future RPi without a dwc2 peripheral controller would
+# need its own :append:<machine> override.
 WENDYOS_RPI_CMDLINE_EXTRAS = " console=serial0,115200${@' modules-load=dwc2' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
 CMDLINE_ROOTFS:append:rpi = "${WENDYOS_RPI_CMDLINE_EXTRAS}"
 

--- a/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,27 +1,12 @@
 inherit partuuid-rpi
 
-# RPi3 (MBR-partitioned card): the kernel reports MBR PARTUUIDs as
-# <disksig>-<partno>, not as the UUIDv4 we generate, so reference root
-# by its filesystem label (set in wic/rpi-mbr.wks).
-#
-# Override is pinned to :raspberrypi3-64 (not :raspberrypi3) on purpose:
-# MACHINEOVERRIDES "raspberrypi3:rpi:raspberrypi3-64:..." has rightmost
-# match winning, so :raspberrypi3-64 sits after :rpi defaults.
-CMDLINE_ROOT_PARTITION:raspberrypi3-64 = "LABEL=root"
-CMDLINE_ROOTFS:raspberrypi3-64 = "console=serial0,115200 root=${CMDLINE_ROOT_PARTITION} rootfstype=ext4 fsck.repair=yes rootwait"
-
-# RPi4 and RPi5 use Mender's U-Boot path. The bbappend in
-# meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
-# conditionally includes rpi-cmdline-mender.inc, which removes the
-# upstream "root=/dev/mmcblk0p2" default and appends
-# "root=${mender_kernel_root}" — U-Boot resolves that at boot to the
-# active A/B slot. We only contribute the WendyOS console + USB-gadget
-# additions so two `root=` arguments don't end up on the cmdline.
+# All Mender-enabled RPi machines (RPi3/4/5) let meta-mender-raspberrypi's
+# rpi-cmdline.bbappend manage `root=` via ${mender_kernel_root} (U-Boot
+# resolves it at boot to the active A/B slot). We only contribute WendyOS
+# console + USB-gadget additions via :append:rpi, which fires once for any
+# RPi machine — future RPi variants pick this up automatically without
+# enumerating them here.
 WENDYOS_RPI_CMDLINE_EXTRAS = " console=serial0,115200${@' modules-load=dwc2' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
-CMDLINE_ROOTFS:append:raspberrypi4-64 = "${WENDYOS_RPI_CMDLINE_EXTRAS}"
-# raspberrypi5-nvme inherits the :raspberrypi5 append via MACHINEOVERRIDES
-# (=. "rpi:raspberrypi5-nvme:raspberrypi5:") — no separate :raspberrypi5-nvme
-# entry needed (and adding one would double the extras on the cmdline).
-CMDLINE_ROOTFS:append:raspberrypi5 = "${WENDYOS_RPI_CMDLINE_EXTRAS}"
+CMDLINE_ROOTFS:append:rpi = "${WENDYOS_RPI_CMDLINE_EXTRAS}"
 
 do_deploy[depends] += "${PN}:do_generate_partuuids"

--- a/recipes-core/base-files/rpi-base-files.inc
+++ b/recipes-core/base-files/rpi-base-files.inc
@@ -19,13 +19,25 @@ RPI_FSTAB_TEMPLATE = "rpi-fstab"
 RPI_FSTAB_TEMPLATE:raspberrypi3-64 = "rpi-mbr-fstab"
 
 do_install:append() {
-    install -m 0644 ${WORKDIR}/${RPI_FSTAB_TEMPLATE} ${D}${sysconfdir}/fstab
-    sed -i "s/RPI_BOOT_UUID/${WENDYOS_BOOT_PARTUUID}/g" ${D}${sysconfdir}/fstab
-    sed -i "s/RPI_ROOT_UUID/${WENDYOS_ROOT_PARTUUID}/g" ${D}${sysconfdir}/fstab
+    if [ "${WENDYOS_RPI_UBOOT}" = "1" ]; then
+        # Mender-managed layout: 4 partitions (boot/A/B/data), MBR disklabel.
+        # The poky-stock /etc/fstab (already installed by base-files's own
+        # do_install) is correct here — the kernel mounts / via the
+        # ${mender_kernel_root} cmdline arg, and Mender's image-build
+        # postprocess appends /data (and /uboot if MENDER_BOOT_PART_MOUNT_LOCATION
+        # is set). Our rpi-fstab references /boot by GPT-style PARTUUID and a
+        # /config label-mount; neither device exists in the Mender layout, so
+        # systemd would block 90s on each before dropping to emergency.
+        :
+    else
+        install -m 0644 ${WORKDIR}/${RPI_FSTAB_TEMPLATE} ${D}${sysconfdir}/fstab
+        sed -i "s/RPI_BOOT_UUID/${WENDYOS_BOOT_PARTUUID}/g" ${D}${sysconfdir}/fstab
+        sed -i "s/RPI_ROOT_UUID/${WENDYOS_ROOT_PARTUUID}/g" ${D}${sysconfdir}/fstab
+    fi
 }
 
-# Trigger a rebuild whenever the PARTUUIDs or selected template change
-do_install[vardeps] += " WENDYOS_BOOT_PARTUUID WENDYOS_ROOT_PARTUUID RPI_FSTAB_TEMPLATE"
+# Trigger a rebuild whenever the inputs to fstab generation change
+do_install[vardeps] += " WENDYOS_BOOT_PARTUUID WENDYOS_ROOT_PARTUUID RPI_FSTAB_TEMPLATE WENDYOS_RPI_UBOOT"
 
 # systemd persistent log
 # If /var/log is a symlink into /var/volatile/log, journald cannot persist logs

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -69,9 +69,11 @@ IMAGE_INSTALL:append = " \
     "
 
 # Mender userspace packages — gated on WENDYOS_MENDER (set in wendyos.conf
-# and overridable per-machine).
+# and overridable per-machine). python3-pip-jetson-config lives in
+# meta-tegra-extensions, so it's split out as Tegra-only.
 IMAGE_INSTALL:append = " \
-    ${@'mender-configure mender-connect python3-pip-jetson-config' if d.getVar('WENDYOS_MENDER') == '1' else ''} \
+    ${@'mender-configure mender-connect' if d.getVar('WENDYOS_MENDER') == '1' else ''} \
+    ${@'python3-pip-jetson-config' if 'tegra' in d.getVar('MACHINEOVERRIDES').split(':') else ''} \
     "
 
 # Enable USB peripheral (gadget) support for real hardware

--- a/scripts/upstream-repos.env
+++ b/scripts/upstream-repos.env
@@ -34,6 +34,7 @@ URL_VIRT="https://git.yoctoproject.org/meta-virtualization.git"
 URL_MENDER="https://github.com/mendersoftware/meta-mender.git"
 URL_MENDER_COMM="https://github.com/mendersoftware/meta-mender-community.git"
 URL_RPI="https://github.com/agherzan/meta-raspberrypi.git"
+URL_LTS_MIXINS="https://git.yoctoproject.org/meta-lts-mixins"
 
 SRCREV_BITBAKE="8dcf084522b9c66a6639b5f117f554fde9b6b45a"
 SRCREV_OECORE="d50e4680ed6f930582d907b37c9ed545a89f5c27"
@@ -45,3 +46,7 @@ SRCREV_VIRT="f92518e20530edfebca45e4170e11460949a5303"
 SRCREV_MENDER="76404a7b914676a57d76ccb5fe12149112c05c03"
 SRCREV_MENDER_COMM="9145b8e34bac23c82984ddcdd5468154ffe7af6d"
 SRCREV_RPI="3afc9728b1f4ba0f5be1af34883d6582966133a1"
+# scarthgap/u-boot branch — provides backported U-Boot for RPi5 (BCM2712).
+# Pin matches meta-mender-community/kas/include/raspberrypi.yml so the kas
+# integration recipe and our bitbake build see the same revision.
+SRCREV_LTS_MIXINS="a44882db02a0ed0f149371831bfbe067665eb42b"


### PR DESCRIPTION
Added OTA support for RPi.
Tested and confirmed for RPi3 and RPi4.

It has NOT been tested on RPi5 and it is possible we need to make adjustments. 