### PR TITLE
fix(ci): port Jetson flashable image fixes from build.yml into release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,22 @@ jobs:
           fi
 
           cd "$GITHUB_WORKSPACE/wendy-os-publisher/cmd"
-          go run upload_and_manifest.go "${ARGS[@]}"
+          # Outer retry mirrors build.yml: handles 412 races when multiple matrix
+          # jobs for the same device write to the same manifest concurrently.
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            if go run upload_and_manifest.go "${ARGS[@]}"; then
+              break
+            fi
+            if [ "$attempt" -lt 10 ]; then
+              JITTER=$((RANDOM % 30))
+              SLEEP_TIME=$((attempt * 20 + JITTER))
+              echo "Outer attempt $attempt failed, sleeping ${SLEEP_TIME}s before retry..."
+              sleep "$SLEEP_TIME"
+            else
+              echo "All outer attempts exhausted"
+              exit 1
+            fi
+          done
 
   create-github-release:
     name: Create GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,16 +123,46 @@ jobs:
         with:
           go-version-file: wendy-os-publisher/go.mod
 
+      - name: Install flashable image dependencies (Jetson only)
+        if: startsWith(matrix.device, 'jetson-')
+        env:
+          DEVICE: ${{ matrix.device }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y device-tree-compiler
+          # simg2img converts Android sparse ext4 images to raw; needed by
+          # make-thor-nvme-img.py to write APP/APP_b into the Thor NVMe image.
+          if [[ "$DEVICE" == "jetson-agx-thor" ]]; then
+            sudo apt-get install -y android-sdk-libsparse-utils
+          fi
+
       - name: Generate flashable image (Jetson)
         if: startsWith(matrix.device, 'jetson-')
         env:
           DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
           MACHINE: ${{ steps.vars.outputs.machine }}
+          DEVICE: ${{ matrix.device }}
           STORAGE: ${{ matrix.storage }}
         run: |
-          TEGRAFLASH_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz"
           FLASH_WORKDIR="$GITHUB_WORKSPACE/flash-work"
           mkdir -p "$FLASH_WORKDIR"
+
+          if [[ "$DEVICE" == "jetson-agx-thor" ]]; then
+            # Thor (JP7/L4T r38.4.x / T264): the tegraflash-tar bundle does not
+            # include doexternal.sh.  make-thor-nvme-img.py reimplements the same
+            # offline GPT image creation by parsing external-flash.xml.in and
+            # writing each partition's binary at the correct sector offset.
+            # The resulting wendyos-nvme.img is the primary artifact for
+            # `wendy os install` (dd-based provisioning); the tegraflash-tar
+            # bundle remains available as the recovery-flash artifact.
+            TEGRAFLASH_TAR="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
+            tar -xf "$TEGRAFLASH_TAR" -C "$FLASH_WORKDIR"
+            python3 "$GITHUB_WORKSPACE/wendyos/scripts/make-thor-nvme-img.py" \
+              "$FLASH_WORKDIR" "$GITHUB_WORKSPACE/wendyos-nvme.img"
+            exit 0
+          fi
+
+          TEGRAFLASH_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz"
           tar -xzf "$TEGRAFLASH_FILE" -C "$FLASH_WORKDIR"
           if [[ "$STORAGE" != "nvme" && ! -f "$FLASH_WORKDIR/config-partition.fat32.img" ]]; then
             cp "$DEPLOY_DIR/config-partition.fat32.img" "$FLASH_WORKDIR/"
@@ -150,13 +180,7 @@ jobs:
           fi
           cd "$FLASH_WORKDIR"
           case "$STORAGE" in
-            nvme)
-              # Thor (JP7, Phase 1): tegraflash bundle is the primary deliverable.
-              # doexternal.sh is not used; the tarball itself is uploaded as IMAGE_FILE.
-              if [[ "$DEVICE" != "jetson-agx-thor" ]]; then
-                sudo ./doexternal.sh -s 64G "$GITHUB_WORKSPACE/wendyos-nvme.img"
-              fi
-              ;;
+            nvme)  sudo ./doexternal.sh -s 64G "$GITHUB_WORKSPACE/wendyos-nvme.img" ;;
             # eMMC uses sdmmc_user device type; meta-tegra never generates dosdcard.sh for it.
             # The tegraflash tarball is the correct recovery-flash artifact for eMMC.
             emmc) : ;;
