### PR TITLE
fix(ci): correct path to make-thor-nvme-img.py (repo checks out under wendyos/)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -462,7 +462,7 @@ jobs:
             # bundle remains available as the recovery-flash artifact.
             TEGRAFLASH_TAR="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
             tar -xf "$TEGRAFLASH_TAR" -C "$FLASH_WORKDIR"
-            python3 "$GITHUB_WORKSPACE/scripts/make-thor-nvme-img.py" \
+            python3 "$GITHUB_WORKSPACE/wendyos/scripts/make-thor-nvme-img.py" \
               "$FLASH_WORKDIR" "$GITHUB_WORKSPACE/wendyos-nvme.img"
             exit 0
           fi


### PR DESCRIPTION
## Summary

- The `Generate flashable image` step was failing for `jetson-agx-thor` with `python3: can't open file '.../scripts/make-thor-nvme-img.py': No such file or directory`
- The main `Checkout` step uses `path: wendyos`, so the repo is at `$GITHUB_WORKSPACE/wendyos/` — the script path in the run step was missing that prefix

## Root cause

```
python3 "$GITHUB_WORKSPACE/scripts/make-thor-nvme-img.py" ...
#                          ↑ missing /wendyos/
```

Fixed to:

```
python3 "$GITHUB_WORKSPACE/wendyos/scripts/make-thor-nvme-img.py" ...
```

## Test plan

- [ ] `Build jetson-agx-thor (nvme)` CI job passes the `Generate flashable image` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)