### PR TITLE
feat(mount): persist /var/lib/wendy and /var/lib/wendy-agent on /data

### DIFF
--- a/recipes-core/packagegroups/packagegroup-base-rpi.inc
+++ b/recipes-core/packagegroups/packagegroup-base-rpi.inc
@@ -1,5 +1,6 @@
-# Note: the /data-dependent recipes (systemd-mount-containerd, wendyos-etc-binds,
-# swapfile-setup, wendyos-user-data-setup) are intentionally NOT removed here.
+# Note: the /data-dependent recipes (systemd-mount-containerd, systemd-mount-wendy,
+# wendyos-etc-binds, swapfile-setup, wendyos-user-data-setup) are intentionally NOT
+# removed here.
 # They are gated on WENDYOS_MENDER in packagegroup-wendyos-base.bb, and 64-bit RPi
 # now sets WENDYOS_MENDER=1 (raspberrypi-common-wendyos.inc, WDY-983), so the /data
 # partition exists. In particular, systemd-mount-containerd bind-mounts containerd's

--- a/recipes-core/packagegroups/packagegroup-wendyos-base.bb
+++ b/recipes-core/packagegroups/packagegroup-wendyos-base.bb
@@ -39,7 +39,7 @@ RDEPENDS:${PN} = " \
 # services would fail at boot.
 RDEPENDS:${PN}:append = " \
     ${@'' if (d.getVar('WENDYOS_OTA') or 'none') == 'none' else \
-        'wendyos-user-data-setup systemd-mount-containerd swapfile-setup wendyos-etc-binds'} \
+        'wendyos-user-data-setup systemd-mount-containerd systemd-mount-wendy swapfile-setup wendyos-etc-binds'} \
     "
 
 RDEPENDS:${PN}:append = " \

--- a/recipes-core/packagegroups/qemu-packagegroup-base.inc
+++ b/recipes-core/packagegroups/qemu-packagegroup-base.inc
@@ -8,4 +8,5 @@ RDEPENDS:${PN}:remove = " \
     wendyos-etc-binds \
     swapfile-setup \
     systemd-mount-containerd \
+    systemd-mount-wendy \
     "

--- a/recipes-core/systemd-mount-wendy/files/var-lib-wendy-agent.mount
+++ b/recipes-core/systemd-mount-wendy/files/var-lib-wendy-agent.mount
@@ -1,0 +1,24 @@
+[Unit]
+Description=Bind mount /var/lib/wendy-agent from persistent data partition
+Documentation=man:systemd.mount(5)
+
+# Ensure data partition is mounted and filesystem is fully expanded
+RequiresMountsFor=/data
+After=data.mount
+
+# Wait for Mender data partition resize to complete (if enabled)
+# This is safe even if mender-systemd-growfs-data.service doesn't exist
+After=mender-systemd-growfs-data.service
+
+# Must be mounted before the agent starts (this is its WorkingDirectory)
+Before=wendyos-agent.service
+DefaultDependencies=no
+
+[Mount]
+What=/data/wendy-agent
+Where=/var/lib/wendy-agent
+Type=none
+Options=bind,nosuid,nodev,x-systemd.mkdir
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-wendy/files/var-lib-wendy.mount
+++ b/recipes-core/systemd-mount-wendy/files/var-lib-wendy.mount
@@ -1,0 +1,24 @@
+[Unit]
+Description=Bind mount /var/lib/wendy from persistent data partition
+Documentation=man:systemd.mount(5)
+
+# Ensure data partition is mounted and filesystem is fully expanded
+RequiresMountsFor=/data
+After=data.mount
+
+# Wait for Mender data partition resize to complete (if enabled)
+# This is safe even if mender-systemd-growfs-data.service doesn't exist
+After=mender-systemd-growfs-data.service
+
+# Must be mounted before the agent starts
+Before=wendyos-agent.service
+DefaultDependencies=no
+
+[Mount]
+What=/data/wendy
+Where=/var/lib/wendy
+Type=none
+Options=bind,nosuid,nodev,x-systemd.mkdir
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
+++ b/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Systemd mount units for persistent wendy data directories"
+DESCRIPTION = "Bind mounts /var/lib/wendy from /data/wendy and /var/lib/wendy-agent \
+from /data/wendy-agent to provide persistent agent state across Mender OTA updates. \
+Ensures wendy-agent data survives A/B partition switches."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit systemd
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = "file://var-lib-wendy.mount \
+           file://var-lib-wendy-agent.mount"
+S = "${UNPACKDIR}"
+
+SYSTEMD_SERVICE:${PN} = "var-lib-wendy.mount var-lib-wendy-agent.mount"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/var-lib-wendy.mount ${D}${systemd_system_unitdir}/var-lib-wendy.mount
+    install -m 0644 ${UNPACKDIR}/var-lib-wendy-agent.mount ${D}${systemd_system_unitdir}/var-lib-wendy-agent.mount
+}
+
+FILES:${PN} += "${systemd_system_unitdir}/var-lib-wendy.mount \
+                ${systemd_system_unitdir}/var-lib-wendy-agent.mount"
+
+RDEPENDS:${PN} = "systemd"


### PR DESCRIPTION
## What

Adds a `systemd-mount-wendy` recipe (modeled on `systemd-mount-containerd`) that bind-mounts:

- `/var/lib/wendy` ← `/data/wendy`
- `/var/lib/wendy-agent` ← `/data/wendy-agent`

`/var/lib/wendy-agent` is `wendyos-agent.service`'s `WorkingDirectory`, so this keeps agent state on the persistent `/data` partition and it survives Mender A/B OTA swaps. Without it, agent state lives on the small A/B root slot and is lost on every update — the same failure mode `systemd-mount-containerd` was added to fix.

## How

- Two `.mount` units reuse the containerd unit's `/data` + Mender-resize ordering and `x-systemd.mkdir`, ordered `Before=wendyos-agent.service`.
- Recipe wired into `packagegroup-wendyos-base` under the OTA/`WENDYOS_MENDER` gate and added to the QEMU `:remove` list (QEMU has no `/data` partition), exactly matching `systemd-mount-containerd`.

## Notes

- `/var/lib/wendy` (exact) isn't referenced anywhere in the tree yet, so that mount persists an empty dir until something is pointed there. The `/var/lib/wendy-agent` mount is the one that persists live state today.
- Not yet built/booted — relying on CI to validate parse/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)