### PR TITLE
fix(agent): pin wendyos-agent to a resolved release so CI ships the latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,6 +380,38 @@ jobs:
       # by conf/template/include/local/common.inc, which matches the S3 sync paths
       # below, no auto.conf override needed.
 
+      # Resolve the latest *stable* wendyos-agent release (tag + asset sha256)
+      # and export them so the wendyos-agent recipe pins this exact version.
+      # This is what makes "ship the latest agent on every run" actually work:
+      # the recipe embeds the version + checksum in SRC_URI, so a new release
+      # changes the do_fetch signature and sstate re-fetches instead of reusing
+      # a stale cached binary. Authenticated to avoid the 60/hr anon API limit.
+      - name: Resolve latest wendyos-agent version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_json="$(curl -sSfL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/wendylabsinc/WendyOS/releases/latest")"
+
+          version="$(jq -r '.tag_name' <<<"$release_json")"
+          sha="$(jq -r '.assets[]
+            | select(.name | test("^wendy-agent-linux-arm64-.*\\.tar\\.gz$"))
+            | .digest' <<<"$release_json" | sed 's/^sha256://')"
+
+          if [[ -z "$version" || "$version" == "null" || -z "$sha" || "$sha" == "null" ]]; then
+            echo "Failed to resolve wendyos-agent version/sha (version='$version' sha='$sha')" >&2
+            exit 1
+          fi
+
+          echo "Resolved wendyos-agent $version (sha256=$sha)"
+          {
+            echo "WENDYOS_AGENT_VERSION=$version"
+            echo "WENDYOS_AGENT_SHA256=$sha"
+          } >> "$GITHUB_ENV"
+
       - name: Build image
         working-directory: ${{ github.workspace }}/wendyos
         env:

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ build: _check-machine _check-setup _ensure-volumes
 		cd $(PROJECT_DIR) && \
 		. ./$(BUILD_DIR)/.wendyos-env && \
 		source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-		BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET); \
+		BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDYOS_AGENT_VERSION WENDYOS_AGENT_SHA256" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET); \
 	elif [ "$$(uname)" = "Darwin" ]; then \
 		docker run \
 			--rm -t \
@@ -192,7 +192,7 @@ build: _check-machine _check-setup _ensure-volumes
 				cd $(DOCKER_WORKDIR) && \
 				. ./$(BUILD_DIR)/.wendyos-env && \
 				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDYOS_AGENT_VERSION WENDYOS_AGENT_SHA256" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
 			'; \
 	else \
 		cd $(DOCKER_DIR) && docker run \
@@ -208,7 +208,7 @@ build: _check-machine _check-setup _ensure-volumes
 				cd $(DOCKER_WORKDIR) && \
 				. ./$(BUILD_DIR)/.wendyos-env && \
 				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDYOS_AGENT_VERSION WENDYOS_AGENT_SHA256" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) \
 			'; \
 	fi
 	@printf "\n"
@@ -239,7 +239,7 @@ build-sdk: _check-machine _check-setup _ensure-volumes
 				cd $(DOCKER_WORKDIR) && \
 				. ./$(BUILD_DIR)/.wendyos-env && \
 				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDYOS_AGENT_VERSION WENDYOS_AGENT_SHA256" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
 			'; \
 	else \
 		cd $(DOCKER_DIR) && docker run \
@@ -255,7 +255,7 @@ build-sdk: _check-machine _check-setup _ensure-volumes
 				cd $(DOCKER_WORKDIR) && \
 				. ./$(BUILD_DIR)/.wendyos-env && \
 				source ./repos/$$WENDYOS_LAYER_TREE/openembedded-core/oe-init-build-env $(BUILD_DIR) && \
-				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
+				BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDYOS_AGENT_VERSION WENDYOS_AGENT_SHA256" MACHINE=$(MACHINE) bitbake $(IMAGE_TARGET) -c populate_sdk \
 			'; \
 	fi
 	@printf "\n"

