### PR TITLE
fix(ci): add gzip -f to handle Yocto hard-linked sdimg files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -530,8 +530,9 @@ jobs:
             if [[ -f "$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg" ]]; then
               # Resolve the Yocto symlink to the real file before gzipping;
               # gzip fails with ELOOP when the symlink chain is too deep.
+              # Use -f to suppress the "has N other links" error from Yocto hard links.
               SDIMG_REAL=$(readlink -f "$DEPLOY_DIR/wendyos-image-${MACHINE}.sdimg")
-              gzip "$SDIMG_REAL"
+              gzip -f "$SDIMG_REAL"
               IMAGE_FILE="${SDIMG_REAL}.gz"
             else
               IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.rootfs.wic"


### PR DESCRIPTION
Yocto hard-links build outputs, so the real file resolved by readlink -f has multiple links. gzip refuses to compress such files without -f, exiting with code 2 and "has N other links -- file ignored".