### PR TITLE
fix(ci): single-writer manifest publishing + GCS cache poisoning fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -603,6 +603,9 @@ jobs:
           path: manifest-entry-${{ matrix.device }}-${{ matrix.storage }}.json
           if-no-files-found: error
           retention-days: 7
+          # v4 artifacts are immutable per name; without this, re-running a
+          # failed build job 409s on the artifact left by the earlier attempt.
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # publish: the ONLY writer of GCS manifests. Build jobs upload files and
@@ -666,12 +669,15 @@ jobs:
           fi
           TOKEN=$(gcloud auth print-access-token)
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
+          # Build once; up to 15 invocations follow across this step and the
+          # master manifest step ($RUNNER_TEMP persists between steps).
+          go build -o "$RUNNER_TEMP/publisher" .
           # Applied strictly one at a time: this job is the only manifest
           # writer, so there is nothing to race against and no retry loop.
           for entry in "${entries[@]}"; do
             echo "::group::apply $(basename "$entry")"
             cat "$entry"
-            go run . --apply-metadata "$entry" --access-token "$TOKEN"
+            "$RUNNER_TEMP/publisher" --apply-metadata "$entry" --access-token "$TOKEN"
             echo "::endgroup::"
           done
 
@@ -686,6 +692,9 @@ jobs:
           fi
           TOKEN=$(gcloud auth print-access-token)
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
+          # Reuse the binary from the previous step; rebuild only if missing
+          # (e.g. this step re-run in isolation).
+          [[ -x "$RUNNER_TEMP/publisher" ]] || go build -o "$RUNNER_TEMP/publisher" .
           # One master-manifest write per device that actually published
           # (storage variants of a device share one device manifest, hence
           # unique_by). Devices whose builds failed keep their previous
@@ -705,7 +714,7 @@ jobs:
             if [[ "$NIGHTLY" == "true" ]]; then
               ARGS+=(--nightly)
             fi
-            go run . "${ARGS[@]}" </dev/null
+            "$RUNNER_TEMP/publisher" "${ARGS[@]}" </dev/null
           done
 
       - name: Send Discord announcement

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,15 @@ on:
         required: false
         default: ""
 
+# Never let two runs for the same ref overlap: the failing nightly on
+# 2026-06-04 had two main-push runs uploading and publishing the same
+# version concurrently (4 writers per device manifest). PR runs cancel
+# superseded builds; main/tag runs queue instead so a publish in progress
+# is never killed halfway.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ---------------------------------------------------------------------------
   # detect-changes: compute the build matrix.
@@ -496,7 +505,7 @@ jobs:
             sd)   sudo ./dosdcard.sh "$GITHUB_WORKSPACE/wendyos-sd.img" ;;
           esac
 
-      - name: Upload image and update device manifest
+      - name: Upload image and emit manifest entry
         if: github.event_name != 'pull_request'
         env:
           DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
@@ -539,15 +548,22 @@ jobs:
             UPLOAD_VERSION="${VERSION}-nightly"
           fi
 
+          # Upload-only: files are pushed to GCS here, but ALL manifest writes
+          # are deferred to the single serialised publish job. Parallel matrix
+          # entries must never read-modify-write shared manifests (412 races,
+          # lost updates). The entry JSON below is the handoff.
+          ENTRY_FILE="$GITHUB_WORKSPACE/manifest-entry-${DEVICE}-${STORAGE}.json"
           ARGS=(
             --device "$DEVICE"
             --version "$UPLOAD_VERSION"
             --file "$IMAGE_FILE"
             --access-token "$TOKEN"
+            --upload-only
+            --metadata-out "$ENTRY_FILE"
           )
 
           if [[ "$IS_RELEASE" != "true" ]]; then
-            ARGS+=(--nightly --skip-master-manifest)
+            ARGS+=(--nightly)
           fi
 
           # For all Jetson targets, include the tegraflash bundle as the recovery file
@@ -574,28 +590,31 @@ jobs:
           fi
 
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
-          # Outer retry handles 412 races when multiple storage variants for the
-          # same device write to the same device manifest concurrently.
-          # 10 attempts with jitter breaks lockstep between competing builds.
-          for attempt in 1 2 3 4 5 6 7 8 9 10; do
-            if go run . "${ARGS[@]}"; then
-              break
-            fi
-            if [ "$attempt" -lt 10 ]; then
-              JITTER=$((RANDOM % 30))
-              SLEEP_TIME=$((attempt * 20 + JITTER))
-              echo "Outer attempt $attempt failed, sleeping ${SLEEP_TIME}s before retry..."
-              sleep "$SLEEP_TIME"
-            else
-              echo "All outer attempts exhausted"
-              exit 1
-            fi
-          done
+          # No retry loop: uploads go to unique per-version paths (no shared
+          # state to race on) and the publisher's storage client already
+          # retries transient errors internally.
+          go run . "${ARGS[@]}"
 
+      - name: Upload manifest entry artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest-entry-${{ matrix.device }}-${{ matrix.storage }}
+          path: manifest-entry-${{ matrix.device }}-${{ matrix.storage }}.json
+          if-no-files-found: error
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # publish: the ONLY writer of GCS manifests. Build jobs upload files and
+  # hand over manifest-entry artifacts; this job applies them one at a time,
+  # so device and master manifests never see concurrent read-modify-writes
+  # from CI. Runs for nightly (main/dispatch) and release (tag) builds.
+  # !cancelled(): publish whatever subset of devices built successfully.
+  # ---------------------------------------------------------------------------
   publish:
-    name: Update master manifest
+    name: Publish manifests
     needs: build
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.ref_type != 'tag' }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     concurrency:
       group: update-master-manifest
       cancel-in-progress: false