--- a/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
+++ b/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
@@ -1,26 +1,39 @@
-
-# [Note]
-# This recipe fetches the wendyos-agent binary from GitHub at build time
-# inside do_compile using wget/curl, bypassing SRC_URI checksums and breaking
-# build reproducibility (two builds may produce different binaries).
-# It also uses 'SRCREV = "${AUTOREV}"'' for the source repo.
-#
-# [Fix]
-# Pin the binary download URL and its sha256sum in SRC_URI, or use a proper
-# recipe with SRC_URI[sha256sum].
-# Runtime self-update should remain in wendyos-agent-updater.service,
-# not at build time.
-
 SUMMARY = "WendyOS Agent"
 DESCRIPTION = "WendyOS agent binary for device management"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI = "file://wendyos-agent.service \
+# The wendyos-agent binary is published per-release in wendylabsinc/WendyOS.
+#
+# CI resolves the latest *stable* release (tag + asset sha256) and passes them
+# in via WENDYOS_AGENT_VERSION / WENDYOS_AGENT_SHA256 (whitelisted through
+# BB_ENV_PASSTHROUGH_ADDITIONS in the Makefile). Pinning both the version and
+# the checksum makes the fetch reproducible AND lets sstate notice a new
+# release: the version is embedded in SRC_URI and the checksum, so both become
+# part of the do_fetch task signature. A new release therefore changes the
+# signature and re-runs the fetch instead of serving a stale cached binary --
+# which is exactly the bug this recipe used to have when it downloaded the
+# binary inside do_compile (invisible to BitBake's hashing).
+#
+# The ??= defaults are the fallback for local builds with no env override:
+# they pin a known-good version so local builds stay reproducible. Bump them
+# when you want local builds to track a newer agent; CI always overrides them
+# with the latest stable release.
+WENDYOS_AGENT_VERSION ??= "2026.06.10-142200"
+WENDYOS_AGENT_SHA256  ??= "29f024ae06c83deba114b588fefa147a8a632e24eef1ff69c715fa857f58bf82"
+
+# Surface the resolved agent version as the package version for traceability
+# (e.g. in the image manifest). Hyphens are not valid in PV, so map them to
+# dots: 2026.06.10-142200 -> 2026.06.10.142200.
+PV = "${@d.getVar('WENDYOS_AGENT_VERSION').replace('-', '.')}"
+
+SRC_URI = "https://github.com/wendylabsinc/WendyOS/releases/download/${WENDYOS_AGENT_VERSION}/wendy-agent-linux-arm64-${WENDYOS_AGENT_VERSION}.tar.gz;name=agent \
+           file://wendyos-agent.service \
            file://wendyos-agent-updater.service \
            file://wendyos-agent-updater.timer \
            file://wendyos-agent-updater.sh \
            file://download-wendyos-agent.sh"
+SRC_URI[agent.sha256sum] = "${WENDYOS_AGENT_SHA256}"
 
 S = "${UNPACKDIR}"
 
@@ -29,56 +42,20 @@ inherit systemd
 SYSTEMD_SERVICE:${PN} = "wendyos-agent.service wendyos-agent-updater.service wendyos-agent-updater.timer"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
