### PR TITLE
fix(publisher): record nvme_ota_update_path for NVMe OTA artifacts

### DIFF
--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -131,6 +131,14 @@ type VersionMetadata struct {
 	// offline image, hence no bmap.
 	NVMEBmapPath   string `json:"nvme_bmap_path,omitempty"`
 	SDCardBmapPath string `json:"sd_bmap_path,omitempty"`
+	// Storage-specific OTA (Mender) artifacts. The NVMe and SD/eMMC builds
+	// produce distinct .mender artifacts whose embedded device_type differs,
+	// so they cannot share a single ota_update_path. The CLI selects
+	// nvme_ota_update_path when the device reports storage_medium=nvme;
+	// otherwise it uses ota_update_path.
+	NVMEOTAUpdatePath      string `json:"nvme_ota_update_path,omitempty"`
+	NVMEOTAUpdateChecksum  string `json:"nvme_ota_update_checksum,omitempty"`
+	NVMEOTAUpdateSizeBytes int64  `json:"nvme_ota_update_size_bytes,omitempty"`
 }
 
 // MasterManifest represents the top-level manifest
@@ -1806,6 +1814,35 @@ func setBmapPath(meta *VersionMetadata, storageType, bmapPath string) {
 	}
 }
 
+// applyOTAUpdate records an OTA (Mender) artifact in the version metadata,
+// routing NVMe artifacts to the NVMe-specific fields. The NVMe and SD/eMMC
+// builds emit distinct .mender artifacts whose embedded device_type differs,
+// so they must not share ota_update_path — otherwise whichever variant
+// publishes last wins and the other variant's devices reject the artifact
+// ("Artifact device type doesn't match"). For "nvme" the artifact also
+// populates ota_update_path as a default, but only when it is unset, so a
+// single-variant NVMe board still exposes an OTA without clobbering a
+// previously published SD/eMMC artifact.
+func applyOTAUpdate(meta *VersionMetadata, storageType, otaPath, otaChecksum string, otaSize int64) {
+	if otaPath == "" {
+		return
+	}
+	if storageType == "nvme" {
+		meta.NVMEOTAUpdatePath = otaPath
+		meta.NVMEOTAUpdateChecksum = otaChecksum
+		meta.NVMEOTAUpdateSizeBytes = otaSize
+		if meta.OTAUpdatePath == "" {
+			meta.OTAUpdatePath = otaPath
+			meta.OTAUpdateChecksum = otaChecksum
+			meta.OTAUpdateSizeBytes = otaSize
+		}
+		return
+	}
+	meta.OTAUpdatePath = otaPath
+	meta.OTAUpdateChecksum = otaChecksum
+	meta.OTAUpdateSizeBytes = otaSize
+}
+
 // copyManifestArtifact copies one artifact (image, block map, …) from srcPath
 // into the stable version's image directory and returns the new path. It
 // returns "" when srcPath is empty, malformed, or the copy fails — the caller
@@ -1981,12 +2018,13 @@ func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 		// top-level path (the orin-nano NVMe-vs-SD mismatch).
 		setBmapPath(&versionMetadata, storageType, bmapPath)
 
-		// Update OTA update fields only if provided
+		// Update OTA update fields only if provided. NVMe artifacts are routed
+		// to the NVMe-specific field so storage variants don't clobber each
+		// other (see applyOTAUpdate).
 		if otaUpdatePath != "" {
-			versionMetadata.OTAUpdatePath = otaUpdatePath
-			versionMetadata.OTAUpdateChecksum = otaUpdateChecksum
-			versionMetadata.OTAUpdateSizeBytes = otaUpdateSize
+			applyOTAUpdate(&versionMetadata, storageType, otaUpdatePath, otaUpdateChecksum, otaUpdateSize)
 			logger.WithFields(logrus.Fields{
+				"storage":      storageType,
 				"ota_path":     otaUpdatePath,
 				"ota_size":     otaUpdateSize,
 				"ota_checksum": otaUpdateChecksum,

--- a/tools/publisher/upload_and_manifest_test.go
+++ b/tools/publisher/upload_and_manifest_test.go
@@ -562,3 +562,64 @@ func TestSetBmapPath(t *testing.T) {
 		}
 	})
 }
