### PR TITLE
fix(ci): use .sdimg for Mender-enabled RPi uploads; add rpi-5 --storage flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -518,7 +518,14 @@ jobs:
           elif [[ "$MACHINE" != raspberry* && "$STORAGE" == "sd" ]]; then
             IMAGE_FILE="$GITHUB_WORKSPACE/wendyos-sd.img"
           else
-            IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.rootfs.wic"
+            # Mender-enabled RPi builds (post-PR-79) produce .sdimg (A/B slot
+            # image); fall back to .rootfs.wic for any non-Mender RPi build.
+            SDIMG="$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg"
+            if [[ -f "$SDIMG" ]]; then
+              IMAGE_FILE="$SDIMG"
+            else
+              IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.rootfs.wic"
+            fi
           fi
 
           ARGS=(
@@ -543,7 +550,7 @@ jobs:
 
           # Devices with multiple storage variants pass --storage so the manifest
           # records the correct per-storage-type paths.
-          if [[ "$DEVICE" == "jetson-orin-nano" || "$DEVICE" == "jetson-agx-orin" ]]; then
+          if [[ "$DEVICE" == "jetson-orin-nano" || "$DEVICE" == "jetson-agx-orin" || "$DEVICE" == "raspberry-pi-5" ]]; then
             ARGS+=(--storage "$STORAGE")
           fi
 


### PR DESCRIPTION
## Summary

PR #79 enabled Mender OTA on all RPi targets, switching the build output from `.rootfs.wic` to `.sdimg` (A/B slot Mender image). The upload step still hardcoded `.rootfs.wic` for all RPi targets, causing every RPi upload job to fail with:

```
level=fatal msg="Invalid main file" error="file does not exist: .../wendyos-image-<machine>.rootfs.wic"
```

## Changes

- **RPi image selection**: prefer `.sdimg` over `.rootfs.wic` — mirrors the same fallback logic already added to the `Makefile` in PR #79; non-Mender RPi builds that still emit `.wic` keep working
- **`raspberry-pi-5` `--storage` flag**: RPi5 has sd and nvme variants, so the manifest needs to record the storage type, the same way Orin/Nano Jetsons already do
- **Mender OTA artifact**: the `--ota-update` search over `DEPLOY_DIR` for `*.mender` files already covers RPi generically — no additional changes needed; once builds pass, `.mender` artifacts are uploaded automatically

## Test plan

- [ ] All four RPi build jobs (rpi-3/sd, rpi-4/sd, rpi-5/sd, rpi-5/nvme) pass `Upload image and update device manifest`
- [ ] RPi5-nvme manifest entry shows storage type correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)