### PR TITLE
fix(ci): replace dropped android-tools-fsutils with android-sdk-libsparse-utils

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -438,7 +438,7 @@ jobs:
           # simg2img converts Android sparse ext4 images to raw; needed by
           # make-thor-nvme-img.py to write APP/APP_b into the Thor NVMe image.
           if [[ "$DEVICE" == "jetson-agx-thor" ]]; then
-            sudo apt-get install -y android-tools-fsutils
+            sudo apt-get install -y android-sdk-libsparse-utils
           fi
 
       - name: Generate flashable image (Jetson)

--- a/scripts/make-thor-nvme-img.py
+++ b/scripts/make-thor-nvme-img.py
@@ -12,7 +12,7 @@ image creation that doexternal.sh provides for Orin/Nano:
   4. Copy each partition's binary content at the right sector offset.
      .simg files (Android sparse ext4) are converted with simg2img first.
 
-Requires: sgdisk (gdisk package), simg2img (android-tools-fsutils package)
+Requires: sgdisk (gdisk package), simg2img (android-sdk-libsparse-utils package)
 
 Usage:
     python3 make-thor-nvme-img.py <bundle_dir> <output_img>


### PR DESCRIPTION
## Summary

- `android-tools-fsutils` no longer has an installation candidate on Ubuntu Noble — the package was obsoleted and replaced by `android-sdk-libsparse-utils`
- Updates the Thor NVMe CI step that installs `simg2img` to use the correct package name
- Updates the matching comment in `make-thor-nvme-img.py`

## Root cause

The `Build jetson-agx-thor (nvme)` job was failing at **Install flashable image dependencies** with:
```
E: Package 'android-tools-fsutils' has no installation candidate
```
Ubuntu Noble ships `simg2img` via `android-sdk-libsparse-utils` instead.

## Test plan

- [ ] Re-run `Build jetson-agx-thor (nvme)` CI job and confirm the install step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)