### PR TITLE
fix: add actions:write permission to promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -18,6 +18,7 @@ jobs:
     name: Promote ${{ inputs.source_nightly || 'latest nightly' }} to ${{ inputs.release_tag }}
     permissions:
       contents: write
+      actions: write
     runs-on:
       - runs-on
       - family=c7i-flex.8xlarge


### PR DESCRIPTION
## Summary

- The `promote` job in `promote.yml` was missing `actions: write` permission
- `gh workflow run` dispatches a workflow event, which requires this permission
- Without it, the "Trigger release build" step fails with HTTP 403

## Root cause

[CI run 27212935342](https://github.com/wendylabsinc/WendyOS-Builder/actions/runs/27212935342):
```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
```

The job's permission block only had `contents: write` (for pushing the release tag and creating the GitHub release), but `gh workflow run` additionally requires `actions: write`.

## Test plan

- [ ] Re-run the promote workflow — "Trigger release build" step should succeed