### PR TITLE
Add feed-backed x86 ROCm install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,6 +956,14 @@ driver packaging are not enabled yet. When `WENDYOS_NVIDIA_DGPU = "1"`, the imag
 includes a lightweight CDI generation service that no-ops unless an NVIDIA driver
 and `nvidia-ctk` are present.
 
+ROCm is also optional on x86. The base image ships the open AMD graphics stack,
+but ROCm userland is installed only from a configured WendyOS driver feed via
+`packagegroup-wendyos-rocm`. The installer schedules ROCm automatically only for
+AMD Ryzen AI / AI Max APUs that match AMD's current Ryzen ROCm support matrix,
+such as Ryzen AI 9 HX 370-class and Ryzen AI Max+ 395-class systems. AMD's Ryzen
+ROCm install guide currently requires a 6.14-1018 OEM-or-newer class kernel, so
+older WendyOS x86 kernels will skip ROCm installation until the kernel is updated.
+
 ### x86 Build
 
 ```bash

--- a/conf/distro/include/x86-image.inc
+++ b/conf/distro/include/x86-image.inc
@@ -13,6 +13,7 @@ WENDYOS_SSHD:x86-wendyos ?= "1"
 WENDYOS_DRIVER_FEED_URI ??= ""
 WENDYOS_DRIVER_FEED_GPGCHECK ??= "0"
 WENDYOS_NVIDIA_DRIVER_PACKAGE ??= "packagegroup-wendyos-nvidia-graphics"
+WENDYOS_ROCM_DRIVER_PACKAGE ??= "packagegroup-wendyos-rocm"
 
 # Useful on commodity PCs and harmless on machines without a given bus/device.
 IMAGE_INSTALL:append = " \
@@ -33,6 +34,7 @@ configure_wendyos_driver_feed() {
     install -d ${IMAGE_ROOTFS}${libdir}/wendyos
     cat > ${IMAGE_ROOTFS}${libdir}/wendyos/driver-installer.conf <<EOF
 WENDYOS_NVIDIA_DRIVER_PACKAGE="${WENDYOS_NVIDIA_DRIVER_PACKAGE}"
+WENDYOS_ROCM_DRIVER_PACKAGE="${WENDYOS_ROCM_DRIVER_PACKAGE}"
 EOF
 
     if [ -n "${WENDYOS_DRIVER_FEED_URI}" ]; then

--- a/recipes-core/initrdscripts/files/wendyos-install-drivers.sh
+++ b/recipes-core/initrdscripts/files/wendyos-install-drivers.sh
@@ -44,15 +44,35 @@ detect_gpu_vendor() {
     return 1
 }
 
+detect_supported_ryzen_rocm_apu() {
+    cpu_model="$(sed -n 's/^model name[[:space:]]*: //p' /proc/cpuinfo 2>/dev/null | head -1)"
+
+    case "$cpu_model" in
+        *"AMD Ryzen AI Max"*|\
+        *"AMD Ryzen AI 9 HX 37"*|\
+        *"AMD Ryzen AI 9 HX 47"*|\
+        *"AMD Ryzen AI 9 365"*|\
+        *"AMD Ryzen AI 9 465"*)
+            echo "$cpu_model"
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 write_request() {
     install_amd="$1"
     install_nvidia="$2"
+    install_rocm="$3"
 
     mkdir -p "$REQUEST_DIR"
     umask 077
     {
         echo "INSTALL_AMD=\"${install_amd}\""
         echo "INSTALL_NVIDIA=\"${install_nvidia}\""
+        echo "INSTALL_ROCM=\"${install_rocm}\""
         echo "REQUEST_SOURCE=\"installer\""
     } > "$REQUEST_FILE"
     chmod 0600 "$REQUEST_FILE"
@@ -78,12 +98,24 @@ fi
 
 install_amd=0
 install_nvidia=0
+install_rocm=0
 
 if [ "$detected_amd" = "1" ]; then
     echo "Detected AMD graphics hardware."
     read_answer "Schedule AMD graphics/firmware update from WendyOS feed after first boot? [y/N]: " answer_amd
     if yes_selected "$answer_amd"; then
         install_amd=1
+    fi
+
+    if rocm_apu="$(detect_supported_ryzen_rocm_apu)"; then
+        echo "Detected ROCm-capable Ryzen APU candidate: ${rocm_apu}"
+        echo "ROCm requires a WendyOS ROCm feed package and a supported kernel."
+        read_answer "Schedule ROCm/HIP runtime install from WendyOS feed after first boot? [y/N]: " answer_rocm
+        if yes_selected "$answer_rocm"; then
+            install_rocm=1
+        fi
+    else
+        echo "No AMD Ryzen AI/AI Max ROCm APU was detected; ROCm auto-install will not be scheduled."
     fi
 fi
 
@@ -97,12 +129,12 @@ if [ "$detected_nvidia" = "1" ]; then
     fi
 fi
 
-if [ "$install_amd" != "1" ] && [ "$install_nvidia" != "1" ]; then
+if [ "$install_amd" != "1" ] && [ "$install_nvidia" != "1" ] && [ "$install_rocm" != "1" ]; then
     echo "Skipping GPU driver update scheduling."
     exit 0
 fi
 
-write_request "$install_amd" "$install_nvidia"
+write_request "$install_amd" "$install_nvidia" "$install_rocm"
 
 if [ -r "${TARGET_ROOT}/etc/yum.repos.d/wendyos-drivers.repo" ]; then
     echo "Driver update request saved. WendyOS will download updates on first boot after networking is online."

--- a/recipes-core/packagegroups/packagegroup-wendyos-rocm.bb
+++ b/recipes-core/packagegroups/packagegroup-wendyos-rocm.bb
@@ -1,0 +1,21 @@
+SUMMARY = "WendyOS ROCm runtime package group"
+DESCRIPTION = "Feed target for optional ROCm runtime support on validated x86 AMD GPUs and APUs"
+LICENSE = "MIT"
+
+PR = "r0"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+COMPATIBLE_MACHINE = "(genericx86-64-wendyos)"
+
+# This packagegroup is intentionally not installed in the base image. It is the
+# package name requested by the x86 driver updater when a WendyOS driver feed
+# provides a validated ROCm stack for the running kernel and hardware.
+#
+# WendyOS-Builder does not provide ROCm recipes yet. Keep the default empty so
+# this layer remains buildable; a ROCm driver feed layer should override this
+# with package names such as rocm-core, rocminfo, and rocm-hip-runtime.
+WENDYOS_ROCM_RUNTIME_PACKAGES ??= ""
+
+RRECOMMENDS:${PN} = "${WENDYOS_ROCM_RUNTIME_PACKAGES}"

--- a/recipes-extended/wendyos-user/wendyos-user_1.0.bb
+++ b/recipes-extended/wendyos-user/wendyos-user_1.0.bb
@@ -18,10 +18,11 @@ PACKAGES = "${PN}-data-setup ${PN}"
 
 # Create wendy user - simplified group list (non-existent groups cause failures)
 USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM:${PN} = "-r render"
 # Password 'wendy' hash generated with: openssl passwd -6 -salt 5ixFr0sKRtsKKKhY wendy
 # useradd -m creates /home/wendy on the rootfs; on Tegra, the first-boot service
 # in wendyos-user-data-setup re-initializes it from persistent storage (/data/home)
-USERADD_PARAM:${PN} = "-m -d /home/wendy -s /bin/bash -G dialout,video,audio,users -p '\$6\$5ixFr0sKRtsKKKhY\$5SyCVB9y95JEITWZ8AMcMCrMF4Rvq97ymUjEoUCBKfTl7vWHjTLEboowxWF6hIJgBUMOnJQfeIRPPwYCUaIwm.' wendy"
+USERADD_PARAM:${PN} = "-m -d /home/wendy -s /bin/bash -G dialout,video,audio,users,render -p '\$6\$5ixFr0sKRtsKKKhY\$5SyCVB9y95JEITWZ8AMcMCrMF4Rvq97ymUjEoUCBKfTl7vWHjTLEboowxWF6hIJgBUMOnJQfeIRPPwYCUaIwm.' wendy"
 
 SYSTEMD_SERVICE:${PN}-data-setup = "wendyos-user-setup.service"
 SYSTEMD_AUTO_ENABLE:${PN}-data-setup = "enable"

--- a/recipes-support/wendyos-driver-installer/files/wendyos-driver-update.sh
+++ b/recipes-support/wendyos-driver-installer/files/wendyos-driver-update.sh
@@ -6,8 +6,10 @@ REQUEST_FILE="/etc/wendyos/driver-request.conf"
 REPO_FILE="/etc/yum.repos.d/wendyos-drivers.repo"
 CONFIG_FILE="/usr/lib/wendyos/driver-installer.conf"
 NVIDIA_DRIVER_PACKAGE="packagegroup-wendyos-nvidia-graphics"
+ROCM_DRIVER_PACKAGE="packagegroup-wendyos-rocm"
 INSTALL_AMD="0"
 INSTALL_NVIDIA="0"
+INSTALL_ROCM="0"
 
 log() {
     echo "wendyos-driver-update: $*"
@@ -46,6 +48,81 @@ installed_package_list() {
     done
 }
 
+detect_amd_gpu() {
+    for device_dir in /sys/bus/pci/devices/*; do
+        [ -r "${device_dir}/vendor" ] || continue
+        [ -r "${device_dir}/class" ] || continue
+
+        class="$(cat "${device_dir}/class" 2>/dev/null || true)"
+        case "$class" in
+            0x03*) ;;
+            *) continue ;;
+        esac
+
+        vendor="$(cat "${device_dir}/vendor" 2>/dev/null || true)"
+        [ "$vendor" = "0x1002" ] && return 0
+    done
+
+    return 1
+}
+
+detect_supported_ryzen_rocm_apu() {
+    cpu_model="$(sed -n 's/^model name[[:space:]]*: //p' /proc/cpuinfo 2>/dev/null | head -1)"
+
+    case "$cpu_model" in
+        *"AMD Ryzen AI Max"*|\
+        *"AMD Ryzen AI 9 HX 37"*|\
+        *"AMD Ryzen AI 9 HX 47"*|\
+        *"AMD Ryzen AI 9 365"*|\
+        *"AMD Ryzen AI 9 465"*)
+            log "detected ROCm-capable Ryzen APU candidate: ${cpu_model}"
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+kernel_at_least() {
+    required_major="$1"
+    required_minor="$2"
+    kernel_release="$(uname -r)"
+    kernel_major="$(printf '%s\n' "$kernel_release" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')"
+    kernel_minor="$(printf '%s\n' "$kernel_release" | sed -n 's/^[0-9][0-9]*\.\([0-9][0-9]*\).*/\1/p')"
+
+    [ -n "$kernel_major" ] || return 1
+    [ -n "$kernel_minor" ] || return 1
+
+    [ "$kernel_major" -gt "$required_major" ] && return 0
+    [ "$kernel_major" -eq "$required_major" ] && [ "$kernel_minor" -ge "$required_minor" ] && return 0
+    return 1
+}
+
+rocm_preflight() {
+    if ! detect_amd_gpu; then
+        log "no AMD display controller detected; skipping ROCm install"
+        return 1
+    fi
+
+    if detect_supported_ryzen_rocm_apu && ! kernel_at_least 6 14; then
+        log "ROCm on Ryzen APUs requires a 6.14-1018 OEM-or-newer class kernel; current kernel is $(uname -r)"
+        return 1
+    fi
+
+    if [ ! -e /dev/kfd ]; then
+        log "/dev/kfd is not present; amdgpu compute support is not available"
+        return 1
+    fi
+
+    if ! ls /dev/dri/renderD* >/dev/null 2>&1; then
+        log "no DRM render node found; ROCm user access cannot be validated"
+        return 1
+    fi
+
+    return 0
+}
+
 update_amd_stack() {
     packages="$(installed_package_list | tr '\n' ' ')"
     if [ -z "$packages" ]; then
@@ -69,10 +146,41 @@ install_nvidia_stack() {
     dnf_driver_repo install "$NVIDIA_DRIVER_PACKAGE"
 }
 
+install_rocm_stack() {
+    if ! rocm_preflight; then
+        return 1
+    fi
+
+    log "checking WendyOS feed for ${ROCM_DRIVER_PACKAGE}"
+    if ! dnf -q --disablerepo='*' --enablerepo='wendyos-drivers' list --available "$ROCM_DRIVER_PACKAGE" >/dev/null 2>&1 && \
+       ! rpm -q "$ROCM_DRIVER_PACKAGE" >/dev/null 2>&1; then
+        log "${ROCM_DRIVER_PACKAGE} is not available in the configured WendyOS driver feed"
+        return 1
+    fi
+
+    dnf_driver_repo install "$ROCM_DRIVER_PACKAGE" || return 1
+
+    if command -v usermod >/dev/null 2>&1 && id wendy >/dev/null 2>&1; then
+        usermod -a -G render,video wendy 2>/dev/null || \
+            log "could not add wendy to render/video groups; check group availability"
+    fi
+
+    if command -v rocminfo >/dev/null 2>&1; then
+        if rocminfo >/var/log/wendyos-rocminfo.log 2>&1; then
+            log "rocminfo validation succeeded"
+        else
+            log "rocminfo validation failed; see /var/log/wendyos-rocminfo.log"
+            return 1
+        fi
+    else
+        log "ROCm package installed but rocminfo is not present"
+    fi
+}
+
 main() {
     load_config
 
-    if [ "$INSTALL_AMD" != "1" ] && [ "$INSTALL_NVIDIA" != "1" ]; then
+    if [ "$INSTALL_AMD" != "1" ] && [ "$INSTALL_NVIDIA" != "1" ] && [ "$INSTALL_ROCM" != "1" ]; then
         log "no driver update request found"
         return 0
     fi
@@ -93,6 +201,9 @@ main() {
     fi
     if [ "$INSTALL_NVIDIA" = "1" ]; then
         install_nvidia_stack || status=1
+    fi
+    if [ "$INSTALL_ROCM" = "1" ]; then
+        install_rocm_stack || status=1
     fi
 
     if [ "$status" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- add an installer prompt that can schedule ROCm/HIP runtime installation after first boot on supported AMD Ryzen AI / AI Max x86 systems
- add first-boot ROCm preflight checks for AMD GPU presence, supported Ryzen APU classes, kernel version, `/dev/kfd`, and render nodes
- add a `packagegroup-wendyos-rocm` feed target and wire it into the x86 driver installer config
- add the `wendy` user to the `render` group for GPU compute access
- document the current ROCm caveat for generic x86_64 builds

## Caveat
This adds the WendyOS installer and first-boot plumbing for ROCm, but it intentionally does not bundle ROCm runtime packages yet. The new packagegroup defaults empty until a ROCm-capable Yocto feed/layer provides package contents.

For Ryzen AI / AI Max APU systems such as GMKtec-style Strix/Halo machines, the first-boot installer also requires a 6.14-class kernel before attempting ROCm. Current 6.6-based images will skip ROCm with a log message until the kernel work lands.

Refs #102

## Validation
- `sh -n recipes-core/initrdscripts/files/wendyos-install-drivers.sh`
- `sh -n recipes-support/wendyos-driver-installer/files/wendyos-driver-update.sh`
- `git diff --check -- . ':(exclude)recipes-kernel/linux/files/*.patch'`
- `MACHINE=genericx86-64-wendyos bitbake -p`
- `MACHINE=genericx86-64-wendyos bitbake packagegroup-wendyos-rocm -c package`
- `MACHINE=genericx86-64-wendyos bitbake wendyos-image wendyos-installer-image`