@@ -629,37 +648,69 @@ jobs:
           go-version-file: wendyos/tools/publisher/go.mod
           cache-dependency-path: wendyos/tools/publisher/go.sum
 
+      - name: Download manifest entries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: manifest-entry-*
+          path: manifest-entries
+          merge-multiple: true
+
+      - name: Write device manifests
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          entries=("$GITHUB_WORKSPACE"/manifest-entries/*.json)
+          if [[ ${#entries[@]} -eq 0 ]]; then
+            echo "::warning::No manifest entries found (did every build fail?); nothing to publish."
+            exit 0
+          fi
+          TOKEN=$(gcloud auth print-access-token)
+          cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
+          # Applied strictly one at a time: this job is the only manifest
+          # writer, so there is nothing to race against and no retry loop.
+          for entry in "${entries[@]}"; do
+            echo "::group::apply $(basename "$entry")"
+            cat "$entry"
+            go run . --apply-metadata "$entry" --access-token "$TOKEN"
+            echo "::endgroup::"
+          done
+
       - name: Update master manifest
         run: |
-          VERSION=$(grep 'DISTRO_VERSION' "$GITHUB_WORKSPACE/wendyos/conf/distro/wendyos.conf" | head -1 | sed 's/.*"\(.*\)"/\1/')
+          set -euo pipefail
+          shopt -s nullglob
+          entries=("$GITHUB_WORKSPACE"/manifest-entries/*.json)
+          if [[ ${#entries[@]} -eq 0 ]]; then
+            echo "No manifest entries; skipping master manifest update."
+            exit 0
+          fi
           TOKEN=$(gcloud auth print-access-token)
-
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
-          for DEVICE in raspberry-pi-3 raspberry-pi-4 raspberry-pi-5 jetson-agx-orin jetson-orin-nano jetson-agx-thor; do
-            # Outer shell retry handles transient 412 bursts from concurrent writers
-            # (e.g. Cloud Function draining a Pub/Sub backlog). The publisher already
-            # retries internally 10x with exponential backoff; this adds 5 extra rounds.
-            for attempt in 1 2 3 4 5; do
-              if go run . \
-                --device "$DEVICE" \
-                --version "${VERSION}-nightly" \
-                --nightly \
-                --master-manifest-only \
-                --access-token "$TOKEN"; then
-                break
-              fi
-              if [ "$attempt" -lt 5 ]; then
-                echo "Outer attempt $attempt failed for $DEVICE, sleeping before retry..."
-                sleep $((attempt * 30))
-              else
-                echo "All outer attempts exhausted for $DEVICE"
-                exit 1
-              fi
-            done
+          # One master-manifest write per device that actually published
+          # (storage variants of a device share one device manifest, hence
+          # unique_by). Devices whose builds failed keep their previous
+          # latest pointers instead of being bumped to a version they
+          # never produced.
+          readarray -t rows < <(jq -sc '[.[] | {device, version, nightly}] | unique_by(.device) | .[]' "${entries[@]}")
+          for row in "${rows[@]}"; do
+            DEVICE=$(jq -r .device <<<"$row")
+            VERSION=$(jq -r .version <<<"$row")
+            NIGHTLY=$(jq -r .nightly <<<"$row")
+            ARGS=(
+              --device "$DEVICE"
+              --version "$VERSION"
+              --master-manifest-only
+              --access-token "$TOKEN"
+            )
+            if [[ "$NIGHTLY" == "true" ]]; then
+              ARGS+=(--nightly)
+            fi
+            go run . "${ARGS[@]}" </dev/null
           done
 
       - name: Send Discord announcement
-        if: ${{ success() }}
+        # Nightly builds only: release announcements are sent by promote.yml.
+        if: ${{ success() && github.ref_type != 'tag' }}
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
           VERSION_FILE: ${{ github.workspace }}/wendyos/conf/distro/wendyos.conf
@@ -674,7 +725,8 @@ jobs:
               "$DISCORD_WEBHOOK_URL"
 
       - name: Tag nightly pre-release on GitHub
-        if: ${{ success() }}
+        # Nightly builds only: release tags already exist (created by promote.yml).
+        if: ${{ success() && github.ref_type != 'tag' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
     tags:
-      - 'v*'
+      # Release tags are plain MAJOR.MINOR.PATCH - no 'v' prefix anywhere
+      # (git tags, GitHub releases, and GCS manifests all use the same string).
+      - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
   workflow_dispatch:
     inputs:
@@ -50,11 +52,44 @@ jobs:
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
       devices: ${{ steps.set.outputs.devices }}
+      version: ${{ steps.version.outputs.version }}
+      is-release: ${{ steps.version.outputs.is-release }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.version }}
+
+      # Compute the build version exactly once so every matrix job and the
+      # publish job agree on a single version string for the whole run.
+      #   tag push        -> MAJOR.MINOR.PATCH (the tag itself, no 'v')
+      #   main / dispatch -> nightly-YYYYMMDDTHHMMSS
+      - id: version
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            VERSION="${REF_NAME#v}"
+            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "ERROR: release tag must be MAJOR.MINOR.PATCH (got: $REF_NAME)" >&2
+              exit 1
+            fi
+            # The published version must match what the image believes it is.
+            # promote.yml checks this before tagging; this guards manual tags.
+            DISTRO_VERSION=$(grep 'DISTRO_VERSION' conf/distro/wendyos.conf | head -1 | sed 's/.*"\(.*\)"/\1/')
+            if [[ "$VERSION" != "$DISTRO_VERSION" ]]; then
+              echo "ERROR: tag $REF_NAME does not match DISTRO_VERSION=$DISTRO_VERSION in conf/distro/wendyos.conf" >&2
+              exit 1
+            fi
+            echo "is-release=true" >> "$GITHUB_OUTPUT"
+          else
+            VERSION="nightly-$(date -u +%Y%m%dT%H%M%S)"
+            echo "is-release=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Build version: $VERSION"
 
       - id: set
         env:
@@ -512,9 +547,9 @@ jobs:
           MACHINE: ${{ steps.vars.outputs.machine }}
           DEVICE: ${{ matrix.device }}
           STORAGE: ${{ matrix.storage }}
-          IS_RELEASE: ${{ github.ref_type == 'tag' }}
+          IS_RELEASE: ${{ needs.detect-changes.outputs.is-release }}
+          UPLOAD_VERSION: ${{ needs.detect-changes.outputs.version }}
         run: |
-          VERSION=$(grep 'DISTRO_VERSION' "$GITHUB_WORKSPACE/wendyos/conf/distro/wendyos.conf" | head -1 | sed 's/.*"\(.*\)"/\1/')
           TOKEN=$(gcloud auth print-access-token)
 
           if [[ "$MACHINE" != raspberry* && "$STORAGE" == "nvme" ]]; then
@@ -540,12 +575,6 @@ jobs:
             else
               IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.rootfs.wic"
             fi
-          fi
-
-          if [[ "$IS_RELEASE" == "true" ]]; then
-            UPLOAD_VERSION="$VERSION"
-          else
-            UPLOAD_VERSION="${VERSION}-nightly"
           fi
 
           # Upload-only: files are pushed to GCS here, but ALL manifest writes
@@ -613,7 +642,7 @@ jobs:
   # ---------------------------------------------------------------------------
   publish:
     name: Publish manifests
-    needs: build
+    needs: [detect-changes, build]
     if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     concurrency:
       group: update-master-manifest
@@ -708,41 +737,52 @@ jobs:
             go run . "${ARGS[@]}" </dev/null
           done
 
-      - name: Send Discord announcement
-        # Nightly builds only: release announcements are sent by promote.yml.
-        if: ${{ success() && github.ref_type != 'tag' }}
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
-          VERSION_FILE: ${{ github.workspace }}/wendyos/conf/distro/wendyos.conf
-        run: |
-          [[ -z "${DISCORD_WEBHOOK_URL}" ]] && exit 0
-          VERSION=$(grep 'DISTRO_VERSION' "$VERSION_FILE" | head -1 | sed 's/.*"\(.*\)"/\1/')
-          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/nightly"
-          jq -n --arg msg "**WendyOS ${VERSION}-nightly** is out! Full changelog and downloads: ${RELEASE_URL}" '{content: $msg}' | \
-            curl -fsS -o /dev/null \
-              -H "Content-Type: application/json" \
-              -d @- \
-              "$DISCORD_WEBHOOK_URL"
-
       - name: Tag nightly pre-release on GitHub
         # Nightly builds only: release tags already exist (created by promote.yml).
         if: ${{ success() && github.ref_type != 'tag' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.detect-changes.outputs.version }}
         run: |
-          VERSION=$(grep 'DISTRO_VERSION' "$GITHUB_WORKSPACE/wendyos/conf/distro/wendyos.conf" | head -1 | sed 's/.*"\(.*\)"/\1/')
-          TAG="nightly"
-
-          gh release delete "$TAG" --yes --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
-
+          set -euo pipefail
           cd "$GITHUB_WORKSPACE/wendyos"
-          git tag -f "$TAG"
-          git tag -f "${VERSION}-nightly"
-          git push origin "$TAG" --force
-          git push origin "${VERSION}-nightly" --force
 
-          gh release create "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "Nightly ${VERSION}-nightly ($(date -u +%Y-%m-%d))" \
-            --generate-notes \
-            --prerelease
+          # -f/--force for idempotency: a re-run of this job re-tags the same
+          # commit with the same nightly-<timestamp> version.
+          git tag -f "$VERSION"
+          git push origin "$VERSION" --force
+
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists (job re-run), skipping create."
+          else
+            gh release create "$VERSION" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "WendyOS $VERSION" \
+              --generate-notes \
+              --prerelease
+          fi
+
+          # Keep the releases page tidy: retain the 7 most recent nightly
+          # pre-releases. Git tags are kept forever for traceability and
+          # promotion; nightly-YYYYMMDDTHHMMSS sorts chronologically.
+          gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,isPrerelease \
+            --jq '[.[] | select(.isPrerelease and (.tagName | startswith("nightly-"))) | .tagName] | sort | reverse | .[7:][]' |
+            while read -r old; do
+              echo "Pruning old nightly pre-release $old (tag kept)"
+              gh release delete "$old" --yes --repo "$GITHUB_REPOSITORY"
+            done
+
+      - name: Send Discord announcement
+        # Nightly builds only: release announcements are sent by promote.yml.
+        if: ${{ success() && github.ref_type != 'tag' }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          VERSION: ${{ needs.detect-changes.outputs.version }}
+        run: |
+          [[ -z "${DISCORD_WEBHOOK_URL}" ]] && exit 0
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${VERSION}"
+          jq -n --arg msg "**WendyOS ${VERSION}** is out! Full changelog and downloads: ${RELEASE_URL}" '{content: $msg}' | \
+            curl -fsS -o /dev/null \
+              -H "Content-Type: application/json" \
+              -d @- \
+              "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -688,14 +688,17 @@ jobs:
           merge-multiple: true
 
       - name: Write device manifests
+        id: apply
         run: |
           set -euo pipefail
           shopt -s nullglob
           entries=("$GITHUB_WORKSPACE"/manifest-entries/*.json)
           if [[ ${#entries[@]} -eq 0 ]]; then
             echo "::warning::No manifest entries found (did every build fail?); nothing to publish."
+            echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "published=true" >> "$GITHUB_OUTPUT"
           TOKEN=$(gcloud auth print-access-token)
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
           # Build once; up to 15 invocations follow across this step and the
@@ -748,7 +751,9 @@ jobs:
 
       - name: Tag nightly pre-release on GitHub
         # Nightly builds only: release tags already exist (created by promote.yml).
-        if: ${{ success() && github.ref_type != 'tag' }}
+        # Skipped when zero entries were published (every build failed) - never
+        # tag and announce a nightly that has no images behind it.
+        if: ${{ success() && github.ref_type != 'tag' && steps.apply.outputs.published == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.detect-changes.outputs.version }}
@@ -783,7 +788,7 @@ jobs:
 
       - name: Send Discord announcement
         # Nightly builds only: release announcements are sent by promote.yml.
-        if: ${{ success() && github.ref_type != 'tag' }}
+        if: ${{ success() && github.ref_type != 'tag' && steps.apply.outputs.published == 'true' }}
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
           VERSION: ${{ needs.detect-changes.outputs.version }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,18 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Release tag to create (e.g. v1.2.3)"
+        description: "Release version to create, e.g. 1.2.3 (no 'v' prefix; one is stripped if given)"
         type: string
         required: true
       source_nightly:
-        description: "Nightly tag to promote from"
+        description: "Nightly tag to promote from (empty = most recent nightly-* tag)"
         type: string
         required: false
-        default: nightly
+        default: ""
 
 jobs:
   promote:
-    name: Promote ${{ inputs.source_nightly }} to ${{ inputs.release_tag }}
+    name: Promote ${{ inputs.source_nightly || 'latest nightly' }} to ${{ inputs.release_tag }}
     permissions:
       contents: write
     runs-on:
@@ -33,45 +33,69 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9] ]]; then
-            echo "ERROR: release_tag must start with vMAJOR.MINOR.PATCH (got: $RELEASE_TAG)"
+          set -euo pipefail
+          # Versions are plain MAJOR.MINOR.PATCH everywhere (git tags, GitHub
+          # releases, GCS manifests). Strip a leading 'v' typed out of habit.
+          TAG="${RELEASE_TAG#v}"
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: release_tag must be MAJOR.MINOR.PATCH (got: $RELEASE_TAG)"
             exit 1
           fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
 
       - name: Resolve nightly commit and push release tag
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
           SOURCE_NIGHTLY: ${{ inputs.source_nightly }}
         run: |
-          # Resolve the exact commit the nightly tag points to.
-          if ! SHA=$(git rev-parse "refs/tags/${SOURCE_NIGHTLY}^{commit}" 2>/dev/null); then
-            git fetch origin "refs/tags/${SOURCE_NIGHTLY}:refs/tags/${SOURCE_NIGHTLY}"
-            SHA=$(git rev-parse "refs/tags/${SOURCE_NIGHTLY}^{commit}")
-          fi
-          echo "Promoting commit $SHA to $RELEASE_TAG"
+          set -euo pipefail
+          git fetch --tags --quiet
 
-          if git rev-parse "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1 || \
-             git ls-remote --exit-code origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
-            echo "Tag $RELEASE_TAG already exists, skipping create/push."
+          # Default to the most recent nightly: nightly-YYYYMMDDTHHMMSS sorts
+          # chronologically as a string.
+          if [[ -z "$SOURCE_NIGHTLY" ]]; then
+            SOURCE_NIGHTLY=$(git tag -l 'nightly-*' | sort | tail -1)
+            if [[ -z "$SOURCE_NIGHTLY" ]]; then
+              echo "ERROR: no nightly-* tags found; pass source_nightly explicitly."
+              exit 1
+            fi
+            echo "Resolved latest nightly: $SOURCE_NIGHTLY"
+          fi
+
+          SHA=$(git rev-parse "refs/tags/${SOURCE_NIGHTLY}^{commit}")
+          echo "Promoting commit $SHA ($SOURCE_NIGHTLY) to $TAG"
+
+          # The tag-triggered release build publishes with the tag as the
+          # version and fails if it disagrees with DISTRO_VERSION baked into
+          # the image. Catch that here, before any tag exists.
+          DISTRO_VERSION=$(git show "$SHA:conf/distro/wendyos.conf" | grep 'DISTRO_VERSION' | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [[ "$TAG" != "$DISTRO_VERSION" ]]; then
+            echo "ERROR: release tag $TAG != DISTRO_VERSION=$DISTRO_VERSION at $SOURCE_NIGHTLY ($SHA)."
+            echo "Bump DISTRO_VERSION in conf/distro/wendyos.conf, let a nightly build, then promote that."
+            exit 1
+          fi
+
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1 || \
+             git ls-remote --exit-code origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping create/push."
           else
-            git tag "$RELEASE_TAG" "$SHA"
-            git push origin "$RELEASE_TAG"
+            git tag "$TAG" "$SHA"
+            git push origin "$TAG"
           fi
 
       - name: Create GitHub release
         id: create_release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Release $RELEASE_TAG already exists."
+          set -euo pipefail
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists."
             echo "created=false" >> "$GITHUB_OUTPUT"
           else
-            gh release create "$RELEASE_TAG" \
+            gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
-              --title "WendyOS $RELEASE_TAG" \
+              --title "WendyOS $TAG" \
               --generate-notes
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
@@ -80,11 +104,10 @@ jobs:
         if: steps.create_release.outputs.created == 'true'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           [[ -z "${DISCORD_WEBHOOK_URL}" ]] && exit 0
-          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
-          jq -n --arg msg "**WendyOS ${RELEASE_TAG}** is out! Full changelog and downloads: ${RELEASE_URL}" '{content: $msg}' | \
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
+          jq -n --arg msg "**WendyOS ${TAG}** is out! Full changelog and downloads: ${RELEASE_URL}" '{content: $msg}' | \
             curl -fsS -o /dev/null \
               -H "Content-Type: application/json" \
               -d @- \

--- a/tools/publisher/RUNBOOK.md
+++ b/tools/publisher/RUNBOOK.md
@@ -87,7 +87,13 @@ This preserves the version's metadata (release date, changelog) but replaces the
 
 ### 3. Promote a Nightly to Stable
 
-After testing a nightly build on devices and confirming it's good:
+> **CI nightlies (`nightly-YYYYMMDDTHHMMSS`) are NOT promoted with this tool.**
+> They don't embed a semantic version, so there is nothing to strip the
+> `nightly` marker from (the tool refuses with an error). Promote them by
+> running the **"Promote Nightly to Release"** GitHub workflow, which tags the
+> commit `MAJOR.MINOR.PATCH` and rebuilds/publishes the real version.
+
+For legacy `X.Y.Z-nightly` versions, after testing on devices:
 
 ```bash
 go run . \
@@ -206,8 +212,9 @@ The typical flow for Jetson releases:
 
 ### Version Naming Convention
 
-- **Nightly:** `X.Y.Z-nightly` (e.g., `0.10.4-nightly`)
-- **Stable:** `X.Y.Z` (e.g., `0.10.5`)
+- **Nightly (CI):** `nightly-YYYYMMDDTHHMMSS` (e.g., `nightly-20260604T163205`, UTC; sorts chronologically)
+- **Stable:** `X.Y.Z` (e.g., `0.10.5`) — never a `v` prefix
+- **Nightly (legacy):** `X.Y.Z-nightly` (e.g., `0.10.4-nightly`)
 - **Date-based nightly (legacy):** `nightly-YYYY-MM-DD`
 
 ---

--- a/tools/publisher/manifest_entry.go
+++ b/tools/publisher/manifest_entry.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// ManifestEntry is the handoff record between a build job running
+// --upload-only and the publish job running --apply-metadata. It captures
+// everything updateManifests needs so that manifest writes can happen in a
+// single serialised job after all parallel builds have finished, instead of
+// having every matrix entry race read-modify-writes on the shared manifests.
+type ManifestEntry struct {
+	Device    string `json:"device"`
+	Version   string `json:"version"`
+	Storage   string `json:"storage,omitempty"`
+	Nightly   bool   `json:"nightly"`
+	Stability string `json:"stability,omitempty"`
+
+	FilePath     string `json:"file_path,omitempty"`
+	FileSize     int64  `json:"file_size,omitempty"`
+	FileChecksum string `json:"file_checksum,omitempty"`
+
+	OTAUpdatePath     string `json:"ota_update_path,omitempty"`
+	OTAUpdateSize     int64  `json:"ota_update_size,omitempty"`
+	OTAUpdateChecksum string `json:"ota_update_checksum,omitempty"`
+
+	RecoveryPath     string `json:"recovery_path,omitempty"`
+	RecoverySize     int64  `json:"recovery_size,omitempty"`
+	RecoveryChecksum string `json:"recovery_checksum,omitempty"`
+}
+
+func (e *ManifestEntry) validate() error {
+	if err := validateDeviceType(e.Device); err != nil {
+		return fmt.Errorf("invalid device: %w", err)
+	}
+	if err := validateVersion(e.Version); err != nil {
+		return fmt.Errorf("invalid version: %w", err)
+	}
+	if e.Stability != "" {
+		if err := validateStability(e.Stability); err != nil {
+			return fmt.Errorf("invalid stability: %w", err)
+		}
+	}
+	if e.Storage != "" && e.Storage != "nvme" && e.Storage != "sd" && e.Storage != "emmc" {
+		return fmt.Errorf("invalid storage %q: must be nvme, sd, or emmc", e.Storage)
+	}
+	if e.FilePath == "" && e.OTAUpdatePath == "" && e.RecoveryPath == "" {
+		return fmt.Errorf("entry contains no files - at least one of OS image, OTA update, or recovery file is required")
+	}
+	return nil
+}
+
+// writeManifestEntry validates and writes an entry as indented JSON.
+func writeManifestEntry(path string, entry ManifestEntry) error {
+	if err := entry.validate(); err != nil {
+		return err
+	}
+	content, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, content, 0o644)
+}
+
+// readManifestEntry reads and validates an entry written by --upload-only.
+func readManifestEntry(path string) (ManifestEntry, error) {
+	var entry ManifestEntry
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return entry, err
+	}
+	if err := json.Unmarshal(content, &entry); err != nil {
+		return entry, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if err := entry.validate(); err != nil {
+		return entry, fmt.Errorf("validating %s: %w", path, err)
+	}
+	return entry, nil
+}

--- a/tools/publisher/manifest_entry_test.go
+++ b/tools/publisher/manifest_entry_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func validEntry() ManifestEntry {
+	return ManifestEntry{
+		Device:            "jetson-agx-orin",
+		Version:           "0.15.1-nightly",
+		Storage:           "emmc",
+		Nightly:           true,
+		Stability:         "stable",
+		FilePath:          "images/jetson-agx-orin/0.15.1-nightly/wendyos-image.tegraflash.tar.gz",
+		FileSize:          2971666096,
+		FileChecksum:      "21f44094492a79d77b0e4ee248eafc9a11b819470e7eb6459ada5ab018328827",
+		OTAUpdatePath:     "images/jetson-agx-orin/0.15.1-nightly/wendyos-image.mender",
+		OTAUpdateSize:     2889977344,
+		OTAUpdateChecksum: "d04d8a8991e621bf62f4bcde5882973bd2cb2948dc841e3469874de2cdddcc66",
+	}
+}
+
+func TestManifestEntryRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "entry.json")
+	want := validEntry()
+
+	if err := writeManifestEntry(path, want); err != nil {
+		t.Fatalf("writeManifestEntry: %v", err)
+	}
+	got, err := readManifestEntry(path)
+	if err != nil {
+		t.Fatalf("readManifestEntry: %v", err)
+	}
+	if got != want {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestManifestEntryValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ManifestEntry)
+		wantErr string
+	}{
+		{"valid", func(e *ManifestEntry) {}, ""},
+		{"empty device", func(e *ManifestEntry) { e.Device = "" }, "invalid device"},
+		{"empty version", func(e *ManifestEntry) { e.Version = "" }, "invalid version"},
+		{"version with slash", func(e *ManifestEntry) { e.Version = "0.1/../evil" }, "invalid version"},
+		{"bad storage", func(e *ManifestEntry) { e.Storage = "floppy" }, "invalid storage"},
+		{"bad stability", func(e *ManifestEntry) { e.Stability = "wobbly" }, "invalid stability"},
+		{"empty storage ok", func(e *ManifestEntry) { e.Storage = "" }, ""},
+		{"empty stability ok", func(e *ManifestEntry) { e.Stability = "" }, ""},
+		{"no files", func(e *ManifestEntry) {
+			e.FilePath, e.OTAUpdatePath, e.RecoveryPath = "", "", ""
+		}, "no files"},
+		{"recovery only ok", func(e *ManifestEntry) {
+			e.FilePath, e.OTAUpdatePath = "", ""
+			e.RecoveryPath = "images/d/v/recovery.tar.gz"
+		}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := validEntry()
+			tt.mutate(&entry)
+			err := entry.validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("validate() = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReadManifestEntryRejectsGarbage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "garbage.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readManifestEntry(path); err == nil {
+		t.Error("readManifestEntry accepted malformed JSON")
+	}
+	if _, err := readManifestEntry(filepath.Join(t.TempDir(), "missing.json")); err == nil {
+		t.Error("readManifestEntry accepted a missing file")
+	}
+}

--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -2248,6 +2249,14 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 		logger.Fatal("Cannot promote version 'nightly' - must have additional version info (e.g., 'nightly-2025-12-20')")
 	} else if !strings.Contains(strings.ToLower(stableVersion), "nightly") {
 		logger.Fatal("Version does not contain 'nightly' - cannot determine stable version name")
+	}
+
+	// CI nightlies named nightly-YYYYMMDDTHHMMSS don't embed a semantic
+	// version: stripping the prefix would "promote" to a bare timestamp.
+	// Those builds are released by tagging the commit MAJOR.MINOR.PATCH
+	// (promote.yml), which rebuilds and publishes the real version.
+	if !regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`).MatchString(stableVersion) {
+		logger.Fatalf("Derived stable version %q is not MAJOR.MINOR.PATCH - cannot promote %q in place. Use the 'Promote Nightly to Release' GitHub workflow instead.", stableVersion, nightlyVersion)
 	}
 
 	logger.WithField("stable_version", stableVersion).Info("Derived stable version name")

--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -56,6 +56,16 @@ func (s *gcloudTokenSource) Token() (*oauth2.Token, error) {
 	return s.token, nil
 }
 
+// manifestCacheControl is set on every manifest write. Manifests are mutable
+// and read-modify-written under GenerationMatch preconditions; without this,
+// GCS applies its default "public, max-age=3600" to publicly readable objects
+// and serves reads (including our own) from its built-in edge cache. Stale
+// reads carry stale generation numbers, which livelocks CAS retries with 412s
+// and silently resurrects old state on unconditional writes — both observed
+// in production (run 26967801954). "no-store" forces every manifest read,
+// by CI and by device clients, to be strongly consistent.
+const manifestCacheControl = "no-store"
+
 // discordWebhookURL is read from the DISCORD_WEBHOOK_URL environment variable.
 var discordWebhookURL = os.Getenv("DISCORD_WEBHOOK_URL")
 
@@ -943,6 +953,9 @@ func main() {
 	updateOnly := flag.Bool("update-only", false, "Only update manifests without uploading")
 	skipMasterManifest := flag.Bool("skip-master-manifest", false, "Skip master manifest update (a separate job will handle it)")
 	masterManifestOnly := flag.Bool("master-manifest-only", false, "Only update the master manifest, skip upload and device manifest")
+	uploadOnly := flag.Bool("upload-only", false, "Upload files without touching any manifest; requires --metadata-out (a serialised publish job applies the manifest writes later)")
+	metadataOut := flag.String("metadata-out", "", "Path to write the manifest-entry JSON produced by --upload-only")
+	applyMetadata := flag.String("apply-metadata", "", "Path to a manifest-entry JSON (from --upload-only); updates the device manifest from it without uploading")
 	listImages := flag.Bool("list", false, "List all images in the bucket")
 	createDevice := flag.Bool("create-device", false, "Create a new device type in the manifest")
 	nightly := flag.Bool("nightly", false, "Mark this build as a nightly/untested build")
@@ -1045,6 +1058,12 @@ func main() {
 		if err := validateFileExists(*localFile); err != nil {
 			log.WithError(err).Fatal("Invalid file")
 		}
+	} else if *applyMetadata != "" {
+		// For applying a manifest entry, the file must exist; everything else
+		// (device, version, paths) is validated from the entry content.
+		if err := validateFileExists(*applyMetadata); err != nil {
+			log.WithError(err).Fatal("Invalid --apply-metadata file")
+		}
 	} else {
 		// For normal operations, we need device type and version
 		if err := validateDeviceType(*deviceType); err != nil {
@@ -1058,6 +1077,14 @@ func main() {
 		}
 		if *storage != "" && *storage != "nvme" && *storage != "sd" && *storage != "emmc" {
 			log.Fatalf("Invalid --storage value %q: must be nvme, sd, or emmc", *storage)
+		}
+		if *uploadOnly {
+			if *metadataOut == "" {
+				log.Fatal("--upload-only requires --metadata-out")
+			}
+			if *updateOnly || *masterManifestOnly {
+				log.Fatal("--upload-only cannot be combined with --update-only or --master-manifest-only")
+			}
 		}
 		if !*updateOnly && !*masterManifestOnly {
 			// At least one file (main, OTA, or recovery) must be provided
@@ -1145,6 +1172,31 @@ func main() {
 		if err := updateMasterManifest(ctx, logger, bucket, *deviceType, *version, *nightly, *stability, true); err != nil {
 			log.WithError(err).Fatal("Failed to update master manifest")
 		}
+		return
+	}
+
+	// Apply a manifest entry produced by --upload-only (used by the serialised
+	// publish job after parallel builds). Only the device manifest is written;
+	// the publish job updates the master manifest separately via
+	// --master-manifest-only once all entries have been applied.
+	if *applyMetadata != "" {
+		entry, err := readManifestEntry(*applyMetadata)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to read manifest entry")
+		}
+		log.WithFields(logrus.Fields{
+			"entry":   *applyMetadata,
+			"device":  entry.Device,
+			"version": entry.Version,
+			"storage": entry.Storage,
+		}).Info("Applying manifest entry")
+		updateManifests(
+			ctx, bucket, entry.Device, entry.Version,
+			entry.FilePath, entry.FileSize, entry.FileChecksum,
+			entry.OTAUpdatePath, entry.OTAUpdateSize, entry.OTAUpdateChecksum,
+			entry.RecoveryPath, entry.RecoverySize, entry.RecoveryChecksum,
+			entry.Storage, entry.Nightly, entry.Stability, *notifyDiscord, true,
+		)
 		return
 	}
 
@@ -1331,6 +1383,32 @@ func main() {
 				log.WithError(recoveryUpload.err).Fatal("Failed to upload recovery file")
 			}
 			log.Info("Recovery file uploaded successfully")
+		}
+
+		// In upload-only mode the manifests are deliberately untouched: write
+		// the entry file for the publish job and stop here.
+		if *uploadOnly {
+			entry := ManifestEntry{
+				Device:            *deviceType,
+				Version:           *version,
+				Storage:           *storage,
+				Nightly:           *nightly,
+				Stability:         *stability,
+				FilePath:          mainUpload.path,
+				FileSize:          mainUpload.size,
+				FileChecksum:      mainResult.checksum,
+				OTAUpdatePath:     otaUpdateUpload.path,
+				OTAUpdateSize:     otaUpdateUpload.size,
+				OTAUpdateChecksum: otaUpdateResult.checksum,
+				RecoveryPath:      recoveryUpload.path,
+				RecoverySize:      recoveryUpload.size,
+				RecoveryChecksum:  recoveryResult.checksum,
+			}
+			if err := writeManifestEntry(*metadataOut, entry); err != nil {
+				log.WithError(err).Fatal("Failed to write manifest entry")
+			}
+			log.WithField("path", *metadataOut).Info("Uploads complete; manifest entry written (manifests untouched, --upload-only)")
+			return
 		}
 
 		// Update manifests with results
@@ -1858,6 +1936,7 @@ func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 			deviceConds = storage.Conditions{GenerationMatch: generation}
 		}
 		w := obj.If(deviceConds).NewWriter(ctx)
+		w.CacheControl = manifestCacheControl
 
 		// Marshal to JSON with indentation
 		content, err := json.MarshalIndent(manifest, "", "  ")
@@ -1997,6 +2076,7 @@ func updateMasterManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 			// job with a concurrency group). Avoids livelock from any mystery concurrent
 			// writer because we are the authoritative publisher.
 			w = obj.NewWriter(ctx)
+			w.CacheControl = manifestCacheControl
 		} else {
 			// Use GenerationMatch so concurrent build jobs don't clobber each other.
 			var masterConds storage.Conditions
@@ -2006,6 +2086,7 @@ func updateMasterManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 				masterConds = storage.Conditions{GenerationMatch: generation}
 			}
 			w = obj.If(masterConds).NewWriter(ctx)
+			w.CacheControl = manifestCacheControl
 		}
 
 		// Marshal to JSON with indentation
@@ -2062,6 +2143,7 @@ func createNewDevice(ctx context.Context, bucket *storage.BucketHandle, deviceTy
 	// Write device manifest
 	obj := bucket.Object(manifestPath)
 	w := obj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 
 	content, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
@@ -2123,6 +2205,7 @@ func createNewDevice(ctx context.Context, bucket *storage.BucketHandle, deviceTy
 
 	// Write master manifest
 	w = masterObj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 
 	content, err = json.MarshalIndent(masterManifest, "", "  ")
 	if err != nil {
@@ -2353,6 +2436,7 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 	// Write device manifest back
 	logger.Info("Writing updated device manifest")
 	w := obj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 
 	manifestContent, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
@@ -2429,6 +2513,7 @@ func updateMasterManifestForPromotion(ctx context.Context, logger *logrus.Entry,
 		}
 
 		w := obj.If(storage.Conditions{GenerationMatch: generation}).NewWriter(ctx)
+		w.CacheControl = manifestCacheControl
 		if _, err := w.Write(manifestContent); err != nil {
 			w.Close()
 			return fmt.Errorf("failed to write master manifest: %w", err)
@@ -2600,6 +2685,7 @@ func swapImageFile(ctx context.Context, bucket *storage.BucketHandle, deviceType
 	manifest.Versions[version] = updatedVersion
 
 	w := obj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 
 	manifestContent, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
@@ -2667,6 +2753,7 @@ func updateMasterManifestTimestamp(ctx context.Context, logger *logrus.Entry, bu
 	masterManifest.LastUpdated = time.Now()
 
 	w := obj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 
 	manifestContent, err := json.MarshalIndent(masterManifest, "", "  ")
 	if err != nil {
@@ -2878,6 +2965,7 @@ func updateFirmwareChipManifest(ctx context.Context, logger *logrus.Entry, bucke
 	// Write back to bucket
 	logger.Info("Writing firmware chip manifest back to bucket")
 	w := obj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 
 	content, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
@@ -2967,6 +3055,7 @@ func updateMasterManifestFirmware(ctx context.Context, logger *logrus.Entry, buc
 	// Write back to bucket
 	logger.Info("Writing master manifest back to bucket")
 	w := obj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 
 	content, err := json.MarshalIndent(masterManifest, "", "  ")
 	if err != nil {
@@ -3151,6 +3240,7 @@ func createNewFirmwareChip(ctx context.Context, bucket *storage.BucketHandle, ch
 	// Write chip manifest
 	obj := bucket.Object(manifestPath)
 	w := obj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 
 	content, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
@@ -3211,6 +3301,7 @@ func createNewFirmwareChip(ctx context.Context, bucket *storage.BucketHandle, ch
 
 	// Write master manifest
 	w = masterObj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 
 	content, err = json.MarshalIndent(masterManifest, "", "  ")
 	if err != nil {
@@ -3320,6 +3411,7 @@ func removeDeviceType(ctx context.Context, bucket *storage.BucketHandle, deviceT
 	masterManifest.LastUpdated = time.Now()
 
 	w := masterObj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 	updatedContent, err := json.MarshalIndent(masterManifest, "", "  ")
 	if err != nil {
 		logger.WithError(err).Error("Failed to marshal master manifest")
@@ -3473,6 +3565,7 @@ func renameDeviceType(ctx context.Context, bucket *storage.BucketHandle, oldDevi
 
 	// Write the new device manifest
 	w := newManifestObj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 	newContent, err := json.MarshalIndent(targetManifest, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal target device manifest: %w", err)
@@ -3521,6 +3614,7 @@ func renameDeviceType(ctx context.Context, bucket *storage.BucketHandle, oldDevi
 
 	// Write master manifest
 	w = masterObj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 	masterContent, err := json.MarshalIndent(masterManifest, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal master manifest: %w", err)
@@ -3604,6 +3698,7 @@ func removeFirmwareChip(ctx context.Context, bucket *storage.BucketHandle, chip 
 	masterManifest.LastUpdated = time.Now()
 
 	w := masterObj.NewWriter(ctx)
+	w.CacheControl = manifestCacheControl
 	updatedContent, err := json.MarshalIndent(masterManifest, "", "  ")
 	if err != nil {
 		logger.WithError(err).Error("Failed to marshal master manifest")


### PR DESCRIPTION
## Summary

PR 2 of 3 — fixes the 412 `conditionNotMet` failures in `Upload image and update device manifest`. **Stacked on #97** (publisher migration); merge that first.

## Root cause (evidence from run 26967801954)

The "writing conflict race" theory was right, but the reason retries never converged is worse than a race:

- The `jetson-agx-orin (emmc)` job made **100 manifest write attempts over 40 min — all 412**. The `(nvme)` job kept 412ing for 20 minutes *after* every other writer had exited.
- The publish job wrote master.json 6× serially, all "successful" — **only 2 of 6 updates survived**. `jetson-agx-orin` still points at `0.15.0-nightly` today.
- Mechanism: manifests are public objects written **without `Cache-Control`**, so GCS defaults them to `public, max-age=3600` and serves reads — including the publisher's own read-modify-write reads — from its built-in edge cache (`curl -sI .../master.json` → `age: 1551`). Stale read ⇒ stale generation ⇒ conditional writes 412 forever; unconditional writes silently resurrect old state. This also means device clients could fetch manifests up to an hour stale.

## Changes

**Publisher** (`tools/publisher/`):
- `Cache-Control: no-store` on all 17 manifest write sites — every manifest read becomes strongly consistent. Image files keep default caching (immutable per-version paths).
- New `--upload-only --metadata-out <file>`: upload files, write a validated manifest-entry JSON, touch no manifests.
- New `--apply-metadata <file>`: write the device manifest from an entry file, no upload. Unit tests for entry round-trip + validation.

**Workflow** (`build.yml`):
- Build jobs upload files + a per-matrix-entry `manifest-entry-<device>-<storage>` artifact. No manifest writes, no retry loops.
- The publish job is the **single serialised manifest writer**: downloads all entries, applies them one at a time, then one master-manifest write per device that actually built. Devices whose builds failed keep their previous `latest` pointers (previously they were bumped to versions they never produced). Now also covers release/tag builds, whose manifest writes raced in build jobs too.
- Workflow-level `concurrency`: PR runs cancel superseded builds; main/tag runs queue — the failing nightly overlapped with the previous main push (up to 4 concurrent writers per manifest).

## Behavior notes
- Partial nightlies still publish + announce the devices that succeeded (same as today, minus corrupting the rest).
- Manual RUNBOOK workflows (`-swap`, `-promote`, etc.) unchanged.

## Next in series
- PR 3: `nightly-YYYYMMDDTHHMMSS` versioning + drop the `v` tag prefix.


## ⚠️ Deployment note — one-time action after merge

`no-store` only applies to manifests written *after* this lands. The currently-stored manifests still carry `public, max-age=3600` metadata, and GCS edge caches are not invalidated by new writes — so for up to 1h after merge, reads (ours and clients') can still be served stale, and the first nightly could still hit 412s. Right after merging, run:

```bash
gcloud storage objects update 'gs://wendyos-images-public/manifests/*.json' --cache-control=no-store
```

This rewrites the metadata on the existing manifests. Cached copies still expire on their own TTL (≤1h after their last cache fill); after that the problem is gone permanently.
