### PR TITLE
chore: bump DISTRO_VERSION to 0.15.1

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -61,7 +61,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.15.0"
+DISTRO_VERSION = "0.15.1"
 # DISTRO_CODENAME is inherited from poky.conf (require'd above), which
 # sets it to the active oe-core series ("scarthgap", "wrynose", ...).
 # Don't override here or it gets stuck on a stale value across series.


### PR DESCRIPTION
## Summary

- Bumps `DISTRO_VERSION` from `0.15.0` to `0.15.1` in `conf/distro/wendyos.conf`

## Test plan

- [ ] Confirm built images report version `0.15.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)