### PR TITLE
fix(rpi): stop removing /data-backed recipes so containerd uses /data

### DIFF
--- a/recipes-core/packagegroups/packagegroup-base-rpi.inc
+++ b/recipes-core/packagegroups/packagegroup-base-rpi.inc
@@ -1,10 +1,13 @@
-# Remove packages that require Mender A/B partitions (/data partition)
-RDEPENDS:${PN}:remove:rpi = " \
-    wendyos-etc-binds \
-    systemd-mount-containerd \
-    swapfile-setup \
-    wendyos-user-data-setup \
-    "
+# Note: the /data-dependent recipes (systemd-mount-containerd, wendyos-etc-binds,
+# swapfile-setup, wendyos-user-data-setup) are intentionally NOT removed here.
+# They are gated on WENDYOS_MENDER in packagegroup-wendyos-base.bb, and 64-bit RPi
+# now sets WENDYOS_MENDER=1 (raspberrypi-common-wendyos.inc, WDY-983), so the /data
+# partition exists. In particular, systemd-mount-containerd bind-mounts containerd's
+# data-root to /data/containerd; without it containerd writes images/snapshots to
+# the small A/B root slot and fills it ("no space left on device"). The earlier
+# :remove:rpi block here predated RPi Mender support (when there was no /data) and
+# became a regression once it was enabled — the WENDYOS_MENDER gate in
+# packagegroup-wendyos-base.bb is the single source of truth for these recipes.
 
 # Add RPi5-specific kernel modules
 RDEPENDS:${PN}:append:rpi = " \


### PR DESCRIPTION
## Problem

On WendyOS RPi 5 (0.15.1), containerd stores images/snapshots on the small ~3.4G A/B **root** slot instead of the large `/data` partition, so the root fills to 100% and `wendy run` fails at the unpack step:

```
/dev/root      3.2G  3.1G   0  100% /        ← containerd lives here (~2.3G)
/dev/mmcblk0p4 106G  142K 101G   1% /data    ← empty
✗ creating container: ... applying layer N: ... no space left on device
```

This is a regression, not a missing config.

## Root cause

The repo already has the right mechanism: `systemd-mount-containerd` installs `var-lib-containerd.mount`, which bind-mounts `/var/lib/containerd` ← `/data/containerd` before `containerd.service` (same pattern as `/var/lib/tee`). `packagegroup-wendyos-base.bb` adds it (and `wendyos-etc-binds`, `swapfile-setup`, `wendyos-user-data-setup`) whenever `WENDYOS_MENDER == '1'`.

But `recipes-core/packagegroups/packagegroup-base-rpi.inc` had a stale `RDEPENDS:${PN}:remove:rpi` block stripping those exact recipes, with the rationale "RPi has no Mender A/B /data partition." BitBake applies `:remove` **last and unconditionally**, so it won over the `WENDYOS_MENDER=1` append in the same package → the containerd bind mount was never installed → containerd fell back to its default data-root on the tiny root slot.

### Timeline
- `70c8530` (Feb 28) "Add RaspberryPi 5 support" — added the remove block. Correct at the time: RPi defaulted to `WENDYOS_MENDER=0`, no `/data`.
- `0441674` (May 22, WDY-983) — enabled Mender on 64-bit RPi (`WENDYOS_MENDER=1` in `raspberrypi-common-wendyos.inc`), giving the Pi a `/data` partition. The remove block was not updated → regression. (`wendyos-user` and `efibootmgr` had already been peeled out of this block in `68f906a` / `05aaee4`; the `/data` recipes were missed.)

## Fix

Delete the stale `:remove:rpi` block (keep the RPi kernel-module appends). The `WENDYOS_MENDER` gate in `packagegroup-wendyos-base.bb` is the single source of truth:
- mender-on RPi (today) → these `/data`-dependent recipes are added (correct).
- any mender-off machine → the gate never adds them, so there is nothing to remove.

This also restores `wendyos-etc-binds`, `swapfile-setup`, and `wendyos-user-data-setup` on RPi, which had the identical latent bug.

## Verification

- `bitbake -e packagegroup-wendyos-base | grep RDEPENDS` should now show `systemd-mount-containerd` retained for an `rpi` machine.
- In a built RPi rootfs, confirm `var-lib-containerd.mount` is present and enabled (`.../local-fs.target.wants/var-lib-containerd.mount`).
- On-device after boot: `findmnt /var/lib/containerd` shows the bind to `/data/containerd`, and containerd images land on `/data`.

## Operational note (out of scope for this change)

Devices already pinned at 100% root won't self-heal from the image fix alone — the bind mount only takes effect on a rebuilt image, and a full root may block the OTA download. Those units likely need manual cleanup (clear `/var/lib/containerd`, prune snapshots) or a reflash to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)