### PR TITLE
fix: pin wendy-agent release so sstate doesn't bundle stale binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,6 +384,11 @@ jobs:
         working-directory: ${{ github.workspace }}/wendyos
         env:
           MACHINE: ${{ steps.vars.outputs.machine }}
+          # Lets the Makefile resolve the latest wendy-agent release tag
+          # without hitting unauthenticated GitHub API rate limits. The tag
+          # pins WENDY_AGENT_VERSION so new agent releases invalidate the
+          # wendyos-agent sstate object instead of reusing a stale binary.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make build MACHINE="$MACHINE"
 
       # ---------- Build cache: save to S3 ----------------------------------

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,19 @@ IMAGE_TARGET ?= wendyos-image
 # has the Yocto host prerequisites installed; local dev leaves it unset.
 WENDYOS_HOST_BUILD ?= 0
 
+# wendy-agent release tag to bundle into the image. Resolved to the latest
+# GitHub release once per build so the wendyos-agent recipe's task signature
+# changes whenever a new agent ships — warm sstate would otherwise keep
+# bundling the old binary. Override with WENDY_AGENT_VERSION=<tag>. If the
+# lookup fails (offline, rate-limited) it stays empty and the recipe falls
+# back to its unpinned "latest" lookup, which is not cache-safe.
+ifneq ($(filter build build-sdk,$(MAKECMDGOALS)),)
+# Uses GITHUB_TOKEN when set (CI) to avoid unauthenticated API rate limits.
+WENDY_AGENT_VERSION ?= $(shell curl -fsSL --connect-timeout 10 $(if $(GITHUB_TOKEN),-H "Authorization: Bearer $(GITHUB_TOKEN)") https://api.github.com/repos/wendylabsinc/WendyOS/releases/latest 2>/dev/null | grep -m1 '"tag_name"' | cut -d '"' -f 4)
+endif
+# Force a single expansion so the GitHub lookup runs at most once.
+WENDY_AGENT_VERSION := $(WENDY_AGENT_VERSION)
+
 # Flash configuration
 FLASH_DEVICE ?=
 FLASH_IMAGE_SIZE ?= 64G
@@ -175,7 +188,7 @@ build: _check-machine _check-setup _ensure-volumes
 		cd $(PROJECT_DIR) && \
 		. ./$(BUILD_DIR)/.wendyos-env && \
 		source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-		BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET); \
+		BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDY_AGENT_VERSION" MACHINE=$(MACHINE) WENDY_AGENT_VERSION="$(WENDY_AGENT_VERSION)" bitbake $(IMAGE_TARGET); \
 	elif [ "$$(uname)" = "Darwin" ]; then \
 		docker run \
 			--rm -t \
@@ -192,7 +205,7 @@ build: _check-machine _check-setup _ensure-volumes
 				cd $(DOCKER_WORKDIR) && \
 				. ./$(BUILD_DIR)/.wendyos-env && \
 				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDY_AGENT_VERSION" MACHINE=$(MACHINE) WENDY_AGENT_VERSION="$(WENDY_AGENT_VERSION)" bitbake $(IMAGE_TARGET) \
 			'; \
 	else \
 		cd $(DOCKER_DIR) && docker run \
@@ -208,7 +221,7 @@ build: _check-machine _check-setup _ensure-volumes
 				cd $(DOCKER_WORKDIR) && \
 				. ./$(BUILD_DIR)/.wendyos-env && \
 				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDY_AGENT_VERSION" MACHINE=$(MACHINE) WENDY_AGENT_VERSION="$(WENDY_AGENT_VERSION)" bitbake $(IMAGE_TARGET) \
 			'; \
 	fi
 	@printf "\n"
@@ -239,7 +252,7 @@ build-sdk: _check-machine _check-setup _ensure-volumes
 				cd $(DOCKER_WORKDIR) && \
 				. ./$(BUILD_DIR)/.wendyos-env && \
 				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDY_AGENT_VERSION" MACHINE=$(MACHINE) WENDY_AGENT_VERSION="$(WENDY_AGENT_VERSION)" bitbake $(IMAGE_TARGET) -c populate_sdk \
 			'; \
 	else \
 		cd $(DOCKER_DIR) && docker run \
@@ -255,7 +268,7 @@ build-sdk: _check-machine _check-setup _ensure-volumes
 				cd $(DOCKER_WORKDIR) && \
 				. ./$(BUILD_DIR)/.wendyos-env && \
 				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDY_AGENT_VERSION" MACHINE=$(MACHINE) WENDY_AGENT_VERSION="$(WENDY_AGENT_VERSION)" bitbake $(IMAGE_TARGET) -c populate_sdk \
 			'; \
 	fi
 	@printf "\n"