+
+func TestApplyOTAUpdate(t *testing.T) {
+	const (
+		nvmeOTA = "images/jetson-orin-nano/v1/wendyos-image-jetson-orin-nano-devkit-nvme-wendyos.mender"
+		sdOTA   = "images/jetson-orin-nano/v1/wendyos-image-jetson-orin-nano-devkit-wendyos.mender"
+	)
+
+	t.Run("nvme routes to nvme field and seeds default", func(t *testing.T) {
+		m := &VersionMetadata{}
+		applyOTAUpdate(m, "nvme", nvmeOTA, "ck-nvme", 10)
+		if m.NVMEOTAUpdatePath != nvmeOTA {
+			t.Errorf("NVMEOTAUpdatePath = %q, want %q", m.NVMEOTAUpdatePath, nvmeOTA)
+		}
+		if m.OTAUpdatePath != nvmeOTA {
+			t.Errorf("OTAUpdatePath = %q, want NVMe seeded as default when unset", m.OTAUpdatePath)
+		}
+	})
+
+	t.Run("sd routes to default ota field", func(t *testing.T) {
+		m := &VersionMetadata{}
+		applyOTAUpdate(m, "sd", sdOTA, "ck-sd", 20)
+		if m.OTAUpdatePath != sdOTA {
+			t.Errorf("OTAUpdatePath = %q, want %q", m.OTAUpdatePath, sdOTA)
+		}
+		if m.NVMEOTAUpdatePath != "" {
+			t.Errorf("NVMEOTAUpdatePath = %q, want empty for sd", m.NVMEOTAUpdatePath)
+		}
+	})
+
+	t.Run("sd then nvme keeps both distinct", func(t *testing.T) {
+		m := &VersionMetadata{}
+		applyOTAUpdate(m, "sd", sdOTA, "ck-sd", 20)
+		applyOTAUpdate(m, "nvme", nvmeOTA, "ck-nvme", 10)
+		if m.OTAUpdatePath != sdOTA {
+			t.Errorf("OTAUpdatePath = %q, want SD preserved (not clobbered by nvme)", m.OTAUpdatePath)
+		}
+		if m.NVMEOTAUpdatePath != nvmeOTA {
+			t.Errorf("NVMEOTAUpdatePath = %q, want %q", m.NVMEOTAUpdatePath, nvmeOTA)
+		}
+	})
+
+	t.Run("nvme then sd keeps both distinct", func(t *testing.T) {
+		m := &VersionMetadata{}
+		applyOTAUpdate(m, "nvme", nvmeOTA, "ck-nvme", 10)
+		applyOTAUpdate(m, "sd", sdOTA, "ck-sd", 20)
+		if m.OTAUpdatePath != sdOTA {
+			t.Errorf("OTAUpdatePath = %q, want SD to own the default", m.OTAUpdatePath)
+		}
+		if m.NVMEOTAUpdatePath != nvmeOTA {
+			t.Errorf("NVMEOTAUpdatePath = %q, want %q", m.NVMEOTAUpdatePath, nvmeOTA)
+		}
+	})
+
+	t.Run("empty path is a no-op", func(t *testing.T) {
+		m := &VersionMetadata{OTAUpdatePath: sdOTA}
+		applyOTAUpdate(m, "nvme", "", "", 0)
+		if m.OTAUpdatePath != sdOTA || m.NVMEOTAUpdatePath != "" {
+			t.Errorf("empty path mutated metadata: %+v", m)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`updateDeviceManifest` wrote every OTA artifact to `ota_update_path` regardless of `--storage`, so a board with both NVMe and SD builds (e.g. `jetson-orin-nano`) had the two `.mender` artifacts clobber each other (last writer wins) and `nvme_ota_update_path` was never emitted. NVMe devices were then served the non-NVMe artifact, which mender rejects with **"Artifact device type doesn't match"**.

This routes NVMe OTA artifacts to a new `nvme_ota_update_path` (matching the CLI's existing manifest schema), keeping `ota_update_path` for the SD/eMMC/default artifact. `ota_update_path` is seeded from the NVMe artifact only when unset, so single-variant NVMe boards still expose an OTA without clobbering an SD/eMMC artifact.

CI already invokes the publisher with `--storage nvme`/`sd` per matrix entry (`build.yml`), so this fix takes effect without workflow changes.

## Changes
- Add `nvme_ota_update_path` / `_checksum` / `_size_bytes` to `VersionMetadata`.
- Extract the OTA-routing logic into `applyOTAUpdate` and branch on storage type.
- Unit tests for both publish orders (sd→nvme, nvme→sd), the no-clobber guarantee, and the empty-path no-op.

## Context
Counterpart fixes in the CLI/agent repo (PR wendylabsinc/WendyOS#1040) make the agent report the board id as `device_type` and infer `storage_medium=nvme` from the machine name, so `wendy [cloud] device update` selects the NVMe artifact this manifest now exposes.

## Test plan
- [x] `go test ./...` and `go vet ./...` in `tools/publisher` pass.
- [ ] After merge + a nightly publish, confirm `manifests/jetson-orin-nano.json` has both `ota_update_path` (SD) and `nvme_ota_update_path` (NVMe) for the latest version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)