### PR TITLE
fix(ci): gzip RPi sdimg before upload to restore ~30× compression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -521,7 +521,9 @@ jobs:
             # RPi: Mender emits .sdimg; pre-Mender RPi builds produced
             # .rootfs.wic. Prefer sdimg, fall back to wic.
             if [[ -f "$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg" ]]; then
-              IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg"
+              # Compress in-place — raw sdimg is ~7–34 GiB; gzip shrinks it ~30×.
+              gzip "$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg"
+              IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg.gz"
             else
               IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.rootfs.wic"
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,9 @@ jobs:
             # RPi: Mender emits .sdimg; pre-Mender RPi builds produced
             # .rootfs.wic. Prefer sdimg, fall back to wic.
             if [[ -f "$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg" ]]; then
-              IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg"
+              # Compress in-place — raw sdimg is ~7–34 GiB; gzip shrinks it ~30×.
+              gzip "$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg"
+              IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg.gz"
             else
               IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.rootfs.wic"
             fi


### PR DESCRIPTION
Since Mender was added, builds emit .sdimg (raw disk image) instead of .rootfs.wic. The old .wic files were zipped for upload (~230 MB); the new .sdimg was being uploaded raw at 7–34 GiB. gzip the sdimg in-place before passing it to the publisher, matching the compression ratio of the old .rootfs.wic.zip artifacts.