--- a/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
+++ b/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
@@ -12,7 +12,7 @@ if [ -f /etc/default/wendy-agent ]; then
 fi
 
 # Default values if not configured
-GITHUB_REPO="${WENDYOS_AGENT_GITHUB_REPO:-wendylabsinc/wendy-agent}"
+GITHUB_REPO="${WENDYOS_AGENT_GITHUB_REPO:-wendylabsinc/WendyOS}"
 VERSION="${WENDYOS_AGENT_VERSION:-latest}"
 ARCH="aarch64"  # Hardcoded for RPi
 

--- a/recipes-core/wendyos-agent/files/wendyos-agent-updater.service
+++ b/recipes-core/wendyos-agent/files/wendyos-agent-updater.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=WendyOS Agent Updater
-Documentation=https://github.com/wendylabsinc/wendy-agent
+Documentation=https://github.com/wendylabsinc/WendyOS
 After=network-online.target
 Wants=network-online.target
 

--- a/recipes-core/wendyos-agent/files/wendyos-agent-updater.sh
+++ b/recipes-core/wendyos-agent/files/wendyos-agent-updater.sh
@@ -12,7 +12,7 @@ if [ -f /etc/default/wendy-agent ]; then
 fi
 
 # Default values if not configured
-GITHUB_REPO="${WENDYOS_AGENT_GITHUB_REPO:-wendylabsinc/wendy-agent}"
+GITHUB_REPO="${WENDYOS_AGENT_GITHUB_REPO:-wendylabsinc/WendyOS}"
 VERSION="${WENDYOS_AGENT_VERSION:-latest}"
 ARCH="aarch64"  # Hardcoded for RPi
 

--- a/recipes-core/wendyos-agent/files/wendyos-agent-updater.timer
+++ b/recipes-core/wendyos-agent/files/wendyos-agent-updater.timer
@@ -1,6 +1,6 @@
 [Unit]
 Description=WendyOS Agent Update Timer
-Documentation=https://github.com/wendylabsinc/wendy-agent
+Documentation=https://github.com/wendylabsinc/WendyOS
 
 [Timer]
 # Run on boot after network is available

--- a/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
+++ b/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
@@ -1,13 +1,18 @@
 
 # [Note]
-# This recipe fetches the wendyos-agent binary from GitHub at build time
-# inside do_compile using wget/curl, bypassing SRC_URI checksums and breaking
-# build reproducibility (two builds may produce different binaries).
-# It also uses 'SRCREV = "${AUTOREV}"'' for the source repo.
+# This recipe fetches the wendy-agent binary from GitHub at build time inside
+# do_compile using wget/curl, bypassing SRC_URI checksums.
 #
-# [Fix]
-# Pin the binary download URL and its sha256sum in SRC_URI, or use a proper
-# recipe with SRC_URI[sha256sum].
+# WENDY_AGENT_VERSION pins the release tag to bundle. The Makefile resolves it
+# to the latest GitHub release before invoking bitbake and passes it through
+# the environment, so a new release changes this task's signature and
+# invalidates stale sstate. If unset/unresolvable it falls back to "latest",
+# which queries the GitHub API here in do_compile — that path is NOT
+# cache-safe: warm sstate will keep bundling whatever was latest when the
+# cache object was created.
+#
+# [Remaining fix]
+# Pin the asset sha256 as well (SRC_URI[sha256sum]) for full reproducibility.
 # Runtime self-update should remain in wendyos-agent-updater.service,
 # not at build time.
 
@@ -29,25 +34,44 @@ inherit systemd
 SYSTEMD_SERVICE:${PN} = "wendyos-agent.service wendyos-agent-updater.service wendyos-agent-updater.timer"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
