### PR TITLE
AGX Thor OTA update - improve data partition initialization

### DIFF
--- a/classes/image_types_wendy.bbclass
+++ b/classes/image_types_wendy.bbclass
@@ -1,9 +1,9 @@
 # image_types_wendy.bbclass
 #
 # Defines the "wendy" IMAGE_FSTYPE: a .wendy OTA artifact for the
-# wendy-update client, produced by running `wendy-update pack` on the
+# wendyos-update client, produced by running `wendyos-update pack` on the
 # image's ext4 rootfs. Replaces mender-artifactimg.bbclass for boards
-# using the wendy-update OTA stack (WENDYOS_OTA = "wendy").
+# using the wendyos-update OTA stack (WENDYOS_OTA = "wendy").
 #
 # Enable per build by adding to the image's fstypes + classes (done in
 # the OTA wiring, gated on WENDYOS_OTA == "wendy"):
@@ -18,7 +18,7 @@
 WENDY_ARTIFACTIMG_FSTYPE ?= "ext4"
 IMAGE_TYPEDEP:wendy:append = " ${WENDY_ARTIFACTIMG_FSTYPE}"
 
-# `wendy-update pack` runs on the build host (native variant of the
+# `wendyos-update pack` runs on the build host (native variant of the
 # client recipe — BBCLASSEXTEND = "native").
 do_image_wendy[depends] += "wendyos-update-native:do_populate_sysroot"
 