-do_compile() {
-    bbnote "Downloading wendy-agent binary for aarch64..."
-
-    # Get the latest stable release from GitHub (excludes pre-releases)
-    RELEASES_URL="https://api.github.com/repos/wendylabsinc/wendy-agent/releases/latest"
-
-    # Fetch latest stable release
-    wget -q -O ${B}/release.json "${RELEASES_URL}" || \
-        curl -sL -o ${B}/release.json "${RELEASES_URL}" || \
-        bbfatal "Failed to fetch latest release from GitHub"
-
-    # Extract download URL for aarch64 binary (match .tar.gz files only)
-    # Asset naming: wendy-agent-linux-arm64-*.tar.gz (formerly wendy-agent-linux-static-musl-aarch64)
-    DOWNLOAD_URL=$(cat ${B}/release.json | \
-        grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*wendy-agent-linux-arm64[^"]*\.tar\.gz[^"]*"' | \
-        head -1 | cut -d'"' -f4)
-
-    if [ -z "${DOWNLOAD_URL}" ]; then
-        bbfatal "Failed to find wendy-agent-linux-static-musl-aarch64 binary in release"
-    fi
-
-    bbnote "Downloading from: ${DOWNLOAD_URL}"
-
-    # Download the binary archive
-    wget -O ${B}/wendy-agent.tar.gz "${DOWNLOAD_URL}" || \
-        curl -L -o ${B}/wendy-agent.tar.gz "${DOWNLOAD_URL}" || \
-        bbfatal "Failed to download wendy-agent binary"
-
-    # Extract the archive
-    tar -xzf ${B}/wendy-agent.tar.gz -C ${B}
-
-    # Find and prepare the binary (exclude wendy-cli)
-    if [ ! -f ${B}/wendy-agent ]; then
-        BINARY=$(find ${B} -name wendy-agent -type f ! -path "*/wendy-cli*" | head -1)
-        if [ -n "${BINARY}" ]; then
-            mv "${BINARY}" ${B}/wendy-agent
-        else
-            bbfatal "wendy-agent binary not found in archive"
-        fi
-    fi
-
-    chmod +x ${B}/wendy-agent
-    bbnote "wendy-agent binary ready"
-}
-
 do_install() {
-    # Install the pre-downloaded binary into /usr/local/bin so it lives
-    # alongside runtime updates written by wendyos-agent-updater.sh.
+    # Install the pre-built binary (fetched + checksum-verified by do_fetch)
+    # into /usr/local/bin so it lives alongside runtime updates written by
+    # wendyos-agent-updater.sh. The tarball unpacks to
+    # wendy-agent-linux-arm64/wendy-agent; find it rather than hard-coding the
+    # inner directory so a future asset layout change fails loudly here instead
+    # of silently shipping nothing.
+    BINARY=$(find ${S} -type f -name wendy-agent ! -path "*/wendy-cli*" | head -1)
+    if [ -z "${BINARY}" ]; then
+        bbfatal "wendy-agent binary not found in unpacked release archive"
+    fi
+
     install -d ${D}/usr/local/bin
-    install -m 0755 ${B}/wendy-agent ${D}/usr/local/bin/wendy-agent
+    install -m 0755 "${BINARY}" ${D}/usr/local/bin/wendy-agent
 
     # Install systemd services
     install -d ${D}${systemd_system_unitdir}
@@ -103,9 +80,6 @@ FILES:${PN} = "/usr/local/bin/wendy-agent \
                ${systemd_system_unitdir}/* \
                /var/lib/wendyos-agent \
                /var/lib/wendy-agent"
-
-# Allow network access during build
-do_compile[network] = "1"
 
 # Skip QA checks for pre-built binary
 INSANE_SKIP:${PN} += "already-stripped"


### PR DESCRIPTION
## Problem

Feedback reported that images ship **stale** wendy-agent (now `wendyos`) binaries instead of the latest on every CI run.

Root cause: `recipes-core/wendyos-agent/wendyos-agent_1.0.bb` fetched the binary inside `do_compile` via `wget`/`curl` from `releases/latest`. BitBake hashes only a task's *declared inputs* (recipe text, `file://` sources, vars) and has no visibility into the content behind that URL. So when a new agent release is published, **no hashed input changes**, the `do_compile` signature stays identical, and on every warm-cache run sstate reuses the cached artifact and never re-downloads. The download only happened on a cold cache. (No `nostamp`/`SRCREV`/sstate-exclusion busted it.)

The repo rename `wendy-agent` → `WendyOS` is *not* a separate cause — the API follows the 301 redirect — but the reference is updated here for hygiene.

## Fix

Resolve a **concrete version + sha256 in CI** and feed both into the recipe, then fetch via the normal `do_fetch` with a pinned checksum. The version and checksum are now hashed inputs, so a new release changes the `do_fetch` signature and sstate correctly re-fetches. This also closes the reproducibility hole the recipe header flagged and routes the tarball through `downloads/` (DL_DIR).

- **recipe**: checksummed `SRC_URI` from `WENDYOS_AGENT_VERSION` / `WENDYOS_AGENT_SHA256`; `??=` defaults as a reproducible fallback for local builds; `PV` reflects the agent version; `do_compile` network fetch removed.
- **Makefile**: the two vars added to the `BB_ENV_PASSTHROUGH_ADDITIONS` allowlist on all bitbake invocations.
- **build.yml**: new step resolves the latest **stable** release (tag + asset `digest`) and exports both to `$GITHUB_ENV` before the build.

"Latest" = latest **stable** release (excludes pre-releases), per design decision.

## Verification

- Resolve step tested verbatim against the live API → correct tag + sha256.
- `build.yml` validated as YAML; tarball layout and asset digest confirmed.
- Full BitBake parse/build verification happens in this PR's CI run.