+# GitHub repo hosting wendy-agent release assets
+# (formerly wendylabsinc/wendy-agent, renamed to wendylabsinc/WendyOS)
+WENDY_AGENT_GITHUB_REPO ?= "wendylabsinc/WendyOS"
+# Release tag to bundle; resolved by the Makefile, see header note.
+WENDY_AGENT_VERSION ?= "latest"
+
 do_compile() {
     bbnote "Downloading wendy-agent binary for aarch64..."
 
-    # Get the latest stable release from GitHub (excludes pre-releases)
-    RELEASES_URL="https://api.github.com/repos/wendylabsinc/wendy-agent/releases/latest"
+    AGENT_VERSION="${WENDY_AGENT_VERSION}"
+    if [ -z "${AGENT_VERSION}" ]; then
+        AGENT_VERSION="latest"
+    fi
 
-    # Fetch latest stable release
-    wget -q -O ${B}/release.json "${RELEASES_URL}" || \
-        curl -sL -o ${B}/release.json "${RELEASES_URL}" || \
-        bbfatal "Failed to fetch latest release from GitHub"
+    if [ "${AGENT_VERSION}" = "latest" ]; then
+        bbwarn "WENDY_AGENT_VERSION is not pinned; querying GitHub for the latest release. Warm sstate may bundle an older agent."
 
-    # Extract download URL for aarch64 binary (match .tar.gz files only)
-    # Asset naming: wendy-agent-linux-arm64-*.tar.gz (formerly wendy-agent-linux-static-musl-aarch64)
-    DOWNLOAD_URL=$(cat ${B}/release.json | \
-        grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*wendy-agent-linux-arm64[^"]*\.tar\.gz[^"]*"' | \
-        head -1 | cut -d'"' -f4)
+        # Get the latest stable release from GitHub (excludes pre-releases)
+        RELEASES_URL="https://api.github.com/repos/${WENDY_AGENT_GITHUB_REPO}/releases/latest"
 
-    if [ -z "${DOWNLOAD_URL}" ]; then
-        bbfatal "Failed to find wendy-agent-linux-static-musl-aarch64 binary in release"
+        # Fetch latest stable release
+        wget -q -O ${B}/release.json "${RELEASES_URL}" || \
+            curl -sL -o ${B}/release.json "${RELEASES_URL}" || \
+            bbfatal "Failed to fetch latest release from GitHub"
+
+        # Extract download URL for aarch64 binary (match .tar.gz files only)
+        # Asset naming: wendy-agent-linux-arm64-*.tar.gz (formerly wendy-agent-linux-static-musl-aarch64)
+        DOWNLOAD_URL=$(cat ${B}/release.json | \
+            grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*wendy-agent-linux-arm64[^"]*\.tar\.gz[^"]*"' | \
+            head -1 | cut -d'"' -f4)
+
+        if [ -z "${DOWNLOAD_URL}" ]; then
+            bbfatal "Failed to find wendy-agent-linux-arm64 binary in release"
+        fi
+    else
+        # Pinned tag: assets are named wendy-agent-linux-arm64-<tag>.tar.gz
+        DOWNLOAD_URL="https://github.com/${WENDY_AGENT_GITHUB_REPO}/releases/download/${WENDY_AGENT_VERSION}/wendy-agent-linux-arm64-${WENDY_AGENT_VERSION}.tar.gz"
+        bbnote "Using pinned wendy-agent release: ${WENDY_AGENT_VERSION}"
     fi
 
     bbnote "Downloading from: ${DOWNLOAD_URL}"


### PR DESCRIPTION
## Problem

The `wendyos-agent` recipe downloads the "latest" agent release inside `do_compile`, but bitbake's sstate signature only hashes the recipe's inputs — not what "latest" resolves to. With warm caches (CI's EBS/S3 sstate layers, local Docker volumes), the previously packaged binary is restored via setscene and the download never re-runs, so images keep bundling whatever agent was current when the sstate object was first created. Only the on-device updater timer fixed it after boot.

## Fix

- The Makefile resolves the latest release tag once per `make build`/`make build-sdk` and passes it to bitbake as `WENDY_AGENT_VERSION` (via `BB_ENV_PASSTHROUGH_ADDITIONS`, all five invocations).
- The recipe references the tag in `do_compile`, so a new release changes the task hash and invalidates stale sstate; an unchanged release stays a cache hit. Pinned builds download `releases/download/<tag>/wendy-agent-linux-arm64-<tag>.tar.gz` directly instead of querying the API.
- If the lookup fails (offline/rate-limited), the recipe falls back to the previous unpinned behavior with a `bbwarn` that it isn't cache-safe.
- CI passes `GITHUB_TOKEN` to the build step so the tag lookup avoids unauthenticated API rate limits on shared runner IPs.
- Repo references updated from `wendylabsinc/wendy-agent` to its new home `wendylabsinc/WendyOS` (recipe API URL, updater/download script defaults, systemd unit `Documentation=` links). Override via `WENDYOS_AGENT_GITHUB_REPO` in `/etc/default/wendy-agent` still works.

Remaining gap (pre-existing, noted in the recipe header): the asset sha256 is still not pinned, so the download itself isn't checksum-verified.

## Validation

- `make -n build MACHINE=raspberrypi5-wendyos` resolves and embeds `WENDY_AGENT_VERSION="2026.06.10-142200"` into the bitbake invocation.
- Constructed pinned download URL for that tag returns HTTP 200.
- Extracted `do_compile` body (with bitbake vars substituted) passes `bash -n`.
- No `wendylabsinc/wendy-agent` references remain outside a "formerly" comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)