### PR TITLE
Bump patch version to 0.15.5

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -76,7 +76,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.15.4"
+DISTRO_VERSION = "0.15.5"
 # DISTRO_CODENAME is inherited from poky.conf (require'd above), which
 # sets it to the active oe-core series ("scarthgap", "wrynose", ...).
 # Don't override here or it gets stuck on a stale value across series.


### PR DESCRIPTION
Bumps `DISTRO_VERSION` from `0.15.4` to `0.15.5` in `conf/distro/wendyos.conf`. `SDK_VERSION` tracks `DISTRO_VERSION` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)