@@ -36,7 +36,7 @@ IMAGE_CMD:wendy () {
     if [ -z "${WENDYOS_BOARD_ID}" ]; then
         bbfatal "image_types_wendy: WENDYOS_BOARD_ID is unset; cannot set the artifact's compatible device"
     fi
-    wendy-update pack \
+    wendyos-update pack \
         --image ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${WENDY_ARTIFACTIMG_FSTYPE} \
         --name ${WENDY_ARTIFACT_NAME} \
         --version ${WENDY_ARTIFACT_VERSION} \

--- a/conf/distro/include/wendyos-update.inc
+++ b/conf/distro/include/wendyos-update.inc
@@ -1,12 +1,12 @@
-# wendy-update OTA stack. Required from wendyos.conf when
+# wendyos-update OTA stack. Required from wendyos.conf when
 # WENDYOS_OTA == "wendy". Parallels conf/distro/include/mender.inc.
 #
 # Pulls in the on-device pieces and the build-side artifact:
-#   - wendyos-update:      the OTA client (/usr/bin/wendy-update + the
+#   - wendyos-update:      the OTA client (/usr/bin/wendyos-update + the
 #                          boot-verify and auto-commit systemd units).
 #   - wendyos-data-setup:  first-boot /data format/grow + the data.mount.
 #   - image_types_wendy:   defines the "wendy" IMAGE_FSTYPE that produces
-#                          the .wendy OTA artifact via `wendy-update pack`.
+#                          the .wendy OTA artifact via `wendyos-update pack`.
 
 # Scope to the product image only (:pn-wendyos-image): this inc is
 # required at distro scope, so a bare :append would also hit the Tegra

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -4,7 +4,7 @@
 
 # OTA stack selector. One of:
 #   "mender"  Mender A/B OTA (the legacy stack; JP6 / scarthgap).
-#   "wendy"   the wendy-update A/B OTA client (docs/plans/wendy-ota-update.md).
+#   "wendy"   the wendyos-update A/B OTA client (docs/plans/wendy-ota-update.md).
 #   "none"    no OTA stack (and no /data services).
 # Everything OTA-related keys off this: Mender-product bits require
 # "mender"; the OTA-runtime /data services and persistent journal require
@@ -20,7 +20,7 @@ WENDYOS_OTA ?= "${@'none' if any(t in d.getVar('MACHINEOVERRIDES').split(':') fo
 # carved into the flash layout, so a board can have /data without an OTA
 # stack (e.g. bring-up / testing). Defaults to "1" whenever an OTA stack
 # is selected. For "mender" the partition gets a <filename> so the flash
-# tools write the .dataimg; for "wendy-update" it is allocated empty (no
+# tools write the .dataimg; for "wendyos-update" it is allocated empty (no
 # <filename>) and formatted on first boot. Consumed by
 # tegra_partition_config.bbclass.
 WENDYOS_DATA_PART ?= "${@'0' if d.getVar('WENDYOS_OTA') == 'none' else '1'}"
@@ -76,7 +76,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.15.2"
+DISTRO_VERSION = "0.15.4"
 # DISTRO_CODENAME is inherited from poky.conf (require'd above), which
 # sets it to the active oe-core series ("scarthgap", "wrynose", ...).
 # Don't override here or it gets stuck on a stale value across series.

--- a/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
@@ -21,7 +21,7 @@ PREFERRED_PROVIDER_virtual/bootloader = "tegra-uefi-prebuilt"
 UBOOT_EXTLINUX = "1"
 
 # Mender vars are intentionally absent — OTA on Thor arrives with
-# wendy-update, not Mender (docs/plans/wendy-ota-update.md).
+# wendyos-update, not Mender (docs/plans/wendy-ota-update.md).
 
 # Rootfs A/B redundancy via upstream meta-tegra machinery
 # (conf/machine/include/tegra-common.inc on r38):
@@ -50,7 +50,7 @@ IMAGE_NAME_SUFFIX = ""
 # Image formats: produces a one-shot flashable image only.
 # 'mender' and 'dataimg' are deliberately omitted — no Mender; the
 # wendy_data partition is allocated empty at flash time (no .dataimg) and
-# the wendy-update artifact (.wup) arrives in a later phase.
+# the wendyos-update artifact (.wup) arrives in a later phase.
 # On r38.4.x the IMAGE_TYPE was renamed: tegraflash → tegraflash-tar
 # (verified via OE4T/meta-tegra master-l4t-r38.4.x:
 #   classes-recipe/image_types_tegra.bbclass:7  IMAGE_TYPES += "tegraflash-tar"

--- a/conf/template/include/bblayers/tegra-base.inc
+++ b/conf/template/include/bblayers/tegra-base.inc
@@ -1,7 +1,7 @@
 # Base Tegra layer set shared by every Tegra board (formerly
 # tegra-thor.inc). Used directly by Thor (tegra264) and JP7/wrynose Orin
 # boards — JP7 has no meta-mender-tegra; OTA on those boards arrives with
-# wendy-update (docs/plans/wendy-ota-update.md).
+# wendyos-update (docs/plans/wendy-ota-update.md).
 #
 # tegra.inc 'require's this file and layers the meta-mender* paths on top
 # for tegra234 JP6 (Orin/scarthgap) builds, so the meta-tegra /

--- a/conf/template/include/local/tegra-t264.inc
+++ b/conf/template/include/local/tegra-t264.inc
@@ -1,9 +1,9 @@
-# Tegra T264 (Thor): wendy-update OTA (no Mender, no UEFI capsule update yet).
+# Tegra T264 (Thor): wendyos-update OTA (no Mender, no UEFI capsule update yet).
 # WENDYOS_UPDATE_BOOTLOADER gates the Mender capsule artefact; Thor uses
-# wendy-update with rootfs-only swaps for now, so keep it off.
+# wendyos-update with rootfs-only swaps for now, so keep it off.
 WENDYOS_UPDATE_BOOTLOADER = "0"
 
-# Thor runs the wendy-update OTA stack (wendyos.conf defaults tegra264 to
+# Thor runs the wendyos-update OTA stack (wendyos.conf defaults tegra264 to
 # "none"; override here). This pulls in the client + data-setup + the
 # .wendy artifact (conf/distro/include/wendyos-update.inc) and implies the
 # persistent /data partition (no separate WENDYOS_DATA_PART needed — its

--- a/meta-tegra-extensions/classes/tegra_partition_config.bbclass
+++ b/meta-tegra-extensions/classes/tegra_partition_config.bbclass
@@ -200,7 +200,7 @@ python do_modify_partition_layout() {
         #   WENDYOS_DATA_PART = "1" + not    -> 'data' with NO filename
         #     Mender (e.g. WENDYOS_OTA=wendy)   (allocated empty at flash time;
         #                                      a first-boot unit formats and
-        #                                      expands it — wendy-update OTA)
+        #                                      expands it — wendyos-update OTA)
         #   WENDYOS_DATA_PART = "0"          -> skipped entirely
         #
         # The no-filename rule is what makes the Mender-free path flashable:
@@ -275,7 +275,7 @@ python do_modify_partition_layout() {
                 device.insert(idx, data_part)
                 bb.note('  Created "data" partition (id=%d)' % data_part_num)
         elif data_part_enabled:
-            # Mender-free data partition (JP7 / wendy-update OTA).
+            # Mender-free data partition (JP7 / wendyos-update OTA).
             # Same placement and numbering as the Mender path, but no
             # <filename> — allocated empty at flash time, formatted on
             # first boot.

--- a/recipes-core/wendyos-data-setup/files/wendyos-data-init.sh
+++ b/recipes-core/wendyos-data-setup/files/wendyos-data-init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # First-boot initialisation of the persistent /data partition for the
-# wendy-update OTA stack (replaces Mender's mender-grow-data).
+# wendyos-update OTA stack (replaces Mender's mender-grow-data).
 #
 # The partition is carved into the flash layout allocated-empty (no
 # <filename> — see tegra_partition_config.bbclass), so on first boot it

--- a/recipes-core/wendyos-data-setup/files/wendyos-data-init.sh
+++ b/recipes-core/wendyos-data-setup/files/wendyos-data-init.sh
@@ -47,15 +47,34 @@ log "data partition: ${DEV}"
 # physically fits the partition; otherwise it is a stale superblock and we
 # must grow + reformat (the mkfs.ext4 -F below overwrites it).
 if [ "$(blkid -o value -s TYPE "${DEV}" 2>/dev/null || true)" = "ext4" ]; then
-    fs_blocks="$(dumpe2fs -h "${DEV}" 2>/dev/null | awk -F: '/^Block count:/{gsub(/ /,"",$2); print $2}')"
-    fs_bsize="$(dumpe2fs -h "${DEV}" 2>/dev/null | awk -F: '/^Block size:/{gsub(/ /,"",$2); print $2}')"
-    dev_bytes="$(blockdev --getsize64 "${DEV}" 2>/dev/null || echo 0)"
-    if [ -n "${fs_blocks}" ] && [ -n "${fs_bsize}" ] && [ "${dev_bytes}" -gt 0 ] \
-       && [ "$(( fs_blocks * fs_bsize ))" -le "${dev_bytes}" ]; then
-        log "already ext4 and fits device; nothing to do"
-        exit 0
+    # Treat the fs as initialised only if dumpe2fs can read it AND it
+    # physically fits the device. A stale superblock that overshoots the
+    # device (the case this guard repairs) makes dumpe2fs exit non-zero, so
+    # a dumpe2fs failure -> reinitialise. The assignment sits in the `if`
+    # test, which set -e exempts, so a non-zero dumpe2fs cannot abort the
+    # script — and we never rely on parsing partial output. dumpe2fs's
+    # stderr is captured and logged on failure so the reason (e.g. "fs size
+    # larger than physical size") is visible in the journal.
+    de2fs_err="$(mktemp 2>/dev/null || printf '%s' /tmp/wendyos-data-init.de2fs)"
+    if sb="$(dumpe2fs -h "${DEV}" 2>"${de2fs_err}")"; then
+        fs_blocks="$(printf '%s\n' "${sb}" | awk -F: '/^Block count:/{gsub(/ /,"",$2); print $2}')"
+        fs_bsize="$(printf '%s\n' "${sb}" | awk -F: '/^Block size:/{gsub(/ /,"",$2); print $2}')"
+        dev_bytes="$(blockdev --getsize64 "${DEV}" 2>/dev/null || echo 0)"
+        if [ -n "${fs_blocks}" ] && [ -n "${fs_bsize}" ] && [ "${dev_bytes}" -gt 0 ] \
+           && [ "$(( fs_blocks * fs_bsize ))" -le "${dev_bytes}" ]; then
+            log "already ext4 and fits device; nothing to do"
+            rm -f "${de2fs_err}"
+            exit 0
+        fi
+        log "ext4 present but does not fit the device (stale from a prior, larger layout); reinitialising"
+    else
+        rc=$?
+        log "dumpe2fs could not validate the existing fs (exit ${rc}); reinitialising:"
+        while IFS= read -r de2fs_line; do
+            [ -n "${de2fs_line}" ] && log "  dumpe2fs: ${de2fs_line}"
+        done < "${de2fs_err}"
     fi
-    log "ext4 superblock present but does not fit device (stale from a prior, larger layout); reinitialising"
+    rm -f "${de2fs_err}"
     # fall through to grow + mkfs
 fi
 

--- a/recipes-core/wendyos-data-setup/wendyos-data-setup_1.0.bb
+++ b/recipes-core/wendyos-data-setup/wendyos-data-setup_1.0.bb
@@ -1,7 +1,7 @@
-SUMMARY = "First-boot /data partition setup for the wendy-update OTA stack"
+SUMMARY = "First-boot /data partition setup for the wendyos-update OTA stack"
 DESCRIPTION = "Formats and grows the persistent /data partition on first \
 boot, and mounts it at /data. Replaces Mender's mender-grow-data and fstab \
-entry for boards using the wendy-update OTA client (WENDYOS_OTA = wendy). \
+entry for boards using the wendyos-update OTA client (WENDYOS_OTA = wendy). \
 The partition is carved allocated-empty by tegra_partition_config.bbclass; \
 this initialises it. Idempotency keys on the on-disk ext4 filesystem, not a \
 per-rootfs stamp, so an A/B rootfs swap can never wipe /data."

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -1,7 +1,7 @@
 
 SUMMARY = "WendyOS A/B OTA update client"
 DESCRIPTION = "Generic A/B over-the-air update client for WendyOS. Installs the \
-wendy-update binary plus the boot-verify and auto-commit systemd units. The \
+wendyos-update binary plus the boot-verify and auto-commit systemd units. The \
 board-specific behaviour lives behind a connector (tegrauefi for Jetson); the \
 engine, artifact format and CLI are board-agnostic. Replaces the Mender client \
 on platforms without meta-mender support (e.g. JetPack 7 / wrynose)."
@@ -13,12 +13,12 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=32329fcd0da888dcffa77ba6
 GO_IMPORT = "github.com/wendylabsinc/wendy-os-update"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
-SRCREV = "205222dcaf5080aa22bd106d0b2a6e4fa6573ad2"
+SRCREV = "21ab29701a4e89c65c13e5d06dc7cf85d9f45ad6"
 
 inherit go-mod systemd
 
 # Build only the CLI we ship; the module also has internal/* libraries.
-GO_INSTALL = "${GO_IMPORT}/cmd/wendy-update"
+GO_INSTALL = "${GO_IMPORT}/cmd/wendyos-update"
 
 # Build offline from the committed vendor/ tree — no module fetching at
 # build time (reproducible). buildvcs is auto-off in the .git-less Yocto
@@ -30,32 +30,32 @@ GO_SRCDIR = "${S}/src/${GO_IMPORT}"
 
 # --- target-only packaging ---
 # The native variant (BBCLASSEXTEND below) builds only the binary so the
-# image class can run `wendy-update pack` on the build host; it must not
+# image class can run `wendyos-update pack` on the build host; it must not
 # carry the systemd units or the nvbootctrl RDEPENDS.
-SYSTEMD_SERVICE:${PN}:class-target = "wendy-update-verify.service wendy-update-commit.service wendy-update-boot-complete.target"
+SYSTEMD_SERVICE:${PN}:class-target = "wendyos-update-verify.service wendyos-update-commit.service wendyos-update-boot-complete.target"
 SYSTEMD_AUTO_ENABLE:${PN}:class-target = "enable"
 
 do_install:append:class-target() {
     # systemd units (shipped in the repo under systemd/)
     install -d ${D}${systemd_system_unitdir}
-    install -m 0644 ${GO_SRCDIR}/systemd/wendy-update-verify.service ${D}${systemd_system_unitdir}/
-    install -m 0644 ${GO_SRCDIR}/systemd/wendy-update-commit.service ${D}${systemd_system_unitdir}/
-    install -m 0644 ${GO_SRCDIR}/systemd/wendy-update-boot-complete.target ${D}${systemd_system_unitdir}/
+    install -m 0644 ${GO_SRCDIR}/systemd/wendyos-update-verify.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${GO_SRCDIR}/systemd/wendyos-update-commit.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${GO_SRCDIR}/systemd/wendyos-update-boot-complete.target ${D}${systemd_system_unitdir}/
 
     # config + lifecycle-hook dirs (config.json is optional; auto-detect
     # works without it — see docs/cli-contract.md). Each <phase>.d holds
     # product executables run at that point in the update sequence; empty
     # dirs are a no-op, shipped for discoverability.
-    install -d ${D}${sysconfdir}/wendy-update/pre-install.d
-    install -d ${D}${sysconfdir}/wendy-update/post-install.d
-    install -d ${D}${sysconfdir}/wendy-update/health.d
-    install -d ${D}${sysconfdir}/wendy-update/post-commit.d
-    install -d ${D}${sysconfdir}/wendy-update/on-failure.d
+    install -d ${D}${sysconfdir}/wendyos-update/pre-install.d
+    install -d ${D}${sysconfdir}/wendyos-update/post-install.d
+    install -d ${D}${sysconfdir}/wendyos-update/health.d
+    install -d ${D}${sysconfdir}/wendyos-update/post-commit.d
+    install -d ${D}${sysconfdir}/wendyos-update/on-failure.d
 }
 
 # The Go source tree (incl. vendor/) installed by go_do_install lands in the
-# -dev package, so the image gets only /usr/bin/wendy-update + the units.
-FILES:${PN}:append:class-target = " ${sysconfdir}/wendy-update"
+# -dev package, so the image gets only /usr/bin/wendyos-update + the units.
+FILES:${PN}:append:class-target = " ${sysconfdir}/wendyos-update"
 
 # No board-specific RDEPENDS here: the binary is board-agnostic (the
 # connector is selected at runtime), so naming a connector's tools would
@@ -66,5 +66,5 @@ FILES:${PN}:append:class-target = " ${sysconfdir}/wendy-update"
 #     capsule staging uses oe4t-set-uefi-OSIndications from
 #     setup-nv-boot-control (packagegroup-wendyos-tegra). efivarfs is in-kernel.
 
-# Native variant provides `wendy-update pack` for image_types_wendy.bbclass.
+# Native variant provides `wendyos-update pack` for image_types_wendy.bbclass.
 BBCLASSEXTEND = "native"

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=32329fcd0da888dcffa77ba6
 GO_IMPORT = "github.com/wendylabsinc/wendy-os-update"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
-SRCREV = "aa6571a005f3aa619a718766a1fc642f4e8ab76d"
+SRCREV = "205222dcaf5080aa22bd106d0b2a6e4fa6573ad2"
 
 inherit go-mod systemd
 
@@ -42,9 +42,15 @@ do_install:append:class-target() {
     install -m 0644 ${GO_SRCDIR}/systemd/wendy-update-commit.service ${D}${systemd_system_unitdir}/
     install -m 0644 ${GO_SRCDIR}/systemd/wendy-update-boot-complete.target ${D}${systemd_system_unitdir}/
 
-    # config + health-hook dirs (config.json is optional; auto-detect works
-    # without it — see docs/cli-contract.md)
+    # config + lifecycle-hook dirs (config.json is optional; auto-detect
+    # works without it — see docs/cli-contract.md). Each <phase>.d holds
+    # product executables run at that point in the update sequence; empty
+    # dirs are a no-op, shipped for discoverability.
+    install -d ${D}${sysconfdir}/wendy-update/pre-install.d
+    install -d ${D}${sysconfdir}/wendy-update/post-install.d
     install -d ${D}${sysconfdir}/wendy-update/health.d
+    install -d ${D}${sysconfdir}/wendy-update/post-commit.d
+    install -d ${D}${sysconfdir}/wendy-update/on-failure.d
 }
 
 # The Go source tree (incl. vendor/) installed by go_do_install lands in the

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=32329fcd0da888dcffa77ba6
 GO_IMPORT = "github.com/wendylabsinc/wendy-os-update"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
-SRCREV = "21ab29701a4e89c65c13e5d06dc7cf85d9f45ad6"
+SRCREV = "a1f8d0f3b89d368630f99a5f4eda26bbdf5837ea"
 
 inherit go-mod systemd
 

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -83,7 +83,7 @@ rm -rf "${tmp_s5}"
 /usr/local/bin/s5cmd version
 
 # Go toolchain. Needed to build wendy-os-update (the OTA tool) and to run
-# its host-side `wendy-update pack` from the build container / CI. Ubuntu
+# its host-side `wendyos-update pack` from the build container / CI. Ubuntu
 # 24.04's apt 'golang' is ~1.22 — too old for the tool's go.mod (go 1.26)
 # — so install the official tarball to /usr/local/go (the upstream
 # location). A profile.d entry and /usr/local/bin symlinks make it


### PR DESCRIPTION

- **data-init: reformat stale /data superblock that outgrew its partition**
  wendyos-data-init's idempotency guard treated any ext4 superblock as "already initialised". A reflash recreates the data partition at its small initial size (512 MiB) while leaving behind the superblock of a previously-grown filesystem (~900 GB). blkid still reports ext4, so init skipped format+grow and the kernel then refused the mount.
  The guard now also checks the filesystem physically fits the device (fs blocks * block size <= device size) before treating it as
initialised; otherwise it falls through to grow + mkfs, which overwrites the stale superblock. Still keys on the filesystem (not a per-rootfs stamp), so it stays A/B-slot-safe.
- **Add support for lifecycle-hooks on the update client** 
- **data-init: reinitialise when dumpe2fs can't validate the filesystem**
  A stale superblock that overshoots the device (the case this guard repairs) makes dumpe2fs exit non-zero — and under `set -euo pipefail` the previous `fs_blocks=$(dumpe2fs | awk)` aborted the script before the geometry check, so data-init failed (exit 1) and /data never mounted.
