### PR TITLE
feat(ci): nightly-YYYYMMDDTHHMMSS versioning, drop the v tag prefix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
     tags:
-      - 'v*'
+      # Release tags are plain MAJOR.MINOR.PATCH - no 'v' prefix anywhere
+      # (git tags, GitHub releases, and GCS manifests all use the same string).
+      - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
   workflow_dispatch:
     inputs:
@@ -50,11 +52,44 @@ jobs:
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
       devices: ${{ steps.set.outputs.devices }}
+      version: ${{ steps.version.outputs.version }}
+      is-release: ${{ steps.version.outputs.is-release }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.version }}
+
+      # Compute the build version exactly once so every matrix job and the
+      # publish job agree on a single version string for the whole run.
+      #   tag push        -> MAJOR.MINOR.PATCH (the tag itself, no 'v')
+      #   main / dispatch -> nightly-YYYYMMDDTHHMMSS
+      - id: version
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            VERSION="${REF_NAME#v}"
+            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "ERROR: release tag must be MAJOR.MINOR.PATCH (got: $REF_NAME)" >&2
+              exit 1
+            fi
+            # The published version must match what the image believes it is.
+            # promote.yml checks this before tagging; this guards manual tags.
+            DISTRO_VERSION=$(grep 'DISTRO_VERSION' conf/distro/wendyos.conf | head -1 | sed 's/.*"\(.*\)"/\1/')
+            if [[ "$VERSION" != "$DISTRO_VERSION" ]]; then
+              echo "ERROR: tag $REF_NAME does not match DISTRO_VERSION=$DISTRO_VERSION in conf/distro/wendyos.conf" >&2
+              exit 1
+            fi
+            echo "is-release=true" >> "$GITHUB_OUTPUT"
+          else
+            VERSION="nightly-$(date -u +%Y%m%dT%H%M%S)"
+            echo "is-release=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Build version: $VERSION"
 
       - id: set
         env:
@@ -512,9 +547,9 @@ jobs:
           MACHINE: ${{ steps.vars.outputs.machine }}
           DEVICE: ${{ matrix.device }}
           STORAGE: ${{ matrix.storage }}
-          IS_RELEASE: ${{ github.ref_type == 'tag' }}
+          IS_RELEASE: ${{ needs.detect-changes.outputs.is-release }}
+          UPLOAD_VERSION: ${{ needs.detect-changes.outputs.version }}
         run: |
-          VERSION=$(grep 'DISTRO_VERSION' "$GITHUB_WORKSPACE/wendyos/conf/distro/wendyos.conf" | head -1 | sed 's/.*"\(.*\)"/\1/')
           TOKEN=$(gcloud auth print-access-token)
 
           if [[ "$MACHINE" != raspberry* && "$STORAGE" == "nvme" ]]; then
@@ -540,12 +575,6 @@ jobs:
             else
               IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.rootfs.wic"
             fi
-          fi
-
-          if [[ "$IS_RELEASE" == "true" ]]; then
-            UPLOAD_VERSION="$VERSION"
-          else
-            UPLOAD_VERSION="${VERSION}-nightly"
           fi
 
           # Upload-only: files are pushed to GCS here, but ALL manifest writes
@@ -613,7 +642,7 @@ jobs:
   # ---------------------------------------------------------------------------
   publish:
     name: Publish manifests
-    needs: build
+    needs: [detect-changes, build]
     if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     concurrency:
       group: update-master-manifest
@@ -708,41 +737,52 @@ jobs:
             go run . "${ARGS[@]}" </dev/null
           done
 
-      - name: Send Discord announcement
-        # Nightly builds only: release announcements are sent by promote.yml.
-        if: ${{ success() && github.ref_type != 'tag' }}
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
-          VERSION_FILE: ${{ github.workspace }}/wendyos/conf/distro/wendyos.conf
-        run: |
-          [[ -z "${DISCORD_WEBHOOK_URL}" ]] && exit 0
-          VERSION=$(grep 'DISTRO_VERSION' "$VERSION_FILE" | head -1 | sed 's/.*"\(.*\)"/\1/')
-          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/nightly"
-          jq -n --arg msg "**WendyOS ${VERSION}-nightly** is out! Full changelog and downloads: ${RELEASE_URL}" '{content: $msg}' | \
-            curl -fsS -o /dev/null \
-              -H "Content-Type: application/json" \
-              -d @- \
-              "$DISCORD_WEBHOOK_URL"
-
       - name: Tag nightly pre-release on GitHub
         # Nightly builds only: release tags already exist (created by promote.yml).
         if: ${{ success() && github.ref_type != 'tag' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.detect-changes.outputs.version }}
         run: |
