### PR TITLE
Bump Jetson rootfs to 16GB (Thor + all Orin boards)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ build/tmp/deploy/images/<machine>/wendyos-image-<machine>.rootfs.tegraflash.tar.
 
 #### For SD Card Builds
 
+> **Requires a 64 GB (or larger) SD card.** The Orin Nano SD image uses a 64GB
+> layout (`WENDYOS_FLASH_IMAGE_SIZE = "64GB"`) so the A/B rootfs slots can hold
+> the 16GB rootfs.
+
 **Option 1: Directly Flash to SD Card**
 
 ```bash

--- a/conf/machine/jetson-agx-orin-devkit-emmc-wendyos.conf
+++ b/conf/machine/jetson-agx-orin-devkit-emmc-wendyos.conf
@@ -99,5 +99,13 @@ IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INIT
 # (P3701-0008, the Industrial 64GB SKU which uses the same eMMC class).
 EMMC_SIZE = "63652757504"
 
+# Root filesystem image size (MB). Overrides the 8192 (8GB) default from
+# recipes-core/images/wendyos-image.bb. flash-image-sizes.inc sizes the
+# device and Mender storage total, but NOT the rootfs filesystem, so without
+# this the rootfs stays at 8GB even though the A/B slots are ~24GB on the 64GB
+# layout (~49.8 GiB Mender storage, see headroom note above). 16GB gives room
+# for the NVIDIA CUDA/TensorRT/DeepStream stack as more features land.
+IMAGE_ROOTFS_SIZE = "16384"
+
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "jetson-agx-orin-emmc"

--- a/conf/machine/jetson-agx-orin-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-agx-orin-devkit-nvme-wendyos.conf
@@ -64,5 +64,13 @@ IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INIT
 # If you really need it, board param (but consider removing if unused):
 EMMC_SIZE = "0"
 
+# Root filesystem image size (MB). Overrides the 8192 (8GB) default from
+# recipes-core/images/wendyos-image.bb. flash-image-sizes.inc sizes the
+# device (TEGRA_EXTERNAL_DEVICE_SECTORS) and Mender storage total, but NOT the
+# rootfs filesystem, so without this the rootfs stays at 8GB even though the
+# A/B slots are ~24GB on the 64GB layout. 16GB gives headroom for the NVIDIA
+# CUDA/TensorRT/DeepStream stack as more features land.
+IMAGE_ROOTFS_SIZE = "16384"
+
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "jetson-agx-orin"

--- a/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
@@ -60,5 +60,13 @@ IMAGE_FSTYPES:tegra = "tegraflash-tar"
 IMAGE_FSTYPES:pn-tegra-minimal-initramfs:tegra = "${INITRAMFS_FSTYPES}"
 IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INITRAMFS_FSTYPES}"
 
+# Root filesystem image size (MB). Overrides the 8192 (8GB) default from
+# recipes-core/images/wendyos-image.bb. Thor runs the wendyos-update OTA
+# stack (WENDYOS_OTA = "wendy"), so the Mender-only flash-image-sizes.inc
+# sizing path does not apply here — without this override Thor would inherit
+# the 8GB default, which is tight once more features land. The two A/B rootfs
+# slots are sized from the rootfs image by the auto-derived redundant layout.
+IMAGE_ROOTFS_SIZE = "16384"
+
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "jetson-agx-thor"

--- a/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
@@ -54,5 +54,13 @@ IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INIT
 # If you really need it, board param (but consider removing if unused):
 EMMC_SIZE = "0"
 
+# Root filesystem image size (MB). Overrides the 8192 (8GB) default from
+# recipes-core/images/wendyos-image.bb. flash-image-sizes.inc sizes the
+# device and Mender storage total, but NOT the rootfs filesystem, so without
+# this the rootfs stays at 8GB even though the A/B slots are ~24GB on the 64GB
+# layout. 16GB gives headroom for the NVIDIA CUDA/TensorRT/DeepStream stack as
+# more features land.
+IMAGE_ROOTFS_SIZE = "16384"
+
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "jetson-orin-nano"

--- a/conf/machine/jetson-orin-nano-devkit-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-wendyos.conf
@@ -31,6 +31,12 @@ TEGRAFLASH_SDCARD_SIZE = "32G"
 # MENDER_STORAGE_TOTAL_SIZE_MB intentionally not set here: the value from
 # distro/include/flash-image-sizes.inc (driven by WENDYOS_FLASH_IMAGE_SIZE)
 # wins in practice and would silently override any value pinned here.
+#
+# Root filesystem size intentionally left at the 8192 (8GB) default from
+# recipes-core/images/wendyos-image.bb. Unlike the 64GB NVMe/eMMC Orin boards
+# (bumped to 16GB), this 32GB SD layout (WENDYOS_FLASH_IMAGE_SIZE = "32GB" ->
+# MENDER_STORAGE_TOTAL_SIZE_MB = 25700, ~12.8GB per A/B rootfs slot) cannot
+# hold a 16GB rootfs filesystem.
 MENDER_STORAGE_DEVICE_BASE = "/dev/mmcblk0p"
 MENDER_BOOT_PART = "${MENDER_STORAGE_DEVICE_BASE}11"
 MENDER_ROOTFS_PART_A = "${MENDER_STORAGE_DEVICE_BASE}1"

--- a/conf/machine/jetson-orin-nano-devkit-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-wendyos.conf
@@ -26,17 +26,12 @@ TEGRA_UEFI_USE_SIGNED_FILES = "false"
 # Mender's per-A/B-slot rootfs size is derived from MENDER_STORAGE_TOTAL_SIZE_MB
 # which itself comes from WENDYOS_FLASH_IMAGE_SIZE in the board template, so
 # this must stay in lockstep with that value to avoid sgdisk failing to lay
-# out the partition table inside an undersized image file.
-TEGRAFLASH_SDCARD_SIZE = "32G"
+# out the partition table inside an undersized image file. 64G requires a 64 GB
+# minimum SD card (32 GB is too tight for practical use).
+TEGRAFLASH_SDCARD_SIZE = "64G"
 # MENDER_STORAGE_TOTAL_SIZE_MB intentionally not set here: the value from
 # distro/include/flash-image-sizes.inc (driven by WENDYOS_FLASH_IMAGE_SIZE)
 # wins in practice and would silently override any value pinned here.
-#
-# Root filesystem size intentionally left at the 8192 (8GB) default from
-# recipes-core/images/wendyos-image.bb. Unlike the 64GB NVMe/eMMC Orin boards
-# (bumped to 16GB), this 32GB SD layout (WENDYOS_FLASH_IMAGE_SIZE = "32GB" ->
-# MENDER_STORAGE_TOTAL_SIZE_MB = 25700, ~12.8GB per A/B rootfs slot) cannot
-# hold a 16GB rootfs filesystem.
 MENDER_STORAGE_DEVICE_BASE = "/dev/mmcblk0p"
 MENDER_BOOT_PART = "${MENDER_STORAGE_DEVICE_BASE}11"
 MENDER_ROOTFS_PART_A = "${MENDER_STORAGE_DEVICE_BASE}1"
@@ -60,6 +55,14 @@ IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INIT
 
 # If you really need it, board param (but consider removing if unused):
 EMMC_SIZE = "0"
+
+# Root filesystem image size (MB). Overrides the 8192 (8GB) default from
+# recipes-core/images/wendyos-image.bb. flash-image-sizes.inc sizes the
+# device and Mender storage total, but NOT the rootfs filesystem. With the
+# 64GB SD layout (WENDYOS_FLASH_IMAGE_SIZE = "64GB" ->
+# MENDER_STORAGE_TOTAL_SIZE_MB = 51000, ~24GB per A/B slot) there is room for
+# a 16GB rootfs, matching the NVMe/eMMC Orin boards.
+IMAGE_ROOTFS_SIZE = "16384"
 
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "jetson-orin-nano"

--- a/conf/template/boards/jetson-orin-nano-sd/local.conf
+++ b/conf/template/boards/jetson-orin-nano-sd/local.conf
@@ -14,6 +14,7 @@ MACHINE = "jetson-orin-nano-devkit-wendyos"
 # Must match TEGRAFLASH_SDCARD_SIZE in the machine config: meta-tegra bakes
 # that into dosdcard.sh at recipe time and the script accepts no runtime size
 # override, so a mismatch makes sgdisk fail to lay out the partition table.
-# 16 GB is too tight for a full WendyOS rootfs (~6.5 GiB image, ~6 GiB per
-# A/B slot after Mender + reserved overhead), so we use 32 GB.
-WENDYOS_FLASH_IMAGE_SIZE = "32GB"
+# 64 GB (requires a 64 GB minimum SD card) so the A/B rootfs slots (~24 GiB
+# each at MENDER_STORAGE_TOTAL_SIZE_MB = 51000) can hold the 16 GB rootfs,
+# matching the NVMe/eMMC Orin boards. 32 GB is too tight for practical use.
+WENDYOS_FLASH_IMAGE_SIZE = "64GB"


### PR DESCRIPTION
## What

Bump the root filesystem image size from 8GB to **16GB** across all Jetson boards, and move the Orin Nano SD board to a 64GB layout so it can fit.

## Why

`IMAGE_ROOTFS_SIZE ?= "8192"` (8GB) in `recipes-core/images/wendyos-image.bb` is the size of the **rootfs filesystem**, and nothing overrode it for the Jetsons. The per-size Tegra helper (`flash-image-sizes.inc`) only sizes the **device and Mender storage** — not the rootfs — so every Jetson's OS filesystem was capped at 8GB regardless of how big its partitions were.

That's tight as we add features, especially given the NVIDIA CUDA / TensorRT / DeepStream stack (full JetPack on-device is ~16–20GB+). 16GB is nearly free here since the ext4 is sparse and the partitions have ample room.

## Changes

Per-board `IMAGE_ROOTFS_SIZE = "16384"` override on:

| Board | Machine conf | Layout | Notes |
|-------|--------------|--------|-------|
| Thor (AGX Thor NVMe) | `jetson-agx-thor-devkit-nvme-wendyos.conf` | wendy OTA | `flash-image-sizes.inc` is Mender-only, so Thor was on the 8GB default |
| AGX Orin NVMe | `jetson-agx-orin-devkit-nvme-wendyos.conf` | 64GB | ~24GB A/B slots |
| AGX Orin eMMC | `jetson-agx-orin-devkit-emmc-wendyos.conf` | 64GB | ~24GB A/B slots |
| Orin Nano NVMe | `jetson-orin-nano-devkit-nvme-wendyos.conf` | 64GB | ~24GB A/B slots |
| Orin Nano SD | `jetson-orin-nano-devkit-wendyos.conf` | **32GB → 64GB** | bumped layout (see below) |

### Orin Nano SD: 32GB → 64GB layout

The 32GB SD layout (~12.8GB per A/B slot) couldn't hold a 16GB rootfs. Moved it to the 64GB layout — `WENDYOS_FLASH_IMAGE_SIZE = "64GB"` + `TEGRAFLASH_SDCARD_SIZE = "64G"` kept in lockstep — which gives ~24GB slots. **This requires a 64GB minimum SD card** (32GB was too small for practical use anyway); documented in the README SD-card flashing section.

### Not touched

- **QEMU** — sized separately via `QEMU_ROOTFS_SIZE`.
- **Global default / RPi** — left the `8192` default in place rather than bumping globally, to avoid changing RPi (smaller layouts) behavior.

## Verification

Config-only. Recommend a build + flash on each board to confirm the 16GB ext4 fits the derived rootfs partitions end-to-end — particularly the Orin Nano SD on its new 64GB layout, and Thor (the wendy OTA path has no fixed `TEGRA_EXTERNAL_DEVICE_SECTORS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)