### PR TITLE
fix (data-init): reformat stale /data superblock that outgrew its partition

### DIFF
--- a/recipes-core/wendyos-data-setup/files/wendyos-data-init.sh
+++ b/recipes-core/wendyos-data-setup/files/wendyos-data-init.sh
@@ -7,7 +7,9 @@
 # <filename> — see tegra_partition_config.bbclass), so on first boot it
 # has no filesystem. This script, run once before data.mount:
 #   1. resolves the partition by GPT label "data",
-#   2. if it already holds an ext4 filesystem -> nothing to do,
+#   2. if it already holds an ext4 filesystem that fits the partition ->
+#      nothing to do (a stale superblock from a prior larger layout does
+#      not count — see the guard below),
 #   3. otherwise: fix the GPT backup header (the image is flashed to a
 #      disk far larger than the layout), grow the partition to fill the
 #      disk, and mkfs.ext4 it.
@@ -36,10 +38,25 @@ fi
 DEV="$(readlink -f "${BYLABEL}")"
 log "data partition: ${DEV}"
 
-# Already initialised? (slot-safe idempotency)
+# Already initialised? (slot-safe idempotency — key on the filesystem,
+# not a per-rootfs stamp). But "blkid reports ext4" is not sufficient: a
+# reflash recreates this partition at its small initial size while leaving
+# behind the superblock of a previously-grown filesystem. blkid still sees
+# ext4, yet the kernel refuses the mount with "bad geometry: block count N
+# exceeds size of device". Treat the fs as initialised only if it also
+# physically fits the partition; otherwise it is a stale superblock and we
+# must grow + reformat (the mkfs.ext4 -F below overwrites it).
 if [ "$(blkid -o value -s TYPE "${DEV}" 2>/dev/null || true)" = "ext4" ]; then
-    log "already ext4; nothing to do"
-    exit 0
+    fs_blocks="$(dumpe2fs -h "${DEV}" 2>/dev/null | awk -F: '/^Block count:/{gsub(/ /,"",$2); print $2}')"
+    fs_bsize="$(dumpe2fs -h "${DEV}" 2>/dev/null | awk -F: '/^Block size:/{gsub(/ /,"",$2); print $2}')"
+    dev_bytes="$(blockdev --getsize64 "${DEV}" 2>/dev/null || echo 0)"
+    if [ -n "${fs_blocks}" ] && [ -n "${fs_bsize}" ] && [ "${dev_bytes}" -gt 0 ] \
+       && [ "$(( fs_blocks * fs_bsize ))" -le "${dev_bytes}" ]; then
+        log "already ext4 and fits device; nothing to do"
+        exit 0
+    fi
+    log "ext4 superblock present but does not fit device (stale from a prior, larger layout); reinitialising"
+    # fall through to grow + mkfs
 fi
 
 # Resolve parent disk + partition number via sysfs (portable across

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=32329fcd0da888dcffa77ba6
 GO_IMPORT = "github.com/wendylabsinc/wendy-os-update"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
-SRCREV = "1765b2734de0c6c7c29ee7165d58469d80047c5c"
+SRCREV = "aa6571a005f3aa619a718766a1fc642f4e8ab76d"
 
 inherit go-mod systemd
 


### PR DESCRIPTION
wendyos-data-init's idempotency guard treated any ext4 superblock as
"already initialised". A reflash recreates the data partition at its
small initial size (512 MiB) while leaving behind the superblock of a
previously-grown filesystem (~900 GB). blkid still reports ext4, so init
skipped format+grow and the kernel then refused the mount:

  EXT4-fs (nvme0n1p17): bad geometry: block count 236275281 exceeds
  size of device (131072 blocks)

data.mount failed, taking down the /data bind mounts (home, var-log,
containerd) and cascading to user@1000 / pipewire.

The guard now also checks the filesystem physically fits the device
(fs blocks * block size <= device size) before treating it as
initialised; otherwise it falls through to grow + mkfs, which overwrites
the stale superblock. Still keys on the filesystem (not a per-rootfs
stamp), so it stays A/B-slot-safe.