@@ -174,10 +198,9 @@ jobs:
           TOKEN=$(gcloud auth print-access-token)
           RELEASE_VERSION="${RELEASE_VERSION#v}"
 
-          if [[ "$DEVICE" == "jetson-agx-thor" ]]; then
-            # Thor Phase 1: tegraflash bundle is the primary artifact (no standalone disk image).
-            IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz"
-          elif [[ "$MACHINE" != raspberry* && "$STORAGE" == "nvme" ]]; then
+          if [[ "$MACHINE" != raspberry* && "$STORAGE" == "nvme" ]]; then
+            # Covers Thor (wendyos-nvme.img from make-thor-nvme-img.py) and all
+            # other NVMe Jetsons (wendyos-nvme.img from doexternal.sh).
             IMAGE_FILE="$GITHUB_WORKSPACE/wendyos-nvme.img"
           elif [[ "$MACHINE" != raspberry* && "$STORAGE" == "emmc" ]]; then
             # No offline disk image for eMMC (meta-tegra doesn't generate dosdcard.sh for
@@ -202,9 +225,15 @@ jobs:
             --access-token "$TOKEN"
           )
 
-          # For all Jetson targets, include the tegraflash bundle as the recovery file.
+          # For all Jetson targets, include the tegraflash bundle as the recovery file
+          # (used for USB recovery-mode flashing via tegraflash.py / initrd-flash).
+          # Thor uses .tegraflash-tar (JP7/r38.4.x renamed the type); others use .tegraflash.tar.gz.
           if [[ "$MACHINE" != raspberry* ]]; then
-            ARGS+=(--recovery-file "$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz")
+            if [[ "$DEVICE" == "jetson-agx-thor" ]]; then
+              ARGS+=(--recovery-file "$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar")
+            else
+              ARGS+=(--recovery-file "$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz")
+            fi
           fi
 
           # Devices with multiple storage variants pass --storage so the manifest


### PR DESCRIPTION
## Summary

- **WDY-1306**: Add missing "Install flashable image dependencies (Jetson only)" step — installs `device-tree-compiler` (and `android-sdk-libsparse-utils` for thor) on the host runner before `doexternal.sh` is called. Without this, agx-orin and orin-nano nvme release builds fail with `ERR: 'dtc' command not found`.
- **WDY-1305**: Port the thor-specific "Generate flashable image" early-exit path from `build.yml` — opens `.tegraflash-tar` (not `.tegraflash.tar.gz`) and calls `make-thor-nvme-img.py`. Also adds `DEVICE` to the step env (was missing, so `$DEVICE` was always empty string).
- Fix thor `IMAGE_FILE` in "Publish release to GCS": thor now produces `wendyos-nvme.img` via `make-thor-nvme-img.py`, same as other nvme Jetsons — remove the stale special-case that uploaded `tegraflash.tar.gz` as the primary artifact.
- Fix thor recovery file extension in "Publish release to GCS": use `.tegraflash-tar` not `.tegraflash.tar.gz`.

All fixes mirror the current state of `build.yml`, which was updated in prior PRs but never synced to `release.yml`.

## Test plan

- [ ] Trigger `release.yml` via workflow_dispatch and confirm `Build jetson-agx-thor (nvme)` reaches "Publish release to GCS" without tar error
- [ ] Confirm `Build jetson-agx-orin (nvme)` and `Build jetson-orin-nano (nvme)` pass "Generate flashable image (Jetson)" without `dtc not found`
- [ ] Confirm thor recovery file path in GCS manifest uses `.tegraflash-tar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)