### PR TITLE
feat(image): Jetson camera GStreamer stack (nvarguscamerasrc + nvvidconv + v4l-utils)

### DIFF
--- a/conf/distro/include/tegra-image.inc
+++ b/conf/distro/include/tegra-image.inc
@@ -29,6 +29,9 @@ IMAGE_INSTALL:append = " \
     ${@'mender-esp' if d.getVar('WENDYOS_MENDER') == '1' else ''} \
     packagegroup-wendyos-tegra \
     gstreamer1.0-plugins-nvvideo4linux2 \
+    gstreamer1.0-plugins-nvarguscamerasrc \
+    gstreamer1.0-plugins-nvvidconv \
+    v4l-utils \
     "
 
 # Enable DeepStream SDK support (optional - adds ~1GB to image)


### PR DESCRIPTION
## What

Adds the NVIDIA Argus camera GStreamer stack to the WendyOS Jetson image so a CSI/ribbon camera (e.g. Arducam IMX477) can actually be captured.

Single source edit in `conf/distro/include/tegra-image.inc` — three packages added to the existing Tegra-guarded `IMAGE_INSTALL:append`:

- `gstreamer1.0-plugins-nvarguscamerasrc` → element `nvarguscamerasrc` (`libgstnvarguscamerasrc.so`), the Argus CSI capture source
- `gstreamer1.0-plugins-nvvidconv` → element `nvvidconv` (`libgstnvvidconv.so`), the canonical Tegra colorspace/format converter
- `v4l-utils` → `/usr/bin/v4l2-ctl` for camera debugging

This block is `require`d from `wendyos-image.bb` only when `'tegra' in MACHINEOVERRIDES`, so the new packages are automatically scoped to Jetson and excluded from non-Tegra boards.

## Why / root cause

On the live device (Jetson Orin Nano, WendyOS-0.15.0, L4T r36.4.4) the camera hardware works all the way up through the kernel: with an IMX477 in CAM1, `imx477 9-001a` binds, `/dev/video0` exists, and the media graph is `imx477 → nvcsi → vi-output` at `SRGGB10 3840x2160@30`.

The only blocker was **userspace capture** — the image shipped the `nvv4l2` encoders but **no camera source plugin**:

- `gst-inspect-1.0 nvarguscamerasrc` → MISSING (no `.so` on disk)
- `gst-inspect-1.0 nvvidconv` → MISSING
- `v4l2src` fails `not-negotiated (-4)` on the raw-Bayer Tegra pipeline (expected — plain V4L2 can't drive Tegra VI)
- libcamera has no Tegra pipeline handler on L4T (`cam --list` → zero cameras)

Neither plugin recipe was referenced anywhere in the repo (grep across `*.bb`/`*.inc`/`*.conf`/`*.bbappend` = 0 hits). The recipes exist in meta-tegra and build cleanly; they just weren't installed into the image.

## Verification (pending — to be completed after flashing)

This PR is a **draft** until the rebuilt image is flashed to the device and the on-device acceptance test passes. Tracking checklist:

- [ ] Build `wendyos-image` for `jetson-orin-nano-devkit-nvme-wendyos`; confirm `nvarguscamerasrc`, `nvvidconv`, `v4l-utils` appear in the rootfs `.manifest`
- [ ] `.mender` OTA artifact produced
- [ ] Deploy via Mender OTA + reboot (camera seated in CAM1)
- [ ] `gst-inspect-1.0 nvarguscamerasrc` → PRESENT, `nvvidconv` → PRESENT, `v4l2-ctl` present
- [ ] End-to-end capture: `nvarguscamerasrc sensor-id=0 num-buffers=30 ! 'video/x-raw(memory:NVMM),1920x1080@30' ! nvvidconv ! fakesink` → `Got EOS`, no `ERROR`
- [ ] HW encode: `nvarguscamerasrc ! nvv4l2h264enc ! h264parse ! fakesink` → `Got EOS`, no `ERROR`

(`nvarguscamerasrc` is chatty on stderr with `GST_ARGUS:` info lines even on success — that's expected, not a failure.)

## Rollback

Mender A/B means the previous image stays in the other slot; `mender-update rollback` restores prior state. No reflash needed.

Refs WDY-1249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
