### PR TITLE
fix(thor): move -a 1 after --clear in sgdisk call

### DIFF
--- a/scripts/make-thor-nvme-img.py
+++ b/scripts/make-thor-nvme-img.py
@@ -101,7 +101,9 @@ def create_gpt(img_path, sector_size, partitions):
     # + partition entries).  First usable LBA is 34.
     current_lba = 34
 
-    cmd = ["sgdisk", "-a", "1", "--clear"]
+    # --clear resets alignment to the default (2048 sectors); -a 1 must come
+    # after --clear so the 1-sector alignment takes effect for --new entries.
+    cmd = ["sgdisk", "--clear", "-a", "1"]
 
     for p in partitions:
         size_sectors = (p["size_bytes"] + sector_size - 1) // sector_size


### PR DESCRIPTION
## Summary

- `sgdisk --clear` resets alignment back to the 2048-sector default
- With `-a 1` placed *before* `--clear`, the alignment setting was silently discarded
- Partition 3 (recovery) was snapped from LBA 34 → 2048, which made it overlap partition 4 (recovery-dtb at 163874–165409), causing sgdisk to abort with exit code 4

## Fix

Move `-a 1` after `--clear` so 1-sector alignment is active when the `--new` entries are processed, placing each partition at the exact offsets derived from `external-flash.xml.in`.

```
Before: sgdisk -a 1 --clear --new=3:34:163873 ...   ← --clear resets alignment
After:  sgdisk --clear -a 1 --new=3:34:163873 ...   ← -a 1 takes effect
```

## Test plan

- [ ] `Build jetson-agx-thor (nvme)` CI job passes `Generate flashable image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)