-          VERSION=$(grep 'DISTRO_VERSION' "$GITHUB_WORKSPACE/wendyos/conf/distro/wendyos.conf" | head -1 | sed 's/.*"\(.*\)"/\1/')
-          TAG="nightly"
-
-          gh release delete "$TAG" --yes --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
-
+          set -euo pipefail
           cd "$GITHUB_WORKSPACE/wendyos"
-          git tag -f "$TAG"
-          git tag -f "${VERSION}-nightly"
-          git push origin "$TAG" --force
-          git push origin "${VERSION}-nightly" --force
 
-          gh release create "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "Nightly ${VERSION}-nightly ($(date -u +%Y-%m-%d))" \
-            --generate-notes \
-            --prerelease
+          # -f/--force for idempotency: a re-run of this job re-tags the same
+          # commit with the same nightly-<timestamp> version.
+          git tag -f "$VERSION"
+          git push origin "$VERSION" --force
+
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists (job re-run), skipping create."
+          else
+            gh release create "$VERSION" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "WendyOS $VERSION" \
+              --generate-notes \
+              --prerelease
+          fi
+
+          # Keep the releases page tidy: retain the 7 most recent nightly
+          # pre-releases. Git tags are kept forever for traceability and
+          # promotion; nightly-YYYYMMDDTHHMMSS sorts chronologically.
+          gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,isPrerelease \
+            --jq '[.[] | select(.isPrerelease and (.tagName | startswith("nightly-"))) | .tagName] | sort | reverse | .[7:][]' |
+            while read -r old; do
+              echo "Pruning old nightly pre-release $old (tag kept)"
+              gh release delete "$old" --yes --repo "$GITHUB_REPOSITORY"
+            done
+
+      - name: Send Discord announcement
+        # Nightly builds only: release announcements are sent by promote.yml.
+        if: ${{ success() && github.ref_type != 'tag' }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          VERSION: ${{ needs.detect-changes.outputs.version }}
+        run: |
+          [[ -z "${DISCORD_WEBHOOK_URL}" ]] && exit 0
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${VERSION}"
+          jq -n --arg msg "**WendyOS ${VERSION}** is out! Full changelog and downloads: ${RELEASE_URL}" '{content: $msg}' | \
+            curl -fsS -o /dev/null \
+              -H "Content-Type: application/json" \
+              -d @- \
+              "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -688,14 +688,17 @@ jobs:
           merge-multiple: true
 
       - name: Write device manifests
+        id: apply
         run: |
           set -euo pipefail
           shopt -s nullglob
           entries=("$GITHUB_WORKSPACE"/manifest-entries/*.json)
           if [[ ${#entries[@]} -eq 0 ]]; then
             echo "::warning::No manifest entries found (did every build fail?); nothing to publish."
+            echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "published=true" >> "$GITHUB_OUTPUT"
           TOKEN=$(gcloud auth print-access-token)
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
           # Build once; up to 15 invocations follow across this step and the
@@ -748,7 +751,9 @@ jobs:
 
       - name: Tag nightly pre-release on GitHub
         # Nightly builds only: release tags already exist (created by promote.yml).
-        if: ${{ success() && github.ref_type != 'tag' }}
+        # Skipped when zero entries were published (every build failed) - never
+        # tag and announce a nightly that has no images behind it.
+        if: ${{ success() && github.ref_type != 'tag' && steps.apply.outputs.published == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.detect-changes.outputs.version }}
@@ -783,7 +788,7 @@ jobs:
 
       - name: Send Discord announcement
         # Nightly builds only: release announcements are sent by promote.yml.
-        if: ${{ success() && github.ref_type != 'tag' }}
+        if: ${{ success() && github.ref_type != 'tag' && steps.apply.outputs.published == 'true' }}
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
           VERSION: ${{ needs.detect-changes.outputs.version }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,18 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Release tag to create (e.g. v1.2.3)"
+        description: "Release version to create, e.g. 1.2.3 (no 'v' prefix; one is stripped if given)"
         type: string
         required: true
       source_nightly:
-        description: "Nightly tag to promote from"
+        description: "Nightly tag to promote from (empty = most recent nightly-* tag)"
         type: string
         required: false
-        default: nightly
+        default: ""
 
 jobs:
   promote:
-    name: Promote ${{ inputs.source_nightly }} to ${{ inputs.release_tag }}
+    name: Promote ${{ inputs.source_nightly || 'latest nightly' }} to ${{ inputs.release_tag }}
     permissions:
       contents: write
     runs-on:
@@ -33,45 +33,69 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9] ]]; then
-            echo "ERROR: release_tag must start with vMAJOR.MINOR.PATCH (got: $RELEASE_TAG)"
+          set -euo pipefail
+          # Versions are plain MAJOR.MINOR.PATCH everywhere (git tags, GitHub
+          # releases, GCS manifests). Strip a leading 'v' typed out of habit.
+          TAG="${RELEASE_TAG#v}"
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: release_tag must be MAJOR.MINOR.PATCH (got: $RELEASE_TAG)"
             exit 1
           fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
 
       - name: Resolve nightly commit and push release tag
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
           SOURCE_NIGHTLY: ${{ inputs.source_nightly }}
         run: |
-          # Resolve the exact commit the nightly tag points to.
-          if ! SHA=$(git rev-parse "refs/tags/${SOURCE_NIGHTLY}^{commit}" 2>/dev/null); then
-            git fetch origin "refs/tags/${SOURCE_NIGHTLY}:refs/tags/${SOURCE_NIGHTLY}"
-            SHA=$(git rev-parse "refs/tags/${SOURCE_NIGHTLY}^{commit}")
-          fi
-          echo "Promoting commit $SHA to $RELEASE_TAG"
+          set -euo pipefail
+          git fetch --tags --quiet
 
-          if git rev-parse "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1 || \
-             git ls-remote --exit-code origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
-            echo "Tag $RELEASE_TAG already exists, skipping create/push."
+          # Default to the most recent nightly: nightly-YYYYMMDDTHHMMSS sorts
+          # chronologically as a string.
+          if [[ -z "$SOURCE_NIGHTLY" ]]; then
+            SOURCE_NIGHTLY=$(git tag -l 'nightly-*' | sort | tail -1)
+            if [[ -z "$SOURCE_NIGHTLY" ]]; then
+              echo "ERROR: no nightly-* tags found; pass source_nightly explicitly."
+              exit 1
+            fi
+            echo "Resolved latest nightly: $SOURCE_NIGHTLY"
+          fi
+
+          SHA=$(git rev-parse "refs/tags/${SOURCE_NIGHTLY}^{commit}")
+          echo "Promoting commit $SHA ($SOURCE_NIGHTLY) to $TAG"
+
+          # The tag-triggered release build publishes with the tag as the
+          # version and fails if it disagrees with DISTRO_VERSION baked into
+          # the image. Catch that here, before any tag exists.
+          DISTRO_VERSION=$(git show "$SHA:conf/distro/wendyos.conf" | grep 'DISTRO_VERSION' | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [[ "$TAG" != "$DISTRO_VERSION" ]]; then
+            echo "ERROR: release tag $TAG != DISTRO_VERSION=$DISTRO_VERSION at $SOURCE_NIGHTLY ($SHA)."
+            echo "Bump DISTRO_VERSION in conf/distro/wendyos.conf, let a nightly build, then promote that."
+            exit 1
+          fi
+
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1 || \
+             git ls-remote --exit-code origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping create/push."
           else
-            git tag "$RELEASE_TAG" "$SHA"
-            git push origin "$RELEASE_TAG"
+            git tag "$TAG" "$SHA"
+            git push origin "$TAG"
           fi
 
       - name: Create GitHub release
         id: create_release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Release $RELEASE_TAG already exists."
+          set -euo pipefail
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists."
             echo "created=false" >> "$GITHUB_OUTPUT"
           else
-            gh release create "$RELEASE_TAG" \
+            gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
-              --title "WendyOS $RELEASE_TAG" \
+              --title "WendyOS $TAG" \
               --generate-notes
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
@@ -80,11 +104,10 @@ jobs:
         if: steps.create_release.outputs.created == 'true'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           [[ -z "${DISCORD_WEBHOOK_URL}" ]] && exit 0
-          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
-          jq -n --arg msg "**WendyOS ${RELEASE_TAG}** is out! Full changelog and downloads: ${RELEASE_URL}" '{content: $msg}' | \
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
+          jq -n --arg msg "**WendyOS ${TAG}** is out! Full changelog and downloads: ${RELEASE_URL}" '{content: $msg}' | \
             curl -fsS -o /dev/null \
               -H "Content-Type: application/json" \
               -d @- \

--- a/tools/publisher/RUNBOOK.md
+++ b/tools/publisher/RUNBOOK.md
@@ -87,7 +87,13 @@ This preserves the version's metadata (release date, changelog) but replaces the
 
 ### 3. Promote a Nightly to Stable
 
-After testing a nightly build on devices and confirming it's good:
+> **CI nightlies (`nightly-YYYYMMDDTHHMMSS`) are NOT promoted with this tool.**
+> They don't embed a semantic version, so there is nothing to strip the
+> `nightly` marker from (the tool refuses with an error). Promote them by
+> running the **"Promote Nightly to Release"** GitHub workflow, which tags the
+> commit `MAJOR.MINOR.PATCH` and rebuilds/publishes the real version.
+
+For legacy `X.Y.Z-nightly` versions, after testing on devices:
 
 ```bash
 go run . \
@@ -206,8 +212,9 @@ The typical flow for Jetson releases:
 
 ### Version Naming Convention
 
-- **Nightly:** `X.Y.Z-nightly` (e.g., `0.10.4-nightly`)
-- **Stable:** `X.Y.Z` (e.g., `0.10.5`)
+- **Nightly (CI):** `nightly-YYYYMMDDTHHMMSS` (e.g., `nightly-20260604T163205`, UTC; sorts chronologically)
+- **Stable:** `X.Y.Z` (e.g., `0.10.5`) — never a `v` prefix
+- **Nightly (legacy):** `X.Y.Z-nightly` (e.g., `0.10.4-nightly`)
 - **Date-based nightly (legacy):** `nightly-YYYY-MM-DD`
 
 ---

--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -2248,6 +2249,14 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 		logger.Fatal("Cannot promote version 'nightly' - must have additional version info (e.g., 'nightly-2025-12-20')")
 	} else if !strings.Contains(strings.ToLower(stableVersion), "nightly") {
 		logger.Fatal("Version does not contain 'nightly' - cannot determine stable version name")
+	}
+
+	// CI nightlies named nightly-YYYYMMDDTHHMMSS don't embed a semantic
+	// version: stripping the prefix would "promote" to a bare timestamp.
+	// Those builds are released by tagging the commit MAJOR.MINOR.PATCH
+	// (promote.yml), which rebuilds and publishes the real version.
+	if !regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`).MatchString(stableVersion) {
+		logger.Fatalf("Derived stable version %q is not MAJOR.MINOR.PATCH - cannot promote %q in place. Use the 'Promote Nightly to Release' GitHub workflow instead.", stableVersion, nightlyVersion)
 	}
 
 	logger.WithField("stable_version", stableVersion).Info("Derived stable version name")


### PR DESCRIPTION
## Summary

PR 3 of 3 — **stacked on #98**; merge #97 → #98 → this.

One version string everywhere: git tag, GitHub release, and GCS manifest version always match. No `v` prefix anywhere.

### Releases
- Tags are plain `MAJOR.MINOR.PATCH`; `build.yml` triggers on `'[0-9]+.[0-9]+.[0-9]+'` (old `v*` tags no longer trigger builds).
- `promote.yml` strips a habit-typed `v`, validates the format, and **refuses to tag if the version differs from `DISTRO_VERSION`** at the promoted commit — caught before any tag/release exists. `detect-changes` re-checks the same invariant to guard manually pushed tags.
- The published version now comes from the tag (single source of truth) instead of being re-derived from `wendyos.conf` in every job.

### Nightlies
- Version is `nightly-YYYYMMDDTHHMMSS` (UTC), computed **once** in `detect-changes` so all 9 matrix jobs + publish share one timestamp.
- Each nightly gets its own git tag + GitHub pre-release, replacing the floating `nightly` tag and its delete/recreate dance. From the user's perspective the change is cosmetic — there's still a nightly release on the Releases page, just timestamp-named.
- Pre-releases beyond the **7 most recent** are pruned (easy to tune); tags are kept forever for traceability.
- `promote.yml`'s `source_nightly` defaults to the most recent `nightly-*` tag (format sorts chronologically).

### Drive-by fix
- The publish job now creates the release **before** announcing it on Discord — the old order announced a link that 404'd until the release-creation step ran.

## Transition notes
- The existing floating `nightly` tag/release are left untouched; delete manually whenever. Until the first new-style nightly lands, promoting requires an explicit `source_nightly` (clear error otherwise).
- Each nightly now creates a **new** manifest version entry + ~15 GB of GCS objects instead of overwriting `X.Y.Z-nightly`. Suggested follow-up (not in this PR): GCS lifecycle rule or publisher pruning for `images/*/nightly-*` older than N days.
