### PR TITLE
feat(publisher): generate & upload seekable-zstd images

### DIFF
--- a/tools/publisher/go.mod
+++ b/tools/publisher/go.mod
@@ -1,6 +1,6 @@
 module github.com/wendylabsinc/wendyos-builder/tools/publisher
 
-go 1.21
+go 1.25.0
 
 require (
 	cloud.google.com/go/storage v1.36.0
@@ -14,16 +14,19 @@ require (
 	cloud.google.com/go/compute v1.23.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.3 // indirect
+	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
+	github.com/klauspost/compress v1.18.6 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/tools/publisher/go.mod
+++ b/tools/publisher/go.mod
@@ -4,6 +4,8 @@ go 1.25.0
 
 require (
 	cloud.google.com/go/storage v1.36.0
+	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0
+	github.com/klauspost/compress v1.18.6
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/oauth2 v0.13.0
 	google.golang.org/api v0.150.0
@@ -14,7 +16,6 @@ require (
 	cloud.google.com/go/compute v1.23.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.3 // indirect
-	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
@@ -22,7 +23,6 @@ require (
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect

--- a/tools/publisher/go.sum
+++ b/tools/publisher/go.sum
@@ -75,9 +75,9 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -103,8 +103,6 @@ golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
-golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/tools/publisher/go.sum
+++ b/tools/publisher/go.sum
@@ -10,7 +10,11 @@ cloud.google.com/go/iam v1.1.3/go.mod h1:3khUlaBXfPKKe7huYgEpDn6FtgRyMEqbkvBxrQy
 cloud.google.com/go/storage v1.36.0 h1:P0mOkAcaJxhCTvAkMhxMfrTKiNcub4YmmPBtlhAyTr8=
 cloud.google.com/go/storage v1.36.0/go.mod h1:M6M/3V/D3KpzMTJyPOR/HU6n2Si5QdaXYEsng2xgOs8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0 h1:LvK7+C6qgz8BPnmn7xGekf8vTkcqTvyBBHaLYIMxx0g=
+github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0/go.mod h1:I28hc9eaiqKCoOB+9Wh/P1IOScfm0xCgyWC6DAo0lmo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -58,6 +62,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -71,6 +77,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -98,6 +105,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
 golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/tools/publisher/manifest_entry.go
+++ b/tools/publisher/manifest_entry.go
@@ -22,6 +22,9 @@ type ManifestEntry struct {
 	FileSize     int64  `json:"file_size,omitempty"`
 	FileChecksum string `json:"file_checksum,omitempty"`
 	BmapPath     string `json:"bmap_path,omitempty"`
+	ZstPath      string `json:"zst_path,omitempty"`
+	ZstChecksum  string `json:"zst_checksum,omitempty"`
+	ZstSize      int64  `json:"zst_size_bytes,omitempty"`
 
 	OTAUpdatePath     string `json:"ota_update_path,omitempty"`
 	OTAUpdateSize     int64  `json:"ota_update_size,omitempty"`

--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+	"github.com/klauspost/compress/zstd"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
@@ -131,6 +133,20 @@ type VersionMetadata struct {
 	// offline image, hence no bmap.
 	NVMEBmapPath   string `json:"nvme_bmap_path,omitempty"`
 	SDCardBmapPath string `json:"sd_bmap_path,omitempty"`
+	// Seekable-zstd images. The top-level ZstPath mirrors Path/BmapPath
+	// semantics (NVMe wins, SD fills only when empty, eMMC has no offline
+	// image hence no zst). Each zst carries a checksum and size so the CLI
+	// can verify integrity before and after download without a separate bmap
+	// file.
+	ZstPath            string `json:"zst_path,omitempty"`
+	ZstChecksum        string `json:"zst_checksum,omitempty"`
+	ZstSizeBytes       int64  `json:"zst_size_bytes,omitempty"`
+	NVMEZstPath        string `json:"nvme_zst_path,omitempty"`
+	NVMEZstChecksum    string `json:"nvme_zst_checksum,omitempty"`
+	NVMEZstSizeBytes   int64  `json:"nvme_zst_size_bytes,omitempty"`
+	SDCardZstPath      string `json:"sd_zst_path,omitempty"`
+	SDCardZstChecksum  string `json:"sd_zst_checksum,omitempty"`
+	SDCardZstSizeBytes int64  `json:"sd_zst_size_bytes,omitempty"`
 }
 
 // MasterManifest represents the top-level manifest
@@ -1211,6 +1227,7 @@ func main() {
 			ctx, bucket, entry.Device, entry.Version,
 			entry.FilePath, entry.FileSize, entry.FileChecksum,
 			entry.BmapPath,
+			entry.ZstPath, entry.ZstChecksum, entry.ZstSize,
 			entry.OTAUpdatePath, entry.OTAUpdateSize, entry.OTAUpdateChecksum,
 			entry.RecoveryPath, entry.RecoverySize, entry.RecoveryChecksum,
 			entry.Storage, entry.Nightly, entry.Stability, *notifyDiscord, true,
@@ -1381,6 +1398,30 @@ func main() {
 			bmapUploadChan = uploadFileAsync(ctx, bucket, *bmapFile, *deviceType, *version)
 		}
 
+		// Generate and upload a seekable-zstd image for OS images (the
+		// .img/.wic/.sdimg → zip case). OTA and recovery files use their own
+		// compression formats and are not wrapped in .zst.
+		var zstUploadChan <-chan uploadResult
+		if *localFile != "" && mainResult.compressedPath != "" {
+			rawPath, symErr := filepath.EvalSymlinks(*localFile)
+			if symErr != nil {
+				rawPath = *localFile
+			}
+			rawExt := strings.ToLower(filepath.Ext(rawPath))
+			if rawExt == ".img" || rawExt == ".wic" || rawExt == ".sdimg" {
+				zstPath := rawPath + ".zst"
+				log.WithFields(logrus.Fields{
+					"src": rawPath,
+					"dst": zstPath,
+				}).Info("Generating seekable-zstd image...")
+				if zstErr := compressSeekableZstd(rawPath, zstPath); zstErr != nil {
+					log.WithError(zstErr).Fatal("Failed to generate seekable-zstd image")
+				}
+				log.Info("Seekable-zstd image generated, uploading...")
+				zstUploadChan = uploadFileAsync(ctx, bucket, zstPath, *deviceType, *version)
+			}
+		}
+
 		// Wait for uploads to complete
 		var mainUpload uploadResult
 		if mainUploadChan != nil {
@@ -1418,6 +1459,30 @@ func main() {
 			log.Info("Bmap file uploaded successfully")
 		}
 
+		var zstUpload uploadResult
+		if zstUploadChan != nil {
+			zstUpload = <-zstUploadChan
+			if zstUpload.err != nil {
+				log.WithError(zstUpload.err).Fatal("Failed to upload seekable-zstd file")
+			}
+			log.Info("Seekable-zstd file uploaded successfully")
+		}
+
+		// The checksum of the uploaded .zst (calculated from the local file).
+		var zstChecksum string
+		if zstUpload.path != "" {
+			rawPath, symErr := filepath.EvalSymlinks(*localFile)
+			if symErr != nil {
+				rawPath = *localFile
+			}
+			zstLocalPath := rawPath + ".zst"
+			if cs, csErr := calculateChecksum(zstLocalPath); csErr == nil {
+				zstChecksum = cs
+			} else {
+				log.WithError(csErr).Warn("Failed to calculate zst checksum; zst_checksum will be empty")
+			}
+		}
+
 		// In upload-only mode the manifests are deliberately untouched: write
 		// the entry file for the publish job and stop here.
 		if *uploadOnly {
@@ -1431,6 +1496,9 @@ func main() {
 				FileSize:          mainUpload.size,
 				FileChecksum:      mainResult.checksum,
 				BmapPath:          bmapUpload.path,
+				ZstPath:           zstUpload.path,
+				ZstChecksum:       zstChecksum,
+				ZstSize:           zstUpload.size,
 				OTAUpdatePath:     otaUpdateUpload.path,
 				OTAUpdateSize:     otaUpdateUpload.size,
 				OTAUpdateChecksum: otaUpdateResult.checksum,
@@ -1450,6 +1518,7 @@ func main() {
 			ctx, bucket, *deviceType, *version,
 			mainUpload.path, mainUpload.size, mainResult.checksum,
 			bmapUpload.path,
+			zstUpload.path, zstChecksum, zstUpload.size,
 			otaUpdateUpload.path, otaUpdateUpload.size, otaUpdateResult.checksum,
 			recoveryUpload.path, recoveryUpload.size, recoveryResult.checksum,
 			*storage, *nightly, *stability, *notifyDiscord, *skipMasterManifest,
@@ -1526,7 +1595,7 @@ func main() {
 			recoverySize = recoveryAttrs.Size
 		}
 
-		updateManifests(ctx, bucket, *deviceType, *version, imagePath, attrs.Size, mainChecksum, "", otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, *storage, *nightly, *stability, *notifyDiscord, *skipMasterManifest)
+		updateManifests(ctx, bucket, *deviceType, *version, imagePath, attrs.Size, mainChecksum, "", "", "", 0, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, *storage, *nightly, *stability, *notifyDiscord, *skipMasterManifest)
 	}
 }
 
@@ -1701,7 +1770,7 @@ func uploadFile(ctx context.Context, bucket *storage.BucketHandle, localPath, de
 	return destinationPath, nil
 }
 
-func updateManifests(ctx context.Context, bucket *storage.BucketHandle, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, storage string, isNightly bool, stability string, notifyDiscord bool, skipMasterManifest bool) {
+func updateManifests(ctx context.Context, bucket *storage.BucketHandle, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, storage string, isNightly bool, stability string, notifyDiscord bool, skipMasterManifest bool) {
 	logger := log.WithFields(logrus.Fields{
 		"device_type":     deviceType,
 		"version":         version,
@@ -1727,7 +1796,7 @@ func updateManifests(ctx context.Context, bucket *storage.BucketHandle, deviceTy
 
 	if skipMasterManifest {
 		logger.Info("Updating device manifest (master manifest will be updated by a separate publish job)")
-		if err := updateDeviceManifest(ctx, deviceLogger, bucket, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, storage, isNightly); err != nil {
+		if err := updateDeviceManifest(ctx, deviceLogger, bucket, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, storage, isNightly); err != nil {
 			logger.WithError(err).Fatal("Failed to update device manifest")
 		}
 	} else {
@@ -1749,7 +1818,7 @@ func updateManifests(ctx context.Context, bucket *storage.BucketHandle, deviceTy
 
 		go func() {
 			defer wg.Done()
-			deviceErrChan <- updateDeviceManifest(ctx, deviceLogger, bucket, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, storage, isNightly)
+			deviceErrChan <- updateDeviceManifest(ctx, deviceLogger, bucket, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, storage, isNightly)
 		}()
 
 		go func() {
@@ -1806,6 +1875,97 @@ func setBmapPath(meta *VersionMetadata, storageType, bmapPath string) {
 	}
 }
 
+// setZstPath records a seekable-zstd image on the version metadata, mirroring
+// setBmapPath's per-storage logic. The top-level ZstPath mirrors the top-level
+// Path (NVMe wins, SD fills only when empty, eMMC ships no offline image so it
+// has no zst). Unlike bmap, each zst also carries a checksum and size for
+// integrity verification. An empty zstPath is a no-op.
+func setZstPath(meta *VersionMetadata, storageType, zstPath, zstChecksum string, zstSize int64) {
+	if zstPath == "" {
+		return
+	}
+	switch storageType {
+	case "nvme":
+		meta.NVMEZstPath = zstPath
+		meta.NVMEZstChecksum = zstChecksum
+		meta.NVMEZstSizeBytes = zstSize
+		meta.ZstPath = zstPath
+		meta.ZstChecksum = zstChecksum
+		meta.ZstSizeBytes = zstSize
+	case "sd":
+		meta.SDCardZstPath = zstPath
+		meta.SDCardZstChecksum = zstChecksum
+		meta.SDCardZstSizeBytes = zstSize
+		if meta.ZstPath == "" {
+			meta.ZstPath = zstPath
+			meta.ZstChecksum = zstChecksum
+			meta.ZstSizeBytes = zstSize
+		}
+	case "emmc":
+		// No offline image for eMMC, hence no seekable-zstd image.
+	default:
+		meta.ZstPath = zstPath
+		meta.ZstChecksum = zstChecksum
+		meta.ZstSizeBytes = zstSize
+	}
+}
+
+// seekableFrameSize is the uncompressed size of each independent zstd frame
+// written by compressSeekableZstd. 4 MiB balances random-access granularity
+// against seek-table overhead.
+const seekableFrameSize = 4 << 20 // 4 MiB
+
+// compressSeekableZstd writes srcPath as a seekable-zstd file to dstPath.
+// Each frame covers seekableFrameSize uncompressed bytes, so the CLI can
+// random-access the image without decompressing from the start.
+func compressSeekableZstd(srcPath, dstPath string) error {
+	in, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("opening image: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dstPath)
+	if err != nil {
+		return fmt.Errorf("creating zst: %w", err)
+	}
+	defer out.Close()
+
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		return err
+	}
+	defer enc.Close()
+
+	w, err := seekable.NewWriter(out, enc)
+	if err != nil {
+		return err
+	}
+
+	buf := make([]byte, seekableFrameSize)
+	for {
+		n, rerr := io.ReadFull(in, buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				w.Close()
+				return werr
+			}
+		}
+		if rerr == io.EOF || rerr == io.ErrUnexpectedEOF {
+			break
+		}
+		if rerr != nil {
+			w.Close()
+			return rerr
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		return err
+	}
+	return out.Close()
+}
+
 // copyManifestArtifact copies one artifact (image, block map, …) from srcPath
 // into the stable version's image directory and returns the new path. It
 // returns "" when srcPath is empty, malformed, or the copy fails — the caller
@@ -1827,7 +1987,7 @@ func copyManifestArtifact(ctx context.Context, logger *logrus.Entry, bucket *sto
 	return destPath
 }
 
-func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, storageType string, isNightly bool) error {
+func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, storageType string, isNightly bool) error {
 	manifestPath := fmt.Sprintf("manifests/%s.json", deviceType)
 	logger = logger.WithField("manifest_path", manifestPath)
 	logger.Info("Processing device manifest")
@@ -1980,6 +2140,8 @@ func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 		// it, leaving top-level bmap_path describing a different image than
 		// top-level path (the orin-nano NVMe-vs-SD mismatch).
 		setBmapPath(&versionMetadata, storageType, bmapPath)
+		// Same per-storage routing for the seekable-zstd image.
+		setZstPath(&versionMetadata, storageType, zstPath, zstChecksum, zstSize)
 
 		// Update OTA update fields only if provided
 		if otaUpdatePath != "" {
@@ -2499,26 +2661,85 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 		topBmapDest = copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.BmapPath, deviceType, stableVersion, "block map")
 	}
 
+	// Copy seekable-zstd images, mirroring bmap promotion. Each zst follows
+	// its image to the stable path and retains its checksum/size metadata.
+	nvmeZstDest := copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.NVMEZstPath, deviceType, stableVersion, "NVMe seekable-zstd")
+	sdZstDest := copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.SDCardZstPath, deviceType, stableVersion, "SD card seekable-zstd")
+	var topZstDest string
+	switch {
+	case nvmeZstDest != "":
+		topZstDest = nvmeZstDest
+	case sdZstDest != "":
+		topZstDest = sdZstDest
+	case sourceVersionMeta.ZstPath != "":
+		topZstDest = copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.ZstPath, deviceType, stableVersion, "seekable-zstd")
+	}
+
 	// Create new stable version entry with promotion metadata
 	promotedAt := time.Now()
 	sourceVersion := nightlyVersion
 	stableVersionMeta := VersionMetadata{
-		ReleaseDate:        sourceVersionMeta.ReleaseDate,
-		Path:               destinationPath,
-		Checksum:           sourceVersionMeta.Checksum,
-		SizeBytes:          sourceVersionMeta.SizeBytes,
-		Changelog:          sourceVersionMeta.Changelog,
-		IsLatest:           true,
-		IsNightly:          false,
-		PromotedFrom:       &sourceVersion,
-		PromotedAt:         &promotedAt,
-		NVMEPath:           nvmeDestPath,
-		NVMEChecksum:       nvmeChecksum,
-		SDCardPath:         sdDestPath,
-		SDCardChecksum:     sdChecksum,
-		NVMEBmapPath:       nvmeBmapDest,
-		SDCardBmapPath:     sdBmapDest,
-		BmapPath:           topBmapDest,
+		ReleaseDate:    sourceVersionMeta.ReleaseDate,
+		Path:           destinationPath,
+		Checksum:       sourceVersionMeta.Checksum,
+		SizeBytes:      sourceVersionMeta.SizeBytes,
+		Changelog:      sourceVersionMeta.Changelog,
+		IsLatest:       true,
+		IsNightly:      false,
+		PromotedFrom:   &sourceVersion,
+		PromotedAt:     &promotedAt,
+		NVMEPath:       nvmeDestPath,
+		NVMEChecksum:   nvmeChecksum,
+		SDCardPath:     sdDestPath,
+		SDCardChecksum: sdChecksum,
+		NVMEBmapPath:   nvmeBmapDest,
+		SDCardBmapPath: sdBmapDest,
+		BmapPath:       topBmapDest,
+		ZstPath:        topZstDest,
+		ZstChecksum: func() string {
+			if nvmeZstDest != "" {
+				return sourceVersionMeta.NVMEZstChecksum
+			}
+			if sdZstDest != "" {
+				return sourceVersionMeta.SDCardZstChecksum
+			}
+			return sourceVersionMeta.ZstChecksum
+		}(),
+		ZstSizeBytes: func() int64 {
+			if nvmeZstDest != "" {
+				return sourceVersionMeta.NVMEZstSizeBytes
+			}
+			if sdZstDest != "" {
+				return sourceVersionMeta.SDCardZstSizeBytes
+			}
+			return sourceVersionMeta.ZstSizeBytes
+		}(),
+		NVMEZstPath: nvmeZstDest,
+		NVMEZstChecksum: func() string {
+			if nvmeZstDest != "" {
+				return sourceVersionMeta.NVMEZstChecksum
+			}
+			return ""
+		}(),
+		NVMEZstSizeBytes: func() int64 {
+			if nvmeZstDest != "" {
+				return sourceVersionMeta.NVMEZstSizeBytes
+			}
+			return 0
+		}(),
+		SDCardZstPath: sdZstDest,
+		SDCardZstChecksum: func() string {
+			if sdZstDest != "" {
+				return sourceVersionMeta.SDCardZstChecksum
+			}
+			return ""
+		}(),
+		SDCardZstSizeBytes: func() int64 {
+			if sdZstDest != "" {
+				return sourceVersionMeta.SDCardZstSizeBytes
+			}
+			return 0
+		}(),
 		OTAUpdatePath:      otaDestPath,
 		OTAUpdateChecksum:  sourceVersionMeta.OTAUpdateChecksum,
 		OTAUpdateSizeBytes: sourceVersionMeta.OTAUpdateSizeBytes,

--- a/tools/publisher/upload_and_manifest_test.go
+++ b/tools/publisher/upload_and_manifest_test.go
@@ -5,9 +5,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"os"
 	"testing"
 	"time"
+
+	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
+	"github.com/klauspost/compress/zstd"
 )
 
 // Test validation functions
@@ -561,4 +565,176 @@ func TestSetBmapPath(t *testing.T) {
 			t.Errorf("empty bmapPath should not change anything, got %+v", m)
 		}
 	})
+}
+
+func TestSetZstPath(t *testing.T) {
+	t.Run("nvme sets per-storage and top-level", func(t *testing.T) {
+		m := &VersionMetadata{}
+		setZstPath(m, "nvme", "images/x/nvme.img.zst", "abc123", 1024)
+		if m.NVMEZstPath != "images/x/nvme.img.zst" {
+			t.Errorf("NVMEZstPath = %q", m.NVMEZstPath)
+		}
+		if m.NVMEZstChecksum != "abc123" {
+			t.Errorf("NVMEZstChecksum = %q", m.NVMEZstChecksum)
+		}
+		if m.NVMEZstSizeBytes != 1024 {
+			t.Errorf("NVMEZstSizeBytes = %d", m.NVMEZstSizeBytes)
+		}
+		if m.ZstPath != "images/x/nvme.img.zst" {
+			t.Errorf("ZstPath = %q, want NVMe zst (matches top-level Path)", m.ZstPath)
+		}
+		if m.ZstChecksum != "abc123" {
+			t.Errorf("ZstChecksum = %q", m.ZstChecksum)
+		}
+		if m.ZstSizeBytes != 1024 {
+			t.Errorf("ZstSizeBytes = %d", m.ZstSizeBytes)
+		}
+		if m.SDCardZstPath != "" {
+			t.Errorf("SDCardZstPath = %q, want empty", m.SDCardZstPath)
+		}
+	})
+
+	t.Run("sd after nvme does not clobber top-level", func(t *testing.T) {
+		m := &VersionMetadata{
+			ZstPath:          "images/x/nvme.img.zst",
+			ZstChecksum:      "abc123",
+			ZstSizeBytes:     1024,
+			NVMEZstPath:      "images/x/nvme.img.zst",
+			NVMEZstChecksum:  "abc123",
+			NVMEZstSizeBytes: 1024,
+		}
+		setZstPath(m, "sd", "images/x/sd.img.zst", "def456", 512)
+		if m.SDCardZstPath != "images/x/sd.img.zst" {
+			t.Errorf("SDCardZstPath = %q", m.SDCardZstPath)
+		}
+		if m.ZstPath != "images/x/nvme.img.zst" {
+			t.Errorf("ZstPath = %q, want NVMe zst preserved", m.ZstPath)
+		}
+		if m.ZstChecksum != "abc123" {
+			t.Errorf("ZstChecksum = %q, want NVMe checksum preserved", m.ZstChecksum)
+		}
+	})
+
+	t.Run("nvme after sd wins top-level", func(t *testing.T) {
+		m := &VersionMetadata{
+			ZstPath:            "images/x/sd.img.zst",
+			ZstChecksum:        "def456",
+			ZstSizeBytes:       512,
+			SDCardZstPath:      "images/x/sd.img.zst",
+			SDCardZstChecksum:  "def456",
+			SDCardZstSizeBytes: 512,
+		}
+		setZstPath(m, "nvme", "images/x/nvme.img.zst", "abc123", 1024)
+		if m.ZstPath != "images/x/nvme.img.zst" {
+			t.Errorf("ZstPath = %q, want NVMe to win top-level", m.ZstPath)
+		}
+		if m.SDCardZstPath != "images/x/sd.img.zst" {
+			t.Errorf("SDCardZstPath = %q, want SD preserved", m.SDCardZstPath)
+		}
+	})
+
+	t.Run("sd-only device fills top-level", func(t *testing.T) {
+		m := &VersionMetadata{}
+		setZstPath(m, "sd", "images/x/sd.img.zst", "def456", 512)
+		if m.ZstPath != "images/x/sd.img.zst" {
+			t.Errorf("ZstPath = %q, want SD zst for sd-only device", m.ZstPath)
+		}
+		if m.SDCardZstPath != "images/x/sd.img.zst" {
+			t.Errorf("SDCardZstPath = %q", m.SDCardZstPath)
+		}
+		if m.ZstChecksum != "def456" {
+			t.Errorf("ZstChecksum = %q", m.ZstChecksum)
+		}
+	})
+
+	t.Run("single-storage default sets top-level", func(t *testing.T) {
+		m := &VersionMetadata{}
+		setZstPath(m, "", "images/x/img.zst", "xyz789", 2048)
+		if m.ZstPath != "images/x/img.zst" {
+			t.Errorf("ZstPath = %q", m.ZstPath)
+		}
+		if m.ZstChecksum != "xyz789" {
+			t.Errorf("ZstChecksum = %q", m.ZstChecksum)
+		}
+	})
+
+	t.Run("emmc gets no zst", func(t *testing.T) {
+		m := &VersionMetadata{}
+		setZstPath(m, "emmc", "images/x/should-not-be-set.zst", "abc", 100)
+		if m.ZstPath != "" || m.NVMEZstPath != "" || m.SDCardZstPath != "" {
+			t.Errorf("eMMC should set no zst fields, got %+v", m)
+		}
+	})
+
+	t.Run("empty zst path is a no-op", func(t *testing.T) {
+		m := &VersionMetadata{ZstPath: "existing", ZstChecksum: "cs", ZstSizeBytes: 99}
+		setZstPath(m, "nvme", "", "", 0)
+		if m.ZstPath != "existing" || m.ZstChecksum != "cs" || m.NVMEZstPath != "" {
+			t.Errorf("empty zstPath should not change anything, got %+v", m)
+		}
+	})
+}
+
+func TestCompressSeekableZstdRoundTrips(t *testing.T) {
+	// Build a known payload that spans multiple frames (> seekableFrameSize would
+	// be slow in tests; use a small payload and verify the whole thing round-trips).
+	payload := make([]byte, 64*1024) // 64 KiB — fits in a single frame
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+
+	// Write source file.
+	srcFile, err := os.CreateTemp("", "zst-src-*.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(srcFile.Name())
+	if _, err := srcFile.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	srcFile.Close()
+
+	// Compress to a .zst file.
+	dstPath := srcFile.Name() + ".zst"
+	defer os.Remove(dstPath)
+	if err := compressSeekableZstd(srcFile.Name(), dstPath); err != nil {
+		t.Fatalf("compressSeekableZstd: %v", err)
+	}
+
+	// Verify the .zst file exists and is non-empty.
+	info, err := os.Stat(dstPath)
+	if err != nil {
+		t.Fatalf("zst file not found: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("zst file is empty")
+	}
+
+	// Round-trip: decompress with seekable reader and verify content.
+	zstFile, err := os.Open(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zstFile.Close()
+
+	dec, err := zstd.NewReader(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dec.Close()
+
+	r, err := seekable.NewReader(zstFile, dec)
+	if err != nil {
+		t.Fatalf("seekable.NewReader: %v", err)
+	}
+	defer r.Close()
+
+	got := make([]byte, len(payload))
+	if _, err := r.ReadAt(got, 0); err != nil && err != io.EOF {
+		t.Fatalf("ReadAt: %v", err)
+	}
+
+	if string(got) != string(payload) {
+		t.Error("round-trip mismatch: decompressed bytes differ from original")
+	}
 }


### PR DESCRIPTION
## Summary
Adds seekable-zstd publishing to `tools/publisher` — the producer half of the CLI seekable-zstd flashing feature (wendylabsinc/WendyOS#1036). The CLI downloads only the `.zst` + `.bmap` and writes mapped ranges (skipping holes); this generates that `.zst` and advertises it in the manifest. Builds on the per-storage bmap support already in `main`.

- Generates `<image>.img.zst` in the **seekable** zstd format (4 MiB frames) from the **same raw image the `.bmap` describes**, and uploads it alongside the existing `.zip`/`.bmap`. OS images only (OTA/recovery excluded).
- Adds per-storage manifest fields `zst_path`/`nvme_zst_path`/`sd_zst_path` (+ `*_zst_checksum`, `*_zst_size_bytes`) whose JSON tags **byte-match the CLI consumer** in WendyOS#1036.
- `setZstPath` mirrors the existing `setBmapPath` per-storage routing (nvme wins top-level, sd fills if empty); threaded through `updateManifests`/`updateDeviceManifest`, the `--upload-only`/`--apply-metadata` handoff, and `promoteNightlyToStable`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` (incl. `TestSetZstPath` and `TestCompressSeekableZstdRoundTrips`)
- [ ] Publish a multi-storage version (jetson-orin-nano) for `--storage nvme` and `--storage sd`; confirm the manifest carries distinct `*_zst_path`/`*_bmap_path`, and the CLI (WendyOS#1036) flashes via the seekable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)