### PR TITLE
JP7.2 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,6 +452,22 @@ jobs:
       # end. L2 (S3) we push explicitly so other matrix entries / future
       # runners can prime from it.
 
+      # Re-assume the role for a fresh STS token before uploading. The
+      # credentials configured at job start expire after the default 1h
+      # session, and a cold blacksail build now runs longer than that — so by
+      # the time we reach the upload the original token is dead ("ExpiredToken:
+      # The provided token has expired"). Bumping role-duration-seconds alone
+      # would also require raising the IAM role's MaxSessionDuration; refreshing
+      # here is self-contained and gives the upload a full fresh hour.
+      # if: always() mirrors the save step so the cache still uploads after a
+      # failed build.
+      - name: Refresh AWS credentials for cache upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BUILD_CACHE_ROLE_ARN }}
+          aws-region: ${{ vars.WENDYOS_BUILD_CACHE_REGION }}
+
       - name: Save sstate-cache and downloads to S3 (L2)
         if: always()
         env:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -321,6 +321,45 @@ function clone_repos() {
     done
 }
 
+# Print which Yocto layer tree is active and, per layer, the short SHA it
+# landed on plus the matching upstream branch. Checkouts are by SRCREV
+# (detached HEAD), so "branch" is best-effort: the remote branch whose tip
+# equals HEAD (the common case — we pin branch tips), else a branch that
+# contains the commit, else "(detached)". Run from inside
+# repos/${WENDYOS_LAYER_TREE}/.
+function report_tree() {
+    printf "\n=== Active Yocto layer tree: %s  (repos/%s/) ===\n" \
+        "${WENDYOS_LAYER_TREE}" "${WENDYOS_LAYER_TREE}"
+    local repo enable url folder short branch
+    for repo in "${repos[@]}"
+    do
+        enable=$(echo "${repo}" | cut -d'|' -f 1)
+        [ "${enable}" -ne 1 ] && continue
+        url=$(echo "${repo}" | cut -d'|' -f 2)
+        folder=$(echo "${repo}" | cut -d'|' -f 3)
+        [[ -z "${folder}" ]] && folder=$(basename "${url%.git}")
+        [[ -d "./${folder}" ]] || continue
+        cd "${folder}"
+        short=$(git rev-parse --short HEAD 2>/dev/null || echo '?')
+        # Prefer the remote branch whose tip == HEAD (we pin branch tips);
+        # else any branch that contains the commit, preferring a real branch
+        # over a contrib/ mirror; drop the origin/HEAD symref either way.
+        # NOTE: trailing '|| true' is required — under `set -e`/`pipefail` a
+        # grep that filters everything exits 1 and would abort the script.
+        branch=$(git branch -r --points-at HEAD --format='%(refname:short)' 2>/dev/null | grep -vE '(^|/)HEAD$' | head -n1 || true)
+        if [[ -z "${branch}" ]]; then
+            local contains
+            contains=$(git branch -r --contains HEAD --format='%(refname:short)' 2>/dev/null | grep -vE '(^|/)HEAD$' || true)
+            branch=$(printf '%s\n' "${contains}" | grep -v 'contrib/' | head -n1 || true)
+            [[ -z "${branch}" ]] && branch=$(printf '%s\n' "${contains}" | head -n1 || true)
+        fi
+        [[ -z "${branch}" ]] && branch='(detached)'
+        printf "  %-20s %-12s %s\n" "${folder}" "${short}" "${branch}"
+        cd ..
+    done
+    printf "\n"
+}
+
 copy_dir() {
     local src="${1}"
     local dst="${2}"
@@ -390,6 +429,11 @@ then
     source "${BOARD_DIR}/repos.overrides"
 fi
 
+# Announce the resolved tree up front (after the board override) so it is
+# obvious which Yocto series this bootstrap targets before any cloning.
+printf "Board '%s' -> Yocto layer tree '%s' (clones under repos/%s/)\n" \
+    "${BOARD}" "${WENDYOS_LAYER_TREE}" "${WENDYOS_LAYER_TREE}"
+
 # Warn (but do not auto-delete) if a pre-migration bundled-poky checkout is
 # still on disk. It is no longer used; the user can remove it manually.
 if [[ -d "${PROJECT_DIR}/repos/poky" ]]
@@ -452,6 +496,9 @@ clone_repos || {
     cd "${WORK_DIR}"
     exit 1
 }
+
+# Summarise the active tree + each layer's branch/revision.
+report_tree
 
 image_name=$(basename "${META_LAYER_DIR}")
 

--- a/classes/image_types_wendy.bbclass
+++ b/classes/image_types_wendy.bbclass
@@ -10,7 +10,7 @@
 #   IMAGE_CLASSES += "image_types_wendy"
 #   IMAGE_FSTYPES += "wendy"
 #
-# The artifact format and `pack` are documented in the wendy-os-update
+# The artifact format and `pack` are documented in the wendyos-update
 # repo (docs/manifest-schema.md, docs/cli-contract.md).
 
 # The artifact payload is the raw rootfs ext4; force it to be built even

--- a/conf/distro/include/tegra-image.inc
+++ b/conf/distro/include/tegra-image.inc
@@ -41,12 +41,15 @@ IMAGE_INSTALL:append = " \
 # - Additional libraries (libnuma) and monitoring paths
 WENDYOS_USB_GADGET ?= "1"
 WENDYOS_DEEPSTREAM ?= "1"
+# The DeepStream package is BSP-specific:
+#   blacksail (JP7.2/r39.2, CUDA 13) -> deepstream-8.0 (meta-tegra-extensions-jp7)
+#   scarthgap (JP6, CUDA 12)         -> deepstream-7.1 (meta-tegra-community)
+#   wrynose (r38.4) / other          -> none (no DeepStream recipe exists there)
+DEEPSTREAM_PKG = "${@'deepstream-8.0' if d.getVar('WENDYOS_LAYER_TREE') == 'blacksail' else ('deepstream-7.1' if d.getVar('WENDYOS_LAYER_TREE') == 'scarthgap' else '')}"
 IMAGE_INSTALL:append = " \
     ${@oe.utils.ifelse( \
         d.getVar('WENDYOS_DEEPSTREAM') == '1', \
-            ' \
-                deepstream-7.1 \
-            ', \
+            d.getVar('DEEPSTREAM_PKG'), \
             '' \
         )} \
     "

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -53,14 +53,21 @@ require ${@'conf/distro/include/mender.inc'              if d.getVar('WENDYOS_OT
 require ${@'conf/distro/include/flash-image-sizes.inc'   if d.getVar('WENDYOS_OTA') == 'mender' and 'tegra' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 require ${@'conf/distro/include/wendyos-update.inc'      if d.getVar('WENDYOS_OTA') == 'wendy' else ''}
 
-# Conditionally require L4T configuration only for Tegra machines.
-# Thor (tegra264) pins L4T 38.4.0 (JetPack 7.1); Orin (tegra234) stays on
-# L4T 36.4.4 (JetPack 6.2.1). Non-Tegra builds (qemuarm64, raspberrypi*)
-# include neither.
-# NOTE for the future Orin JP7 move: the SoC family alone cannot
-# distinguish JP6 from JP7 on Orin (both tegra234) — the gate will need a
-# JP7 discriminator then (e.g. a machine-conf override token).
-require ${@'conf/distro/include/l4t-r38-4-0.conf' if 'tegra264' in d.getVar('MACHINEOVERRIDES').split(':') else ('conf/distro/include/l4t-r36-4-4.conf' if 'tegra' in d.getVar('MACHINEOVERRIDES').split(':') else '')}
+# Conditionally require L4T version-pinning only for Tegra machines.
+#   - blacksail tree (JetPack 7.2 / L4T r39.2.0): pin NOTHING. meta-tegra's
+#     wip-l4t-r39.2.0 branch is single-version and self-defaults
+#     L4T_VERSION ?= "39.2.0" (+ CUDA 13.2 / cuDNN 9.20 / TensorRT 10.16),
+#     so its native recipes are authoritative; a hand-pinned file would only
+#     risk mis-pinning. Applies to every tegra SoC on blacksail (Thor +,
+#     later, Orin) — the layer tree IS the JP6/JP7 discriminator the note
+#     below anticipated.
+#   - tegra264 (Thor / wrynose): pin L4T 38.4.0 (JetPack 7.1).
+#   - other tegra (Orin / scarthgap): pin L4T 36.4.4 (JetPack 6.2.1).
+#   - non-Tegra (qemuarm64, raspberrypi*): pin neither.
+# NOTE: on scarthgap/wrynose the SoC family alone distinguishes the BSP; the
+# JP6-vs-JP7-on-Orin ambiguity (both tegra234) is resolved by the
+# WENDYOS_LAYER_TREE == 'blacksail' branch above.
+require ${@'' if d.getVar('WENDYOS_LAYER_TREE') == 'blacksail' else ('conf/distro/include/l4t-r38-4-0.conf' if 'tegra264' in d.getVar('MACHINEOVERRIDES').split(':') else ('conf/distro/include/l4t-r36-4-4.conf' if 'tegra' in d.getVar('MACHINEOVERRIDES').split(':') else ''))}
 
 # Network management with NetworkManager
 DISTRO_FEATURES:append = " networkmanager"

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -83,7 +83,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.15.5"
+DISTRO_VERSION = "0.16.0"
 # DISTRO_CODENAME is inherited from poky.conf (require'd above), which
 # sets it to the active oe-core series ("scarthgap", "wrynose", ...).
 # Don't override here or it gets stuck on a stale value across series.

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -18,7 +18,7 @@ BBFILE_PRIORITY_wendyos = "50"
 # missing the c710879b4c kernel-initramfs cycle fix that wrynose has — no
 # board pins it now. Drop it from the compat set if/when re-added, also
 # add it to meta-tegra-extensions/conf/layer.conf.
-LAYERSERIES_COMPAT_wendyos = "scarthgap wrynose"
+LAYERSERIES_COMPAT_wendyos = "scarthgap wrynose blacksail"
 LAYERVERSION_wendyos = "1"
 
 # Dependencies on other layers (at minimum you depend on 'core')

--- a/conf/machine/jetson-agx-orin-devkit-emmc-wendyos.conf
+++ b/conf/machine/jetson-agx-orin-devkit-emmc-wendyos.conf
@@ -87,8 +87,21 @@ PARTITION_LAYOUT_TEMPLATE_DEFAULT = "flash_t234_qspi_sdmmc.xml"
 # usage with an eMMC-targeted image.
 PARTITION_LAYOUT_EXTERNAL_DEFAULT = ""
 
-# Jetson image formats that are machine/BSP oriented:
-IMAGE_FSTYPES:tegra = "tegraflash mender dataimg"
+# Jetson image format is OTA-stack dependent (we maintain both Mender and
+# wendyos-update as a switchable capability via WENDYOS_OTA):
+#   wendy (JP7.2/blacksail): a single flashable tegraflash-tar (the r38+
+#     IMAGE_TYPE rename, as on Thor) — mender-full is not inherited, so its
+#     "mender"/"dataimg" types have no IMAGE_CMD and MUST be dropped.
+#   mender (JP6/scarthgap): the original tegraflash + mender + dataimg.
+# Lazy ${@} reads the FINAL WENDYOS_OTA (machine conf parses after local.conf).
+# The MENDER_* vars above are inert when mender-full isn't inherited.
+IMAGE_FSTYPES:tegra = "${@'tegraflash-tar' if (d.getVar('WENDYOS_OTA') or '') == 'wendy' else 'tegraflash mender dataimg'}"
+
+# blacksail oe-core defaults IMAGE_NAME_SUFFIX to ".rootfs", which would push
+# ".rootfs" into deployed artifact/symlink names; the publisher + CI expect
+# none (matching scarthgap). Drop it on the wendy path; keep the default
+# otherwise.
+IMAGE_NAME_SUFFIX = "${@'' if (d.getVar('WENDYOS_OTA') or '') == 'wendy' else '.rootfs'}"
 IMAGE_FSTYPES:pn-tegra-minimal-initramfs:tegra = "${INITRAMFS_FSTYPES}"
 IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INITRAMFS_FSTYPES}"
 

--- a/conf/machine/jetson-agx-orin-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-agx-orin-devkit-nvme-wendyos.conf
@@ -56,8 +56,21 @@ PARTITION_LAYOUT_TEMPLATE_DEFAULT = "flash_t234_qspi.xml"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT = "1"
 PARTITION_LAYOUT_EXTERNAL_DEFAULT = "flash_l4t_t234_nvme.xml"
 
-# Jetson image formats that are machine/BSP oriented:
-IMAGE_FSTYPES:tegra = "tegraflash mender dataimg"
+# Jetson image format is OTA-stack dependent (we maintain both Mender and
+# wendyos-update as a switchable capability via WENDYOS_OTA):
+#   wendy (JP7.2/blacksail): a single flashable tegraflash-tar (the r38+
+#     IMAGE_TYPE rename, as on Thor) — mender-full is not inherited, so its
+#     "mender"/"dataimg" types have no IMAGE_CMD and MUST be dropped.
+#   mender (JP6/scarthgap): the original tegraflash + mender + dataimg.
+# Lazy ${@} reads the FINAL WENDYOS_OTA (machine conf parses after local.conf).
+# The MENDER_* vars above are inert when mender-full isn't inherited.
+IMAGE_FSTYPES:tegra = "${@'tegraflash-tar' if (d.getVar('WENDYOS_OTA') or '') == 'wendy' else 'tegraflash mender dataimg'}"
+
+# blacksail oe-core defaults IMAGE_NAME_SUFFIX to ".rootfs", which would push
+# ".rootfs" into deployed artifact/symlink names; the publisher + CI expect
+# none (matching scarthgap). Drop it on the wendy path; keep the default
+# otherwise.
+IMAGE_NAME_SUFFIX = "${@'' if (d.getVar('WENDYOS_OTA') or '') == 'wendy' else '.rootfs'}"
 IMAGE_FSTYPES:pn-tegra-minimal-initramfs:tegra = "${INITRAMFS_FSTYPES}"
 IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INITRAMFS_FSTYPES}"
 

--- a/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
@@ -46,8 +46,21 @@ PARTITION_LAYOUT_TEMPLATE_DEFAULT = "flash_t234_qspi.xml"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT = "1"
 PARTITION_LAYOUT_EXTERNAL_DEFAULT = "flash_l4t_t234_nvme.xml"
 
-# Jetson image formats that are machine/BSP oriented:
-IMAGE_FSTYPES:tegra = "tegraflash mender dataimg"
+# Jetson image format is OTA-stack dependent (we maintain both Mender and
+# wendyos-update as a switchable capability via WENDYOS_OTA):
+#   wendy (JP7.2/blacksail): a single flashable tegraflash-tar (the r38+
+#     IMAGE_TYPE rename, as on Thor) — mender-full is not inherited, so its
+#     "mender"/"dataimg" types have no IMAGE_CMD and MUST be dropped.
+#   mender (JP6/scarthgap): the original tegraflash + mender + dataimg.
+# Lazy ${@} reads the FINAL WENDYOS_OTA (machine conf parses after local.conf).
+# The MENDER_* vars above are inert when mender-full isn't inherited.
+IMAGE_FSTYPES:tegra = "${@'tegraflash-tar' if (d.getVar('WENDYOS_OTA') or '') == 'wendy' else 'tegraflash mender dataimg'}"
+
+# blacksail oe-core defaults IMAGE_NAME_SUFFIX to ".rootfs", which would push
+# ".rootfs" into deployed artifact/symlink names; the publisher + CI expect
+# none (matching scarthgap). Drop it on the wendy path; keep the default
+# otherwise.
+IMAGE_NAME_SUFFIX = "${@'' if (d.getVar('WENDYOS_OTA') or '') == 'wendy' else '.rootfs'}"
 IMAGE_FSTYPES:pn-tegra-minimal-initramfs:tegra = "${INITRAMFS_FSTYPES}"
 IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INITRAMFS_FSTYPES}"
 

--- a/conf/machine/jetson-orin-nano-devkit-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-wendyos.conf
@@ -47,8 +47,21 @@ MENDER_DATA_PART_SIZE_MB = "400"
 # BUP (Bootloader Update Payload) must not reference data partition images
 TEGRA_BUPGEN_STRIP_IMG_NAMES:append = " config-partition.fat32.img"
 
-# Jetson image formats that are machine/BSP oriented:
-IMAGE_FSTYPES:tegra = "tegraflash mender dataimg"
+# Jetson image format is OTA-stack dependent (we maintain both Mender and
+# wendyos-update as a switchable capability via WENDYOS_OTA):
+#   wendy (JP7.2/blacksail): a single flashable tegraflash-tar (the r38+
+#     IMAGE_TYPE rename, as on Thor) — mender-full is not inherited, so its
+#     "mender"/"dataimg" types have no IMAGE_CMD and MUST be dropped.
+#   mender (JP6/scarthgap): the original tegraflash + mender + dataimg.
+# Lazy ${@} reads the FINAL WENDYOS_OTA (machine conf parses after local.conf).
+# The MENDER_* vars above are inert when mender-full isn't inherited.
+IMAGE_FSTYPES:tegra = "${@'tegraflash-tar' if (d.getVar('WENDYOS_OTA') or '') == 'wendy' else 'tegraflash mender dataimg'}"
+
+# blacksail oe-core defaults IMAGE_NAME_SUFFIX to ".rootfs", which would push
+# ".rootfs" into deployed artifact/symlink names; the publisher + CI expect
+# none (matching scarthgap). Drop it on the wendy path; keep the default
+# otherwise.
+IMAGE_NAME_SUFFIX = "${@'' if (d.getVar('WENDYOS_OTA') or '') == 'wendy' else '.rootfs'}"
 IMAGE_FSTYPES:pn-tegra-minimal-initramfs:tegra = "${INITRAMFS_FSTYPES}"
 IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INITRAMFS_FSTYPES}"
 

--- a/conf/template/boards/jetson-agx-orin-emmc/bblayers.conf
+++ b/conf/template/boards/jetson-agx-orin-emmc/bblayers.conf
@@ -1,4 +1,5 @@
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/core.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/oe-common.inc
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/tegra.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/tegra-base.inc
+BBLAYERS += " ${TOPDIR}/../${WENDYOS_META_REPO}/meta-tegra-extensions-jp7 "
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/wendyos.inc

--- a/conf/template/boards/jetson-agx-orin-emmc/local.conf
+++ b/conf/template/boards/jetson-agx-orin-emmc/local.conf
@@ -2,7 +2,11 @@
 
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra-t234.inc
+
+# blacksail bring-up: bridge meta-oe/meta-virt LAYERSERIES_COMPAT until
+# upstream declares blacksail. Inert on non-blacksail trees.
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/blacksail-compat.inc
 
 MACHINE = "jetson-agx-orin-devkit-emmc-wendyos"
 

--- a/conf/template/boards/jetson-agx-orin-emmc/repos.overrides
+++ b/conf/template/boards/jetson-agx-orin-emmc/repos.overrides
@@ -1,20 +1,47 @@
 # Per-board repo version overrides for jetson-agx-orin-emmc.
 #
-# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set,
-# but before the repos[] array is built. Uncomment a line below to pin
-# this board to a different commit of an upstream layer.
+# === BLACKSAIL / JetPack 7.2 / L4T R39.2.0 EXPERIMENT (feature/jp7.2-support) ===
+# This board joins the JP7.2 fleet-unification experiment alongside Thor.
+# r39.2.0 is the first JP7 line to support the Orin family AND Thor, so all
+# three Jetson boards share one Yocto series (blacksail) under
+# repos/blacksail/. The JP6/Mender Orin fallback lives on `main` (default
+# scarthgap pins); revert = git checkout main + re-bootstrap a clean build dir.
 #
-# Also available (see bootstrap.sh):
-#   URL_<name>           override a source URL (e.g. to use a fork)
-#   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
-#                        each entry "enabled|url|folder|commit"
+# The pins below are the SHARED blacksail tree set — IDENTICAL across Thor and
+# every Orin board. Keep them in sync with
+# conf/template/boards/jetson-agx-thor/repos.overrides. Resolved from upstream
+# HEADs on 2026-06-15 (git ls-remote).
+#
+# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set, but
+# before the repos[] array is built.
 
-#SRCREV_BITBAKE="<commit-hash>"
-#SRCREV_OECORE="<commit-hash>"
-#SRCREV_METAYOCTO="<commit-hash>"
-#SRCREV_OE="<commit-hash>"
-#SRCREV_VIRT="<commit-hash>"
-#SRCREV_TEGRA="<commit-hash>"
-#SRCREV_TEGRA_COMM="<commit-hash>"
-#SRCREV_MENDER="<commit-hash>"
-#SRCREV_MENDER_COMM="<commit-hash>"
+WENDYOS_LAYER_TREE="blacksail"
+
+# Split-poky composition on blacksail. oe-core master declares
+# LAYERSERIES_CORENAMES = "wrynose blacksail" + LAYERSERIES_COMPAT_core =
+# "blacksail"; meta-yocto master + bitbake master (2.19.0 >= BB_MIN 2.18.0) match.
+SRCREV_BITBAKE="30ccfbb849ec80cddb4383d198a1441af0ea760a"
+SRCREV_OECORE="294409c4bfe392471509d4cb6c1e6fb1063d2b3b"
+SRCREV_METAYOCTO="f49de2f33e37ca971d64215cc1a3669312e1e7c3"
+
+# meta-openembedded master HEAD. NOTE: master still declares
+# LAYERSERIES_COMPAT = "whinlatter wrynose" (NOT blacksail) — bridged via
+# conf/template/include/local/blacksail-compat.inc. Re-pin + drop the bridge
+# once meta-oe bumps.
+SRCREV_OE="5d90e6543de4d1c39424956c67ff1925a39bf3c8"
+
+# meta-virtualization master HEAD. Same situation: declares
+# LAYERSERIES_COMPAT = "wrynose" only — bridged via blacksail-compat.inc.
+SRCREV_VIRT="022f4356d4a9b389f51472d40a9330aa59f6bb9a"
+
+# meta-tegra wip-l4t-r39.2.0 (JetPack 7.2 / L4T R39.2.0, Thor + Orin family).
+# conf/layer.conf declares LAYERSERIES_COMPAT_tegra = "blacksail".
+SRCREV_TEGRA="d0b2f4d81dc3cd286a6cfd244044a20cc61ebfe5"
+
+# meta-tegra-community wip-l4t-r39.2.0; conf/layer.conf declares
+# LAYERSERIES_COMPAT_tegra-community = "blacksail". LAYERDEPENDS pulls in
+# openembedded-layer + meta-python (hence the compat bridge).
+SRCREV_TEGRA_COMM="931db8c0f56eefbfb028d340ade0953b91006d54"
+
+# Mender SRCREVs intentionally NOT overridden — JetPack 7 has no Mender
+# support; these boards use the wendyos-update OTA stack (WENDYOS_OTA = "wendy").

--- a/conf/template/boards/jetson-agx-orin/bblayers.conf
+++ b/conf/template/boards/jetson-agx-orin/bblayers.conf
@@ -1,4 +1,5 @@
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/core.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/oe-common.inc
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/tegra.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/tegra-base.inc
+BBLAYERS += " ${TOPDIR}/../${WENDYOS_META_REPO}/meta-tegra-extensions-jp7 "
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/wendyos.inc

--- a/conf/template/boards/jetson-agx-orin/local.conf
+++ b/conf/template/boards/jetson-agx-orin/local.conf
@@ -2,7 +2,11 @@
 
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra-t234.inc
+
+# blacksail bring-up: bridge meta-oe/meta-virt LAYERSERIES_COMPAT until
+# upstream declares blacksail. Inert on non-blacksail trees.
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/blacksail-compat.inc
 
 DEVICE  = "jetson-agx-orin"
 STORAGE = "nvme"

--- a/conf/template/boards/jetson-agx-orin/repos.overrides
+++ b/conf/template/boards/jetson-agx-orin/repos.overrides
@@ -1,20 +1,47 @@
 # Per-board repo version overrides for jetson-agx-orin.
 #
-# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set,
-# but before the repos[] array is built. Uncomment a line below to pin
-# this board to a different commit of an upstream layer.
+# === BLACKSAIL / JetPack 7.2 / L4T R39.2.0 EXPERIMENT (feature/jp7.2-support) ===
+# This board joins the JP7.2 fleet-unification experiment alongside Thor.
+# r39.2.0 is the first JP7 line to support the Orin family AND Thor, so all
+# three Jetson boards share one Yocto series (blacksail) under
+# repos/blacksail/. The JP6/Mender Orin fallback lives on `main` (default
+# scarthgap pins); revert = git checkout main + re-bootstrap a clean build dir.
 #
-# Also available (see bootstrap.sh):
-#   URL_<name>           override a source URL (e.g. to use a fork)
-#   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
-#                        each entry "enabled|url|folder|commit"
+# The pins below are the SHARED blacksail tree set — IDENTICAL across Thor and
+# every Orin board. Keep them in sync with
+# conf/template/boards/jetson-agx-thor/repos.overrides. Resolved from upstream
+# HEADs on 2026-06-15 (git ls-remote).
+#
+# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set, but
+# before the repos[] array is built.
 
-#SRCREV_BITBAKE="<commit-hash>"
-#SRCREV_OECORE="<commit-hash>"
-#SRCREV_METAYOCTO="<commit-hash>"
-#SRCREV_OE="<commit-hash>"
-#SRCREV_VIRT="<commit-hash>"
-#SRCREV_TEGRA="<commit-hash>"
-#SRCREV_TEGRA_COMM="<commit-hash>"
-#SRCREV_MENDER="<commit-hash>"
-#SRCREV_MENDER_COMM="<commit-hash>"
+WENDYOS_LAYER_TREE="blacksail"
+
+# Split-poky composition on blacksail. oe-core master declares
+# LAYERSERIES_CORENAMES = "wrynose blacksail" + LAYERSERIES_COMPAT_core =
+# "blacksail"; meta-yocto master + bitbake master (2.19.0 >= BB_MIN 2.18.0) match.
+SRCREV_BITBAKE="30ccfbb849ec80cddb4383d198a1441af0ea760a"
+SRCREV_OECORE="294409c4bfe392471509d4cb6c1e6fb1063d2b3b"
+SRCREV_METAYOCTO="f49de2f33e37ca971d64215cc1a3669312e1e7c3"
+
+# meta-openembedded master HEAD. NOTE: master still declares
+# LAYERSERIES_COMPAT = "whinlatter wrynose" (NOT blacksail) — bridged via
+# conf/template/include/local/blacksail-compat.inc. Re-pin + drop the bridge
+# once meta-oe bumps.
+SRCREV_OE="5d90e6543de4d1c39424956c67ff1925a39bf3c8"
+
+# meta-virtualization master HEAD. Same situation: declares
+# LAYERSERIES_COMPAT = "wrynose" only — bridged via blacksail-compat.inc.
+SRCREV_VIRT="022f4356d4a9b389f51472d40a9330aa59f6bb9a"
+
+# meta-tegra wip-l4t-r39.2.0 (JetPack 7.2 / L4T R39.2.0, Thor + Orin family).
+# conf/layer.conf declares LAYERSERIES_COMPAT_tegra = "blacksail".
+SRCREV_TEGRA="d0b2f4d81dc3cd286a6cfd244044a20cc61ebfe5"
+
+# meta-tegra-community wip-l4t-r39.2.0; conf/layer.conf declares
+# LAYERSERIES_COMPAT_tegra-community = "blacksail". LAYERDEPENDS pulls in
+# openembedded-layer + meta-python (hence the compat bridge).
+SRCREV_TEGRA_COMM="931db8c0f56eefbfb028d340ade0953b91006d54"
+
+# Mender SRCREVs intentionally NOT overridden — JetPack 7 has no Mender
+# support; these boards use the wendyos-update OTA stack (WENDYOS_OTA = "wendy").

--- a/conf/template/boards/jetson-agx-thor/local.conf
+++ b/conf/template/boards/jetson-agx-thor/local.conf
@@ -1,9 +1,16 @@
 # jetson-agx-thor: NVIDIA Jetson AGX Thor Developer Kit (NVMe).
-# split-poky composition on wrynose, no Mender / no OTA (Phase 1).
+# split-poky composition on blacksail (JetPack 7.2 / L4T R39.2.0 experiment;
+# was wrynose/JP7.1 on main). wendyos-update OTA, no Mender. See
+# repos.overrides for the blacksail pin rationale.
 
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra-t264.inc
+
+# blacksail bring-up: bridge meta-oe/meta-virt LAYERSERIES_COMPAT until
+# upstream declares blacksail. Inert on non-blacksail trees. Remove once
+# upstream catches up (see the include header).
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/blacksail-compat.inc
 
 DEVICE  = "jetson-agx-thor"
 STORAGE = "nvme"

--- a/conf/template/boards/jetson-agx-thor/repos.overrides
+++ b/conf/template/boards/jetson-agx-thor/repos.overrides
@@ -3,42 +3,56 @@
 # Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set
 # (from scripts/upstream-repos.env), but before the repos[] array is built.
 #
-# Thor pins to the wrynose Yocto series — meta-tegra has no Thor support
-# on scarthgap or earlier, and oe-core whinlatter is missing
-# c710879b4c ("kernel.bbclass: remove dependency on initramfs when not
-# bundled"), which we need so the kernel <-> initramfs cycle resolves
-# cleanly without a workaround. wrynose oe-core has that fix.
+# === BLACKSAIL / JetPack 7.2 / L4T R39.2.0 EXPERIMENT (feature/jp7.2-support) ===
+# Thor is the canary for unifying all three Jetson boards onto JetPack 7.2.
+# meta-tegra's wip-l4t-r39.2.0 branch is the first JP7 line to support both
+# the Orin family AND Thor simultaneously (per its
+# docs/release-notes/JetPack-7.2-L4T-R39.2.0-Notes.md), and it declares
+# LAYERSERIES_COMPAT = "blacksail" — the in-development Yocto series after
+# wrynose (6.0). So the whole stack moves to blacksail-era pins.
 #
-# Setting WENDYOS_LAYER_TREE here causes bootstrap.sh to clone all upstream
-# repos under repos/wrynose/ (parallel to repos/scarthgap/ used by Orin/
-# RPi/QEMU boards), and the Makefile sources oe-init-build-env from inside
-# that tree.
-WENDYOS_LAYER_TREE="wrynose"
+# This is an EXPERIMENT to find what breaks: blacksail is a moving dev target
+# and several layers (meta-openembedded, meta-virtualization) have NOT yet
+# declared blacksail compatibility upstream. We bridge that with gated
+# LAYERSERIES_COMPAT:append overrides in
+# conf/template/include/local/blacksail-compat.inc (required from local.conf).
+#
+# Isolation: WENDYOS_LAYER_TREE="blacksail" makes bootstrap.sh clone every
+# upstream repo under repos/blacksail/ — parallel to repos/wrynose/ (the
+# validated r38.4/JP7.1 Thor fallback on main) and repos/scarthgap/ (Orin/
+# RPi/QEMU). The validated trees are never touched; revert = git checkout main.
+#
+# All SRCREVs below were resolved from upstream HEADs on 2026-06-15
+# (git ls-remote). Pinned for reproducibility since blacksail/master move.
+WENDYOS_LAYER_TREE="blacksail"
 
-# bitbake follows version-numbered tags/branches (2.x); wrynose oe-core
-# requires BB_MIN_VERSION 2.18.0, so we pin to a 2.19.0 master commit.
-SRCREV_BITBAKE="df3295f016a74a1414b8af5adb9f2a3967c365b6"
-SRCREV_OECORE="42fa856a00ac16b2a7a83d7ecfa60a5be192b16c"
-SRCREV_METAYOCTO="904846ae078ee20de073040ebb77c86e19250f56"
-SRCREV_OE="420222862f5a6d95023b8f5f3b7e1808b2264ef9"
+# Split-poky composition on blacksail. oe-core master declares
+# LAYERSERIES_CORENAMES = "wrynose blacksail" and LAYERSERIES_COMPAT_core =
+# "blacksail"; meta-yocto master + bitbake master (2.19.0, >= oe-core's
+# BB_MIN_VERSION 2.18.0) match it.
+SRCREV_BITBAKE="30ccfbb849ec80cddb4383d198a1441af0ea760a"
+SRCREV_OECORE="294409c4bfe392471509d4cb6c1e6fb1063d2b3b"
+SRCREV_METAYOCTO="f49de2f33e37ca971d64215cc1a3669312e1e7c3"
 
-# meta-virtualization has no wrynose branch upstream as of 2026-05-08
-# (the remote ships scarthgap, styhead, walnascar, whinlatter, master only).
-# Master is healthy so we pin master HEAD here while waiting for an official
-# wrynose branch. Re-pin to origin/wrynose once upstream ships one.
-SRCREV_VIRT="4ba5825ee16fcded87f4d555b4ed7a7615dc67ac"
+# meta-openembedded master HEAD. NOTE: master still declares
+# LAYERSERIES_COMPAT = "whinlatter wrynose" (NOT blacksail) as of 2026-06-15
+# — bridged via blacksail-compat.inc. Re-pin to an upstream commit that
+# declares blacksail once meta-oe bumps, then drop the override.
+SRCREV_OE="5d90e6543de4d1c39424956c67ff1925a39bf3c8"
 
-# meta-tegra master-l4t-r38.4.x (Thor / L4T 38.4.0 / JetPack 7.1).
-# Branch declares LAYERSERIES_COMPAT = "whinlatter wrynose", so the same
-# commit works for both.
-SRCREV_TEGRA="1f28e68deca6773059da8635f0353aff23340790"
+# meta-virtualization master HEAD. Same situation: master declares
+# LAYERSERIES_COMPAT = "wrynose" only — bridged via blacksail-compat.inc.
+SRCREV_VIRT="022f4356d4a9b389f51472d40a9330aa59f6bb9a"
 
-# meta-tegra-community must follow the wrynose / Thor branch — its
-# scarthgap branch declares LAYERSERIES_COMPAT_tegra-community = "scarthgap"
-# only and would refuse to load in a wrynose build. The
-# master-l4t-r38.4.x branch declares "whinlatter wrynose".
-SRCREV_TEGRA_COMM="f8df91a000aa74f50a78b0fe4b60a65c90fd9ca7"
+# meta-tegra wip-l4t-r39.2.0 (JetPack 7.2 / L4T R39.2.0, Thor + Orin family).
+# conf/layer.conf declares LAYERSERIES_COMPAT_tegra = "blacksail".
+SRCREV_TEGRA="d0b2f4d81dc3cd286a6cfd244044a20cc61ebfe5"
 
-# Mender SRCREVs are intentionally NOT overridden as there is no wrynose
-# support yet.
-# To reconsider once upstream ships the expected branch.
+# meta-tegra-community wip-l4t-r39.2.0; conf/layer.conf declares
+# LAYERSERIES_COMPAT_tegra-community = "blacksail". LAYERDEPENDS pulls in
+# openembedded-layer + meta-python, which is why those must be made
+# blacksail-compatible (see blacksail-compat.inc).
+SRCREV_TEGRA_COMM="931db8c0f56eefbfb028d340ade0953b91006d54"
+
+# Mender SRCREVs are intentionally NOT overridden — JetPack 7 has no Mender
+# support; Thor uses the wendyos-update OTA stack (WENDYOS_OTA = "wendy").

--- a/conf/template/boards/jetson-orin-nano-nvme/bblayers.conf
+++ b/conf/template/boards/jetson-orin-nano-nvme/bblayers.conf
@@ -1,4 +1,5 @@
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/core.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/oe-common.inc
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/tegra.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/tegra-base.inc
+BBLAYERS += " ${TOPDIR}/../${WENDYOS_META_REPO}/meta-tegra-extensions-jp7 "
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/wendyos.inc

--- a/conf/template/boards/jetson-orin-nano-nvme/local.conf
+++ b/conf/template/boards/jetson-orin-nano-nvme/local.conf
@@ -2,7 +2,11 @@
 
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra-t234.inc
+
+# blacksail bring-up: bridge meta-oe/meta-virt LAYERSERIES_COMPAT until
+# upstream declares blacksail. Inert on non-blacksail trees.
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/blacksail-compat.inc
 
 DEVICE  = "jetson-orin-nano"
 STORAGE = "nvme"

--- a/conf/template/boards/jetson-orin-nano-nvme/repos.overrides
+++ b/conf/template/boards/jetson-orin-nano-nvme/repos.overrides
@@ -1,20 +1,47 @@
 # Per-board repo version overrides for jetson-orin-nano-nvme.
 #
-# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set,
-# but before the repos[] array is built. Uncomment a line below to pin
-# this board to a different commit of an upstream layer.
+# === BLACKSAIL / JetPack 7.2 / L4T R39.2.0 EXPERIMENT (feature/jp7.2-support) ===
+# This board joins the JP7.2 fleet-unification experiment alongside Thor.
+# r39.2.0 is the first JP7 line to support the Orin family AND Thor, so all
+# three Jetson boards share one Yocto series (blacksail) under
+# repos/blacksail/. The JP6/Mender Orin fallback lives on `main` (default
+# scarthgap pins); revert = git checkout main + re-bootstrap a clean build dir.
 #
-# Also available (see bootstrap.sh):
-#   URL_<name>           override a source URL (e.g. to use a fork)
-#   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
-#                        each entry "enabled|url|folder|commit"
+# The pins below are the SHARED blacksail tree set — IDENTICAL across Thor and
+# every Orin board. Keep them in sync with
+# conf/template/boards/jetson-agx-thor/repos.overrides. Resolved from upstream
+# HEADs on 2026-06-15 (git ls-remote).
+#
+# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set, but
+# before the repos[] array is built.
 
-#SRCREV_BITBAKE="<commit-hash>"
-#SRCREV_OECORE="<commit-hash>"
-#SRCREV_METAYOCTO="<commit-hash>"
-#SRCREV_OE="<commit-hash>"
-#SRCREV_VIRT="<commit-hash>"
-#SRCREV_TEGRA="<commit-hash>"
-#SRCREV_TEGRA_COMM="<commit-hash>"
-#SRCREV_MENDER="<commit-hash>"
-#SRCREV_MENDER_COMM="<commit-hash>"
+WENDYOS_LAYER_TREE="blacksail"
+
+# Split-poky composition on blacksail. oe-core master declares
+# LAYERSERIES_CORENAMES = "wrynose blacksail" + LAYERSERIES_COMPAT_core =
+# "blacksail"; meta-yocto master + bitbake master (2.19.0 >= BB_MIN 2.18.0) match.
+SRCREV_BITBAKE="30ccfbb849ec80cddb4383d198a1441af0ea760a"
+SRCREV_OECORE="294409c4bfe392471509d4cb6c1e6fb1063d2b3b"
+SRCREV_METAYOCTO="f49de2f33e37ca971d64215cc1a3669312e1e7c3"
+
+# meta-openembedded master HEAD. NOTE: master still declares
+# LAYERSERIES_COMPAT = "whinlatter wrynose" (NOT blacksail) — bridged via
+# conf/template/include/local/blacksail-compat.inc. Re-pin + drop the bridge
+# once meta-oe bumps.
+SRCREV_OE="5d90e6543de4d1c39424956c67ff1925a39bf3c8"
+
+# meta-virtualization master HEAD. Same situation: declares
+# LAYERSERIES_COMPAT = "wrynose" only — bridged via blacksail-compat.inc.
+SRCREV_VIRT="022f4356d4a9b389f51472d40a9330aa59f6bb9a"
+
+# meta-tegra wip-l4t-r39.2.0 (JetPack 7.2 / L4T R39.2.0, Thor + Orin family).
+# conf/layer.conf declares LAYERSERIES_COMPAT_tegra = "blacksail".
+SRCREV_TEGRA="d0b2f4d81dc3cd286a6cfd244044a20cc61ebfe5"
+
+# meta-tegra-community wip-l4t-r39.2.0; conf/layer.conf declares
+# LAYERSERIES_COMPAT_tegra-community = "blacksail". LAYERDEPENDS pulls in
+# openembedded-layer + meta-python (hence the compat bridge).
+SRCREV_TEGRA_COMM="931db8c0f56eefbfb028d340ade0953b91006d54"
+
+# Mender SRCREVs intentionally NOT overridden — JetPack 7 has no Mender
+# support; these boards use the wendyos-update OTA stack (WENDYOS_OTA = "wendy").

--- a/conf/template/boards/jetson-orin-nano-sd/bblayers.conf
+++ b/conf/template/boards/jetson-orin-nano-sd/bblayers.conf
@@ -1,4 +1,5 @@
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/core.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/oe-common.inc
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/tegra.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/tegra-base.inc
+BBLAYERS += " ${TOPDIR}/../${WENDYOS_META_REPO}/meta-tegra-extensions-jp7 "
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/wendyos.inc

--- a/conf/template/boards/jetson-orin-nano-sd/local.conf
+++ b/conf/template/boards/jetson-orin-nano-sd/local.conf
@@ -2,7 +2,11 @@
 
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/usb-gadget.inc
-require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra-t234.inc
+
+# blacksail bring-up: bridge meta-oe/meta-virt LAYERSERIES_COMPAT until
+# upstream declares blacksail. Inert on non-blacksail trees.
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/blacksail-compat.inc
 
 DEVICE  = "jetson-orin-nano"
 STORAGE = "sd"

--- a/conf/template/boards/jetson-orin-nano-sd/repos.overrides
+++ b/conf/template/boards/jetson-orin-nano-sd/repos.overrides
@@ -1,20 +1,47 @@
 # Per-board repo version overrides for jetson-orin-nano-sd.
 #
-# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set,
-# but before the repos[] array is built. Uncomment a line below to pin
-# this board to a different commit of an upstream layer.
+# === BLACKSAIL / JetPack 7.2 / L4T R39.2.0 EXPERIMENT (feature/jp7.2-support) ===
+# This board joins the JP7.2 fleet-unification experiment alongside Thor.
+# r39.2.0 is the first JP7 line to support the Orin family AND Thor, so all
+# three Jetson boards share one Yocto series (blacksail) under
+# repos/blacksail/. The JP6/Mender Orin fallback lives on `main` (default
+# scarthgap pins); revert = git checkout main + re-bootstrap a clean build dir.
 #
-# Also available (see bootstrap.sh):
-#   URL_<name>           override a source URL (e.g. to use a fork)
-#   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
-#                        each entry "enabled|url|folder|commit"
+# The pins below are the SHARED blacksail tree set — IDENTICAL across Thor and
+# every Orin board. Keep them in sync with
+# conf/template/boards/jetson-agx-thor/repos.overrides. Resolved from upstream
+# HEADs on 2026-06-15 (git ls-remote).
+#
+# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set, but
+# before the repos[] array is built.
 
-#SRCREV_BITBAKE="<commit-hash>"
-#SRCREV_OECORE="<commit-hash>"
-#SRCREV_METAYOCTO="<commit-hash>"
-#SRCREV_OE="<commit-hash>"
-#SRCREV_VIRT="<commit-hash>"
-#SRCREV_TEGRA="<commit-hash>"
-#SRCREV_TEGRA_COMM="<commit-hash>"
-#SRCREV_MENDER="<commit-hash>"
-#SRCREV_MENDER_COMM="<commit-hash>"
+WENDYOS_LAYER_TREE="blacksail"
+
+# Split-poky composition on blacksail. oe-core master declares
+# LAYERSERIES_CORENAMES = "wrynose blacksail" + LAYERSERIES_COMPAT_core =
+# "blacksail"; meta-yocto master + bitbake master (2.19.0 >= BB_MIN 2.18.0) match.
+SRCREV_BITBAKE="30ccfbb849ec80cddb4383d198a1441af0ea760a"
+SRCREV_OECORE="294409c4bfe392471509d4cb6c1e6fb1063d2b3b"
+SRCREV_METAYOCTO="f49de2f33e37ca971d64215cc1a3669312e1e7c3"
+
+# meta-openembedded master HEAD. NOTE: master still declares
+# LAYERSERIES_COMPAT = "whinlatter wrynose" (NOT blacksail) — bridged via
+# conf/template/include/local/blacksail-compat.inc. Re-pin + drop the bridge
+# once meta-oe bumps.
+SRCREV_OE="5d90e6543de4d1c39424956c67ff1925a39bf3c8"
+
+# meta-virtualization master HEAD. Same situation: declares
+# LAYERSERIES_COMPAT = "wrynose" only — bridged via blacksail-compat.inc.
+SRCREV_VIRT="022f4356d4a9b389f51472d40a9330aa59f6bb9a"
+
+# meta-tegra wip-l4t-r39.2.0 (JetPack 7.2 / L4T R39.2.0, Thor + Orin family).
+# conf/layer.conf declares LAYERSERIES_COMPAT_tegra = "blacksail".
+SRCREV_TEGRA="d0b2f4d81dc3cd286a6cfd244044a20cc61ebfe5"
+
+# meta-tegra-community wip-l4t-r39.2.0; conf/layer.conf declares
+# LAYERSERIES_COMPAT_tegra-community = "blacksail". LAYERDEPENDS pulls in
+# openembedded-layer + meta-python (hence the compat bridge).
+SRCREV_TEGRA_COMM="931db8c0f56eefbfb028d340ade0953b91006d54"
+
+# Mender SRCREVs intentionally NOT overridden — JetPack 7 has no Mender
+# support; these boards use the wendyos-update OTA stack (WENDYOS_OTA = "wendy").

--- a/conf/template/include/local/blacksail-compat.inc
+++ b/conf/template/include/local/blacksail-compat.inc
@@ -1,0 +1,38 @@
+# blacksail bring-up compatibility bridge (JetPack 7.2 / L4T R39.2.0 experiment).
+#
+# As of 2026-06-15 the core stack (oe-core, meta-yocto, meta-tegra
+# wip-l4t-r39.2.0, meta-tegra-community wip-l4t-r39.2.0) all declare
+# LAYERSERIES_COMPAT = "blacksail", but meta-openembedded and
+# meta-virtualization master have NOT yet bumped past wrynose:
+#
+#   meta-oe        openembedded-layer  -> "whinlatter wrynose"
+#   meta-python    meta-python         -> "whinlatter wrynose"
+#   meta-networking networking-layer   -> (tracks the same)
+#   meta-filesystems filesystems-layer -> (tracks the same)
+#   meta-multimedia multimedia-layer   -> (tracks the same)
+#   meta-virt      virtualization-layer-> "wrynose"
+#
+# meta-tegra-community LAYERDEPENDS requires openembedded-layer + meta-python,
+# so without this bridge bitbake's sanity check aborts the parse with
+# "Layer X is not compatible with the core layer which only supports these
+# series: blacksail".
+#
+# These appends assert "trust me, this layer parses on blacksail" — the
+# standard escape hatch for bleeding-edge bring-up. They are GATED on
+# WENDYOS_LAYER_TREE == "blacksail" so they are completely inert on the
+# validated wrynose/scarthgap trees (and on main). The real fix is upstream
+# bumping these layers' LAYERSERIES_COMPAT; when that lands, re-pin the
+# SRCREVs in repos.overrides and delete this file + its require line.
+#
+# NOTE: this only silences the version *gate*. Any genuine API breakage
+# blacksail introduced in oe-core that these layers rely on will still fail
+# at parse/build time — which is exactly the "what breaks" signal we want.
+
+_BLACKSAIL_COMPAT = "${@' blacksail' if d.getVar('WENDYOS_LAYER_TREE') == 'blacksail' else ''}"
+
+LAYERSERIES_COMPAT_openembedded-layer:append = "${_BLACKSAIL_COMPAT}"
+LAYERSERIES_COMPAT_meta-python:append = "${_BLACKSAIL_COMPAT}"
+LAYERSERIES_COMPAT_networking-layer:append = "${_BLACKSAIL_COMPAT}"
+LAYERSERIES_COMPAT_filesystems-layer:append = "${_BLACKSAIL_COMPAT}"
+LAYERSERIES_COMPAT_multimedia-layer:append = "${_BLACKSAIL_COMPAT}"
+LAYERSERIES_COMPAT_virtualization-layer:append = "${_BLACKSAIL_COMPAT}"

--- a/conf/template/include/local/common.inc
+++ b/conf/template/include/local/common.inc
@@ -22,6 +22,25 @@ BB_DISKMON_DIRS ??= "\
     HALT,${SSTATE_DIR},100M,1K \
     HALT,/tmp,10M,1K"
 
+# Memory pressure management. The CI builders are c8id.8xlarge (32 vCPU /
+# 64 GiB = only 2 GiB/core), and BitBake otherwise defaults BB_NUMBER_THREADS
+# and PARALLEL_MAKE to nproc (32). The heavy native C++ compiles — notably
+# llvm-native and grpc-native — spawn ~32 cc1plus processes that each peak
+# well above 2 GiB, so on a cold sstate cache the kernel OOM-killer takes out
+# the compiler ("g++: fatal error: Killed signal terminated program cc1plus")
+# or starves the bitbake cooker ("No reply from server in 30s"). This only
+# bit us once the blacksail series bumped to llvm 22.1.7 / grpc 1.80.0 with no
+# cache to fall back on.
+#
+# BB_PRESSURE_MAX_MEMORY throttles scheduling of new tasks via the kernel's
+# memory PSI (/proc/pressure/memory) so cross-recipe parallelism backs off
+# under pressure, and the per-recipe PARALLEL_MAKE caps bound peak RSS within
+# the two worst offenders. Both are cheap insurance — they only slow the
+# first cold build of these natives; everything else stays cache-served.
+BB_PRESSURE_MAX_MEMORY ?= "15000"
+PARALLEL_MAKE:pn-llvm-native = "-j 16"
+PARALLEL_MAKE:pn-grpc-native = "-j 16"
+
 PACKAGECONFIG:append:pn-qemu-system-native = " sdl"
 CONF_VERSION = "2"
 

--- a/conf/template/include/local/tegra-t234.inc
+++ b/conf/template/include/local/tegra-t234.inc
@@ -29,11 +29,10 @@ WENDYOS_UPDATE_BOOTLOADER = "0"
 #   "1" - DEBUG (verbose boot/capsule debug output)
 WENDYOS_EFI_DEBUG = "0"
 
-# DeepStream OFF for the initial blacksail bring-up — answer the existential
-# question first (does t234 / r39.2 build + boot the wendy stack, and does it
-# get the A/B redundant flash layout?), exactly like the Thor canary. The
-# DeepStream 8.0 integration (blacksail meta-tegra-community ships
-# deepstream-8.0; tegra-image.inc currently hardcodes deepstream-7.1 and the
-# jp6 7.1 bbappend would need a jp7 8.0 equivalent) is a follow-up once
-# base-green.
-WENDYOS_DEEPSTREAM = "0"
+# DeepStream 8.0 (JetPack 7.2 / CUDA 13) — ENABLED. tegra-image.inc resolves
+# WENDYOS_DEEPSTREAM=1 to the deepstream-8.0 package on blacksail, provided by
+# our vendored recipe in meta-tegra-extensions-jp7 (DS8 is not yet on the
+# meta-tegra-community wip-l4t-r39.2.0 branch — see scripts/check-jp7.2-upstream.sh
+# for when to drop the vendored recipe). COMPATIBLE_MACHINE=(tegra), so the same
+# recipe serves Orin (t234) and Thor (t264).
+WENDYOS_DEEPSTREAM = "1"

--- a/conf/template/include/local/tegra-t234.inc
+++ b/conf/template/include/local/tegra-t234.inc
@@ -1,0 +1,39 @@
+# Tegra T234 (Orin / Orin Nano): wendyos-update OTA on JetPack 7.2 /
+# L4T R39.2.0 (blacksail). Symmetric with tegra-t264.inc (Thor).
+#
+# This is the JP7.2 fleet-unification path: r39.2.0 is the first JetPack 7
+# line to support the Orin family alongside Thor, so all three Jetson boards
+# can share one Yocto series (blacksail) and one OTA stack (wendyos-update).
+# The JP6 / Mender Orin path still lives on `main` (local/tegra.inc); revert
+# a board to it with `git checkout main` + re-bootstrap.
+
+# wendyos-update OTA, replacing Mender. wendyos.conf defaults tegra234 to
+# "mender"; override here. Pulls in the client + data-setup + the .wendy
+# artifact (conf/distro/include/wendyos-update.inc) and implies the
+# persistent /data partition — allocated empty at flash time and
+# formatted/grown on first boot by wendyos-data-setup. See
+# tegra_partition_config.bbclass.
+WENDYOS_OTA = "wendy"
+
+# Rootfs-only swaps for now (no UEFI capsule bootloader update). The t234
+# capsule path needs its own on-device verification on r39.2 — the ESRT
+# entry0 + fw_class GUID must be confirmed (Thor's GUID 3c834404 is
+# t264-only) — so it's a later phase mirroring Thor's Step B. Keep off.
+WENDYOS_UPDATE_BOOTLOADER = "0"
+
+# Persistent journal logs left at the smart default (tracks WENDYOS_OTA):
+# WENDYOS_OTA="wendy" -> persistent on /data.
+
+# UEFI/EFI debug build mode:
+#   "0" - RELEASE (minimal UART output, production default)
+#   "1" - DEBUG (verbose boot/capsule debug output)
+WENDYOS_EFI_DEBUG = "0"
+
+# DeepStream OFF for the initial blacksail bring-up — answer the existential
+# question first (does t234 / r39.2 build + boot the wendy stack, and does it
+# get the A/B redundant flash layout?), exactly like the Thor canary. The
+# DeepStream 8.0 integration (blacksail meta-tegra-community ships
+# deepstream-8.0; tegra-image.inc currently hardcodes deepstream-7.1 and the
+# jp6 7.1 bbappend would need a jp7 8.0 equivalent) is a follow-up once
+# base-green.
+WENDYOS_DEEPSTREAM = "0"

--- a/conf/template/include/local/tegra-t264.inc
+++ b/conf/template/include/local/tegra-t264.inc
@@ -20,10 +20,11 @@ WENDYOS_OTA = "wendy"
 #   "1" - DEBUG (verbose boot/capsule debug output)
 WENDYOS_EFI_DEBUG = "0"
 
-# DeepStream SDK is unavailable on r38.4.x meta-tegra (no deepstream-7.1
-# recipe in that branch — only on scarthgap). Disable so that the
-# WENDYOS_DEEPSTREAM-driven IMAGE_INSTALL block in tegra-image.inc adds
-# nothing on Thor. The deepstream-7.1_%.bbappend itself is housed in the
-# scarthgap-only meta-tegra-extensions-jp6 sub-layer, which Thor's
-# bblayers.conf does not include — so it doesn't dangle here.
-WENDYOS_DEEPSTREAM = "0"
+# DeepStream 8.0 (JetPack 7.2 / CUDA 13) — ENABLED. tegra-image.inc resolves
+# WENDYOS_DEEPSTREAM=1 to the deepstream-8.0 package on blacksail, provided by
+# our vendored recipe in meta-tegra-extensions-jp7 (DS8 is not yet on the
+# meta-tegra-community wip-l4t-r39.2.0 branch — see scripts/check-jp7.2-upstream.sh
+# for when to drop the vendored recipe). COMPATIBLE_MACHINE=(tegra), so the same
+# recipe serves Thor (t264) and Orin (t234).
+# (Was "0" in the wrynose/r38.4 era when no DeepStream recipe existed for Thor.)
+WENDYOS_DEEPSTREAM = "1"

--- a/meta-tegra-extensions-jp7/conf/layer.conf
+++ b/meta-tegra-extensions-jp7/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "wendyos-tegra-jp7"
 BBFILE_PATTERN_wendyos-tegra-jp7 := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wendyos-tegra-jp7 = "52"
 
-LAYERSERIES_COMPAT_wendyos-tegra-jp7 = "wrynose"
+LAYERSERIES_COMPAT_wendyos-tegra-jp7 = "wrynose blacksail"
 LAYERVERSION_wendyos-tegra-jp7 = "1"
 LAYERDEPENDS_wendyos-tegra-jp7 = "core wendyos wendyos-tegra"
 

--- a/meta-tegra-extensions-jp7/recipes-devtools/deepstream/deepstream-8.0_%.bbappend
+++ b/meta-tegra-extensions-jp7/recipes-devtools/deepstream/deepstream-8.0_%.bbappend
@@ -1,0 +1,34 @@
+# Headless/container deployment fixups for DeepStream 8.0 (blacksail / JP7.2).
+#
+# Kept in a bbappend (NOT the recipe) so they apply by PN regardless of which
+# layer provides the deepstream-8.0 recipe. Today they apply to our interim
+# meta-tegra-extensions-jp7/recipes-devtools/deepstream/deepstream-8.0_*.bb;
+# when meta-tegra-community ships an upstream deepstream-8.0, delete that .bb
+# and these fixups keep applying to the upstream recipe with no other changes.
+#
+# Mirrors meta-tegra-extensions-jp6/recipes-devtools/deepstream/deepstream-7.1_%.bbappend
+# (path -> deepstream-8.0).
+
+# Skip X11 dependency for headless/container use — DeepStream ships some
+# X11-linked binaries we do not need, and the prebuilt libs trip OE's
+# file-rdeps QA.
+INSANE_SKIP:${PN} += "file-rdeps"
+INSANE_SKIP:${PN}-samples += "file-rdeps"
+
+# Prevent automatic dependency detection from adding X11 libs.
+PRIVATE_LIBS:${PN} = "libX11.so.6"
+PRIVATE_LIBS:${PN}-samples = "libX11.so.6"
+
+# Skip FILEDEPS scanning for these packages to avoid RPM dep generation.
+SKIP_FILEDEPS:${PN} = "1"
+SKIP_FILEDEPS:${PN}-samples = "1"
+
+# Fix the missing libcivetweb.so.1 symlink (required by the GStreamer plugins);
+# the deb ships only libcivetweb.so + libcivetweb.so.1.16.0. Path hardcoded so
+# this does not depend on the recipe defining DEEPSTREAM_PATH.
+do_install:append() {
+    if [ -f ${D}/opt/nvidia/deepstream/deepstream-8.0/lib/libcivetweb.so.1.16.0 ]; then
+        cd ${D}/opt/nvidia/deepstream/deepstream-8.0/lib
+        ln -sf libcivetweb.so.1.16.0 libcivetweb.so.1
+    fi
+}

--- a/meta-tegra-extensions-jp7/recipes-devtools/deepstream/deepstream-8.0_8.0.0-1.bb
+++ b/meta-tegra-extensions-jp7/recipes-devtools/deepstream/deepstream-8.0_8.0.0-1.bb
@@ -1,0 +1,241 @@
+# NVIDIA DeepStream SDK 8.0 — VENDORED from OE4T meta-tegra-community
+# (branch master-l4t-r38.4.x, recipes-devtools/deepstream/deepstream-8.0_8.0.0-1.bb).
+#
+# Why vendored: meta-tegra-community ships this recipe on the r38.4 (JP7.1)
+# branches but has NOT yet forward-ported it to wip-l4t-r39.2.0 (the blacksail
+# branch we build from — that branch still only has deepstream-7.1). This is a
+# verbatim copy with the minimal blacksail/r39.2 reconciliations noted below.
+#
+# CUTOVER: when wip-l4t-r39.2.0 gains deepstream-8.0, DELETE this file — the
+# upstream recipe takes over (same PN), and the companion deepstream-8.0_%.bbappend
+# keeps applying our headless/container fixups to it. tegra-image.inc + the
+# container CSVs key on the package name / install path, so no other change.
+#
+# r39.2 RECONCILIATIONS vs the upstream r38.4 source (blacksail meta-oe is
+# NEWER than r38.4's, so several patchelf TARGET sonames differ):
+#   * jsoncpp: upstream hardcodes libjsoncpp.so.26 (jsoncpp 1.9.6); blacksail
+#     has jsoncpp 1.9.7 -> read the target dynamically from staging instead.
+#   * libgpr:  upstream hardcodes libgpr.so.46; blacksail has grpc 1.80.0 ->
+#     read dynamically from staging.
+#   * abseil:  upstream targets libabsl_synchronization.so.2505.0.0; blacksail
+#     abseil-cpp 20260107.1 builds .so.2601.0.0 (confirmed) -> use that.
+#   CUDA fixups (libcublas.so.13 / libcufft.so.12 / libnpp*.so.13) are CUDA-13
+#   and identical on r38.4 and r39.2, so kept verbatim.
+#
+# Headless/container fixups (X11 INSANE_SKIP, PRIVATE_LIBS, SKIP_FILEDEPS,
+# libcivetweb symlink) are NOT here — upstream does not carry them either; they
+# live in the companion deepstream-8.0_%.bbappend so they survive the cutover.
+
+DESCRIPTION = "NVIDIA Deepstream SDK"
+HOMEPAGE = "https://developer.nvidia.com/deepstream-sdk"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = " \
+    file://usr/share/doc/deepstream-8.0/copyright;md5=02bfaa859dba1e59dd1b4348a730ee00 \
+    file://opt/nvidia/deepstream/deepstream-8.0/LICENSE.txt;md5=ecccc0f1b797f19a3e80c11a3204d2b4 \
+    file://opt/nvidia/deepstream/deepstream-8.0/doc/nvidia-tegra/LICENSE.iothub_client;md5=4f8c6347a759d246b5f96281726b8611 \
+    file://opt/nvidia/deepstream/deepstream-8.0/doc/nvidia-tegra/LICENSE.nvds_amqp_protocol_adaptor;md5=8b4b651fa4090272b2e08e208140a658 \
+"
+
+inherit l4t_deb_pkgfeed
+
+SRC_COMMON_DEBS = "${BPN}_${PV}_arm64.deb;subdir=${BPN}"
+SRC_URI[sha256sum] = "1eb5ad4550d43416a561a318f53c5c2a4a166f828b9dcc8e50c321d6e6055c31"
+
+COMPATIBLE_MACHINE = "(tegra)"
+PACKAGE_ARCH = "${TEGRA_PKGARCH}"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[amqp] = ",,rabbitmq-c"
+PACKAGECONFIG[kafka] = ",,librdkafka"
+# NB: requires hiredis 1.0.0+
+PACKAGECONFIG[redis] = ",,hiredis"
+# NB: requires avahi to be built with 'libdns_sd' in PACKAGECONFIG
+#     which is not the default
+PACKAGECONFIG[nmos] = ",,avahi"
+# NB: requires Azure IoT Hub client library Azure IoT SDK
+PACKAGECONFIG[azure] = ",,azure-iot-sdk"
+# NB: need recipes for these dependencies
+PACKAGECONFIG[triton] = ""
+PACKAGECONFIG[rivermax] = ""
+PACKAGECONFIG[realsense] = ""
+
+# yaml-cpp: the DS8 libs link libyaml-cpp.so.0.8, but blacksail meta-oe ships
+# yaml-cpp 0.9 (.so.0.9). meta-tegra-community provides yaml-cpp-080 (0.8.0)
+# for exactly this, so depend on it rather than plain yaml-cpp. (Upstream's
+# r38.4 recipe used plain yaml-cpp because r38.4 meta-oe was still 0.8.)
+# Keep in sync with packagegroup-nvidia-container.bb's DS yaml-cpp choice.
+DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-rtsp-server \
+    tensorrt-core tensorrt-plugins libnvvpi4 libcufft libcublas libnpp json-glib \
+    tegra-libraries-multimedia-ds tegra-libraries-multimedia yaml-cpp-080 \
+    grpc protobuf tegra-libraries-nvdsseimeta libgstnvcustomhelper mosquitto jsoncpp cuda-nvrtc \
+"
+# XXX--- see hack in do_install
+DEPENDS += "patchelf-native"
+# ---XXX
+
+S = "${UNPACKDIR}/${BPN}"
+B = "${WORKDIR}/build"
+
+DEEPSTREAM_BASEDIR = "/opt/nvidia/deepstream"
+DEEPSTREAM_PATH = "${DEEPSTREAM_BASEDIR}/deepstream-8.0"
+SYSROOT_DIRS += "${DEEPSTREAM_PATH}/lib/ ${DEEPSTREAM_PATH}/sources/includes/ ${DEEPSTREAM_PATH}/sources/gst-plugins/"
+
+do_configure() {
+    for feature in azure amqp kafka nmos redis triton rivermax realsense; do
+        if ! echo "${PACKAGECONFIG}" | grep -q "$feature"; then
+            rm -f ${S}${DEEPSTREAM_PATH}/lib/libnvds_${feature}*
+            if [ "$feature" = "azure" ]; then
+                rm -f ${D}${DEEPSTREAM_PATH}/lib/libnvds_azure*
+            fi
+            if [ "$feature" = "nmos" ]; then
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/libnvds_nmos.so*
+                rm -f ${S}${DEEPSTREAM_PATH}/sources/includes/nvdsnmos.h
+                rm -f ${S}${DEEPSTREAM_PATH}/bin/deepstream-nmos-app
+                rm -rf ${S}${DEEPSTREAM_PATH}/sources/apps/sample_apps/deepstream-nmos
+            fi
+            if [ "$feature" = "triton" ]; then
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/gst-plugins/libnvdsgst_inferserver.so
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/libnvds_infer_server.so
+            fi
+            if [ "$feature" = "rivermax" ]; then
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/gst-plugins/libnvdsgst_udp.so
+            fi
+            if [ "$feature" = "realsense" ]; then
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/libnvds_3d_dataloader_realsense.so
+            fi
+        fi
+    done
+    rm -rf ${S}${DEEPSTREAM_PATH}/sources/libs/gstnvcustomhelper
+    rm -f ${S}${DEEPSTREAM_PATH}/sources/includes/gst-nvcustomevent.h
+    rm -f ${S}${DEEPSTREAM_PATH}/lib/libiothub_client.so*
+}
+
+do_install() {
+    install -d ${D}${bindir}/
+    install -m 0755 ${S}${DEEPSTREAM_PATH}/bin/* ${D}${bindir}/
+
+    install -d ${D}${DEEPSTREAM_PATH}/lib/
+    for f in ${S}${DEEPSTREAM_PATH}/lib/*; do
+        [ ! -d "$f" ] || continue
+        install -m 0644 "$f" ${D}${DEEPSTREAM_PATH}/lib/
+    done
+    ln -sf libnvds_msgconv.so.1.0.0 ${D}${DEEPSTREAM_PATH}/lib/libnvds_msgconv.so
+    ln -sf libnvds_msgconv_audio.so.1.0.0 ${D}${DEEPSTREAM_PATH}/lib/libnvds_msgconv_audio.so
+
+    install -d ${D}/${sysconfdir}/ld.so.conf.d/
+    echo "${DEEPSTREAM_PATH}/lib" > ${D}/${sysconfdir}/ld.so.conf.d/deepstream.conf
+    echo "${libdir}/gstreamer-1.0/deepstream" >> ${D}/${sysconfdir}/ld.so.conf.d/deepstream.conf
+
+    install -d ${D}${libdir}/gstreamer-1.0/deepstream
+    install -m 0644 ${S}${DEEPSTREAM_PATH}/lib/gst-plugins/* ${D}${libdir}/gstreamer-1.0/deepstream/
+
+    cp -R --preserve=mode,timestamps ${S}${DEEPSTREAM_PATH}/samples ${D}${DEEPSTREAM_PATH}/
+    cp -R --preserve=mode,timestamps ${S}${DEEPSTREAM_PATH}/sources/ ${D}${DEEPSTREAM_PATH}/
+
+    # XXX---
+    # Some of the libraries carry the wrong SONAME in their DT_NEEDED ELF
+    # header, so rewrite them to prevent broken runtime dependencies. The
+    # grpc/grpc++/protobuf/protobuf-lite targets are read dynamically from
+    # staging (so they track whatever meta-oe ships); jsoncpp and gpr are read
+    # the same way here (blacksail meta-oe is newer than the r38.4 the upstream
+    # recipe hardcoded for); abseil uses the confirmed blacksail soname.
+    grpc_soname=$(${OBJDUMP} -p ${STAGING_LIBDIR}/libgrpc.so | grep SONAME | awk '{print $2}')
+    grpcpp_soname=$(${OBJDUMP} -p ${STAGING_LIBDIR}/libgrpc++.so | grep SONAME | awk '{print $2}')
+    protobuf_soname=$(${OBJDUMP} -p ${STAGING_LIBDIR}/libprotobuf.so | grep SONAME | awk '{print $2}')
+    libprotobuf_lite_soname=$(${OBJDUMP} -p ${STAGING_LIBDIR}/libprotobuf-lite.so | grep SONAME | awk '{print $2}')
+    jsoncpp_soname=$(${OBJDUMP} -p ${STAGING_LIBDIR}/libjsoncpp.so | grep SONAME | awk '{print $2}')
+    gpr_soname=$(${OBJDUMP} -p ${STAGING_LIBDIR}/libgpr.so | grep SONAME | awk '{print $2}')
+    patchelf --replace-needed libcufft.so libcufft.so.12 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nvmultiobjecttracker.so
+    patchelf --replace-needed libcublas.so libcublas.so.13 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nvmultiobjecttracker.so
+    patchelf --replace-needed libcufft.so libcufft.so.12 ${D}${DEEPSTREAM_PATH}/lib/libnvds_audiotransform.so
+    bbnote "Patching libgrpc NEEDED to $grpc_soname"
+    patchelf --replace-needed libgrpc.so.31 $grpc_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_tts.so
+    patchelf --replace-needed libgrpc.so.31 $grpc_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_asr_grpc.so
+    bbnote "Patching libgrpc++ NEEDED to $grpcpp_soname"
+    patchelf --replace-needed libgrpc++.so.1.54 $grpcpp_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_tts.so
+    patchelf --replace-needed libgrpc++.so.1.54 $grpcpp_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_asr_grpc.so
+    bbnote "Patching libprotobuf NEEDED to $protobuf_soname"
+    patchelf --replace-needed libprotobuf.so.3.21.12.0 $protobuf_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_asr_grpc.so
+    patchelf --replace-needed libprotobuf.so.3.21.12.0 $protobuf_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_tts.so
+    patchelf --replace-needed libprotobuf.so.3.21.12.0 $protobuf_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_audio_proto.so
+    bbnote "Patching libprotobuf-lite NEEDED to $libprotobuf_lite_soname"
+    patchelf --replace-needed libprotobuf-lite.so.3.21.12.0 $libprotobuf_lite_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_tts.so
+    patchelf --replace-needed libprotobuf-lite.so.3.21.12.0 $libprotobuf_lite_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_asr_grpc.so
+    patchelf --replace-needed libnppial.so libnppial.so.13 ${D}${DEEPSTREAM_PATH}/lib/libnvds_vpicanmatch.so
+    patchelf --replace-needed libnppist.so libnppist.so.13 ${D}${DEEPSTREAM_PATH}/lib/libnvds_vpicanmatch.so
+    bbnote "Patching libjsoncpp NEEDED to $jsoncpp_soname"
+    patchelf --replace-needed libjsoncpp.so.25 $jsoncpp_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_rest_server.so
+    patchelf --replace-needed libjsoncpp.so.25 $jsoncpp_soname ${D}${libdir}/gstreamer-1.0/deepstream/libnvdsgst_nvmultiurisrcbin.so
+    bbnote "Patching libgpr NEEDED to $gpr_soname"
+    patchelf --replace-needed libgpr.so.31 $gpr_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_asr_grpc.so
+    patchelf --replace-needed libgpr.so.31 $gpr_soname ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_tts.so
+    # abseil-cpp 20260107.1 on blacksail builds libabsl_synchronization.so.2601.0.0
+    # (upstream r38.4 targeted .2505.0.0).
+    patchelf --replace-needed libabsl_synchronization.so.2301.0.0 libabsl_synchronization.so.2601.0.0 ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_asr_grpc.so
+    patchelf --replace-needed libabsl_synchronization.so.2301.0.0 libabsl_synchronization.so.2601.0.0 ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_tts.so
+    # Optical-flow plugin links VPI 3 (gone on r39.2, which has VPI 4 only) —
+    # drop it, as upstream does, rather than ship a broken NEEDED.
+    rm -f ${D}${DEEPSTREAM_PATH}/lib/libnvds_opticalflow_orin.so
+    # ---XXX
+    cd ${D}${DEEPSTREAM_BASEDIR}
+    ln -s deepstream-8.0 deepstream
+    cd -
+}
+
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+INSANE_SKIP = "dev-so ldflags"
+
+def pkgconf_packages(d):
+    pkgconf = bb.utils.filter('PACKAGECONFIG', 'azure amqp kafka nmos redis triton rivermax realsense', d).split()
+    pn = d.getVar('PN')
+    return ' '.join(['{}-{}'.format(pn, p) for p in pkgconf])
+
+PKGCONF_PACKAGES = "${@pkgconf_packages(d)}"
+
+PACKAGES = "${PN}-samples-data ${PN}-samples ${PN}-dev ${PN}-staticdev ${PN}-sources ${PN}-dbg ${PKGCONF_PACKAGES} ${PACKAGE_BEFORE_PN} ${PN}"
+
+FILES:${PN} = "\
+    ${sysconfdir}/ld.so.conf.d/  \
+    ${libdir}/gstreamer-1.0/deepstream \
+    ${DEEPSTREAM_PATH}/lib \
+    ${DEEPSTREAM_BASEDIR} \
+"
+
+FILES:${PN}-dev = "${DEEPSTREAM_PATH}/sources/includes"
+
+FILES:${PN}-samples = "${bindir}/*"
+FILES:${PN}-samples-data = "\
+    ${DEEPSTREAM_PATH}/samples \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/*.txt \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/README \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/configs/ \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/inferserver/ \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/csv_files/ \
+"
+
+FILES:${PN}-sources = "${DEEPSTREAM_PATH}/sources"
+
+FILES:${PN}-azure = "${DEEPSTREAM_PATH}/lib/libnvds_azure*"
+FILES:${PN}-nmos = "${DEEPSTREAM_PATH}/lib/lib/libnvds_nmos*"
+FILES:${PN}-triton = "\
+    ${libdir}/gstreamer-1.0/deepstream/libnvdsgst_inferserver.so \
+    ${DEEPSTREAM_PATH}/lib/libnvds_infer_server.so \
+"
+FILES:${PN}-amqp = "${DEEPSTREAM_PATH}/lib/libnvds_amqp*"
+FILES:${PN}-kafka = "${DEEPSTREAM_PATH}/lib/libnvds_kafka*"
+FILES:${PN}-redis = "${DEEPSTREAM_PATH}/lib/libnvds_redis*"
+FILES:${PN}-rivermax = "${libdir}/gstreamer-1.0/deepstream/libnvdsgst_udp.so"
+FILES:${PN}-realsense = "${DEEPSTREAM_PATH}/lib/libnvds_3d_dataloader_realsense.so"
+FILES:${PN}-staticdev = " \
+    ${libdir}/gstreamer-1.0/deepstream/libnvdsgst_multistream_legacy.a \
+    ${DEEPSTREAM_PATH}/lib/libnvds_service_maker_utils.a \
+"
+
+RDEPENDS:${PN} = "libgstnvcustomhelper"
+RDEPENDS:${PN}-samples = "${PN}-samples-data libgstnvcustomhelper"
+RDEPENDS:${PN}-samples-data = "bash"
+RDEPENDS:${PN}-sources = "bash ${PN}-samples-data ${PN}"
+RRECOMMENDS:${PN}-sources += "${PN}-dev"
+RRECOMMENDS:${PN} = "liberation-fonts"

--- a/meta-tegra-extensions-jp7/recipes-multimedia/libcamera/libcamera_%.bbappend
+++ b/meta-tegra-extensions-jp7/recipes-multimedia/libcamera/libcamera_%.bbappend
@@ -1,0 +1,18 @@
+# blacksail (JetPack 7.2 / L4T r39.2.0) build fix.
+#
+# libcamera 0.7.1 (blacksail meta-multimedia) added a PACKAGECONFIG[opengl]
+# that enables its GPU "softISP" path and DEPENDS on
+# "virtual/libgl virtual/egl". Its PACKAGECONFIG default auto-enables that
+# option whenever 'opengl' is in DISTRO_FEATURES (which wendyos sets, for
+# TensorRT). On a headless Jetson there is no provider for virtual/libgl:
+# meta-tegra points PREFERRED_PROVIDER_virtual/libgl at libglvnd, but
+# libglvnd only PROVIDES virtual/libgl via its 'glx' PACKAGECONFIG, which
+# requires the 'x11' DISTRO_FEATURE (GLX) — wrong for a headless device.
+# Result: the wendyos-image dependency chain
+# wireplumber -> pipewire -> libcamera -> virtual/libgl is unbuildable.
+#
+# The older wrynose/scarthgap libcamera had no opengl PACKAGECONFIG, so this
+# is purely a 0.7.1 regression for us. We don't use libcamera's CPU/GPU
+# softISP (Jetson cameras go through NVIDIA's hardware ISP), so drop the
+# option. Gated to blacksail; inert elsewhere (older libcamera lacks it).
+PACKAGECONFIG:remove = "${@'opengl' if d.getVar('WENDYOS_LAYER_TREE') == 'blacksail' else ''}"

--- a/meta-tegra-extensions-jp7/recipes-support/yaml-cpp/yaml-cpp-080_%.bbappend
+++ b/meta-tegra-extensions-jp7/recipes-support/yaml-cpp/yaml-cpp-080_%.bbappend
@@ -1,0 +1,13 @@
+# Build yaml-cpp-080 as a SHARED library for blacksail/JP7.2.
+#
+# DeepStream 8.0's prebuilt libs dynamically link libyaml-cpp.so.0.8, but the
+# meta-tegra-community yaml-cpp-080 recipe builds STATIC
+# (-DYAML_BUILD_SHARED_LIBS=OFF) — its main runtime package is empty and it
+# ships no .so, so DS8 has no provider for libyaml-cpp.so.0.8 (do_rootfs:
+# "nothing provides ..."). Flip it to shared so it ships libyaml-cpp.so.0.8
+# (packaged, via OE's debian renaming, as 'libyaml-cpp').
+#
+# This bbappend lives in meta-tegra-extensions-jp7, which is only in the
+# blacksail/JP7 bblayers, so it is inherently scoped to that tree (scarthgap
+# uses yaml-cpp-070 for DeepStream 7.1 and never sees this).
+EXTRA_OECMAKE = "-DYAML_CPP_BUILD_TESTS=OFF -DYAML_BUILD_SHARED_LIBS=ON -DYAML_CPP_BUILD_TOOLS=OFF"

--- a/meta-tegra-extensions/conf/layer.conf
+++ b/meta-tegra-extensions/conf/layer.conf
@@ -9,6 +9,6 @@ BBFILE_COLLECTIONS += "wendyos-tegra"
 BBFILE_PATTERN_wendyos-tegra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wendyos-tegra = "51"
 
-LAYERSERIES_COMPAT_wendyos-tegra = "scarthgap wrynose"
+LAYERSERIES_COMPAT_wendyos-tegra = "scarthgap wrynose blacksail"
 LAYERVERSION_wendyos-tegra = "1"
 LAYERDEPENDS_wendyos-tegra = "core wendyos"

--- a/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-nvidia-container.bb
+++ b/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-nvidia-container.bb
@@ -86,11 +86,17 @@ RDEPENDS:${PN} = " \
 # DeepStream-specific packages (only when WENDYOS_DEEPSTREAM=1)
 # These provide libraries needed by DeepStream GStreamer plugins
 WENDYOS_DEEPSTREAM ?= "0"
+# NOTE: yaml-cpp is intentionally NOT listed here. The DeepStream package
+# (deepstream-8.0 on blacksail / deepstream-7.1 on scarthgap, installed via
+# tegra-image.inc when DEEPSTREAM=1) links libyaml-cpp.so.0.x and DEPENDS the
+# matching yaml-cpp recipe, so its automatic shlib RDEPENDS pulls the
+# (debian-renamed) libyaml-cpp package into the image. A packagegroup can't
+# RDEPEND that renamed name itself — with no build-time dep here, bitbake
+# fails to resolve it at graph time ("Nothing RPROVIDES libyaml-cpp").
 RDEPENDS:${PN} += "${@bb.utils.contains('WENDYOS_DEEPSTREAM', '1', ' \
     tegra-libraries-multimedia-ds \
     tegra-libraries-nvdsseimeta \
     libgstnvcustomhelper \
-    yaml-cpp-070 \
     tensorrt-trtexec-prebuilt \
     ', '', d)}"
 

--- a/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
+++ b/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
@@ -11,10 +11,13 @@ COMPATIBLE_MACHINE = "(tegra)"
 inherit packagegroup
 
 SUMMARY:${PN} = "Tegra hardware support packages"
-# tegra-flash-reboot ships only on scarthgap meta-tegra (Orin / tegra234);
-# r38.4.x meta-tegra (Thor / tegra264) has no such recipe, so gate it.
+# tegra-flash-reboot ships ONLY on scarthgap meta-tegra (Orin / tegra234 /
+# JP6). Neither Thor (tegra264) nor the JP7.2/blacksail tree has the recipe
+# (blacksail's tegra-flash-init does not RDEPEND on it), so gate on BOTH the
+# SoC and the scarthgap layer tree — a bare tegra234 check would wrongly pull
+# it on blacksail Orin ("Nothing PROVIDES tegra-flash-reboot").
 RDEPENDS:${PN} = " \
-    ${@'tegra-flash-reboot' if 'tegra234' in d.getVar('MACHINEOVERRIDES').split(':') else ''} \
+    ${@'tegra-flash-reboot' if ('tegra234' in d.getVar('MACHINEOVERRIDES').split(':') and (d.getVar('WENDYOS_LAYER_TREE') or '') == 'scarthgap') else ''} \
     tegra-tools-tegrastats \
     tegra-bootcontrol-overlay \
     setup-nv-boot-control \

--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-blacksail.csv
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-blacksail.csv
@@ -1,0 +1,225 @@
+# WendyOS Yocto l4t.csv - NVIDIA Container Library Mapping
+# This file maps host libraries into containers for GPU access
+# Note: Yocto paths differ from standard L4T:
+#   - CUDA libs: /usr/local/cuda-13.2/lib/ (not targets/aarch64-linux/lib/)
+#   - System libs: /usr/lib/ (not /usr/lib/aarch64-linux-gnu/)
+
+# =============================================================================
+# DEVICE NODES
+# =============================================================================
+dev, /dev/nvidiactl
+dev, /dev/nvidia0
+dev, /dev/nvmap
+dev, /dev/nvhost-gpu
+dev, /dev/nvhost-ctrl-gpu
+dev, /dev/nvhost-as-gpu
+dev, /dev/nvhost-dbg-gpu
+dev, /dev/nvhost-prof-gpu
+dev, /dev/nvhost-ctxsw-gpu
+dev, /dev/nvhost-sched-gpu
+dev, /dev/nvhost-tsg-gpu
+dev, /dev/nvhost-vic
+
+# DRI devices (for graphics/display)
+dev, /dev/dri
+
+# =============================================================================
+# CUDA RUNTIME (required by all CUDA applications)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libcudart.so.12.6.68
+sym, /usr/local/cuda-13.2/lib/libcudart.so.12
+sym, /usr/local/cuda-13.2/lib/libcudart.so
+
+# =============================================================================
+# cuBLAS - Linear algebra (REQUIRED by PyTorch)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libcublas.so.12.6.1.4
+sym, /usr/local/cuda-13.2/lib/libcublas.so.12
+sym, /usr/local/cuda-13.2/lib/libcublas.so
+lib, /usr/local/cuda-13.2/lib/libcublasLt.so.12.6.1.4
+sym, /usr/local/cuda-13.2/lib/libcublasLt.so.12
+sym, /usr/local/cuda-13.2/lib/libcublasLt.so
+
+# =============================================================================
+# cuSPARSE - Sparse matrix operations (used by PyTorch sparse tensors)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libcusparse.so.12.5.3.3
+sym, /usr/local/cuda-13.2/lib/libcusparse.so.12
+sym, /usr/local/cuda-13.2/lib/libcusparse.so
+
+# =============================================================================
+# cuSPARSELt - Lightweight sparse operations
+# =============================================================================
+lib, /usr/lib/libcusparseLt.so.0.8.1.1
+sym, /usr/lib/libcusparseLt.so.0
+
+# =============================================================================
+# cuSOLVER - Linear solvers (used by torch.linalg operations)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libcusolver.so.11.6.4.69
+sym, /usr/local/cuda-13.2/lib/libcusolver.so.11
+sym, /usr/local/cuda-13.2/lib/libcusolver.so
+lib, /usr/local/cuda-13.2/lib/libcusolverMg.so.11.6.4.69
+sym, /usr/local/cuda-13.2/lib/libcusolverMg.so.11
+sym, /usr/local/cuda-13.2/lib/libcusolverMg.so
+
+# =============================================================================
+# cuRAND - Random number generation (used by torch.rand with CUDA)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libcurand.so.10.3.7.68
+sym, /usr/local/cuda-13.2/lib/libcurand.so.10
+sym, /usr/local/cuda-13.2/lib/libcurand.so
+
+# =============================================================================
+# cuFFT - Fast Fourier Transform (used by torch.fft)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libcufft.so.11.2.6.59
+sym, /usr/local/cuda-13.2/lib/libcufft.so.11
+sym, /usr/local/cuda-13.2/lib/libcufft.so
+lib, /usr/local/cuda-13.2/lib/libcufftw.so.11.2.6.59
+sym, /usr/local/cuda-13.2/lib/libcufftw.so.11
+sym, /usr/local/cuda-13.2/lib/libcufftw.so
+
+# =============================================================================
+# NVRTC - Runtime compilation (used by torch.jit)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libnvrtc.so.12.6.68
+sym, /usr/local/cuda-13.2/lib/libnvrtc.so.12
+sym, /usr/local/cuda-13.2/lib/libnvrtc.so
+lib, /usr/local/cuda-13.2/lib/libnvrtc-builtins.so.12.6.68
+sym, /usr/local/cuda-13.2/lib/libnvrtc-builtins.so.12.6
+sym, /usr/local/cuda-13.2/lib/libnvrtc-builtins.so
+
+# =============================================================================
+# nvJitLink - JIT Linker (required by PyTorch JIT and torch.compile)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libnvJitLink.so.12.6.68
+sym, /usr/local/cuda-13.2/lib/libnvJitLink.so.12
+sym, /usr/local/cuda-13.2/lib/libnvJitLink.so
+
+# =============================================================================
+# NVTX - NVIDIA Tools Extension (used by PyTorch profiler)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libnvToolsExt.so.1.0.0
+sym, /usr/local/cuda-13.2/lib/libnvToolsExt.so.1
+
+# =============================================================================
+# CUPTI - CUDA Profiling Tools Interface (used by PyTorch profiler)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libcupti.so.2024.3.1
+sym, /usr/local/cuda-13.2/lib/libcupti.so.12
+
+# =============================================================================
+# cuFile - GPUDirect Storage (required by PyTorch 2.8.0)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libcufile.so.1.11.1
+sym, /usr/local/cuda-13.2/lib/libcufile.so.0
+sym, /usr/local/cuda-13.2/lib/libcufile.so
+
+# =============================================================================
+# cuDLA - Deep Learning Accelerator Runtime
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libcudla.so.1.0.0
+sym, /usr/local/cuda-13.2/lib/libcudla.so.1
+sym, /usr/local/cuda-13.2/lib/libcudla.so
+
+# =============================================================================
+# NPP - Image processing primitives (used by vision operations)
+# =============================================================================
+lib, /usr/local/cuda-13.2/lib/libnppc.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppc.so.12
+sym, /usr/local/cuda-13.2/lib/libnppc.so
+lib, /usr/local/cuda-13.2/lib/libnppial.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppial.so.12
+sym, /usr/local/cuda-13.2/lib/libnppial.so
+lib, /usr/local/cuda-13.2/lib/libnppicc.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppicc.so.12
+sym, /usr/local/cuda-13.2/lib/libnppicc.so
+lib, /usr/local/cuda-13.2/lib/libnppidei.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppidei.so.12
+sym, /usr/local/cuda-13.2/lib/libnppidei.so
+lib, /usr/local/cuda-13.2/lib/libnppif.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppif.so.12
+sym, /usr/local/cuda-13.2/lib/libnppif.so
+lib, /usr/local/cuda-13.2/lib/libnppig.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppig.so.12
+sym, /usr/local/cuda-13.2/lib/libnppig.so
+lib, /usr/local/cuda-13.2/lib/libnppim.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppim.so.12
+sym, /usr/local/cuda-13.2/lib/libnppim.so
+lib, /usr/local/cuda-13.2/lib/libnppist.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppist.so.12
+sym, /usr/local/cuda-13.2/lib/libnppist.so
+lib, /usr/local/cuda-13.2/lib/libnppisu.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppisu.so.12
+sym, /usr/local/cuda-13.2/lib/libnppisu.so
+lib, /usr/local/cuda-13.2/lib/libnppitc.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppitc.so.12
+sym, /usr/local/cuda-13.2/lib/libnppitc.so
+lib, /usr/local/cuda-13.2/lib/libnpps.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnpps.so.12
+sym, /usr/local/cuda-13.2/lib/libnpps.so
+
+# =============================================================================
+# cuDNN - Deep learning primitives (REQUIRED by PyTorch)
+# =============================================================================
+lib, /usr/lib/libcudnn.so.9.20.0
+sym, /usr/lib/libcudnn.so.9
+lib, /usr/lib/libcudnn_ops.so.9.20.0
+sym, /usr/lib/libcudnn_ops.so.9
+lib, /usr/lib/libcudnn_cnn.so.9.20.0
+sym, /usr/lib/libcudnn_cnn.so.9
+lib, /usr/lib/libcudnn_adv.so.9.20.0
+sym, /usr/lib/libcudnn_adv.so.9
+lib, /usr/lib/libcudnn_graph.so.9.20.0
+sym, /usr/lib/libcudnn_graph.so.9
+lib, /usr/lib/libcudnn_engines_runtime_compiled.so.9.20.0
+sym, /usr/lib/libcudnn_engines_runtime_compiled.so.9
+lib, /usr/lib/libcudnn_engines_precompiled.so.9.20.0
+sym, /usr/lib/libcudnn_engines_precompiled.so.9
+lib, /usr/lib/libcudnn_heuristic.so.9.20.0
+sym, /usr/lib/libcudnn_heuristic.so.9
+
+# =============================================================================
+# TensorRT - Inference optimization (required by torch-tensorrt)
+# =============================================================================
+lib, /usr/lib/libnvinfer.so.10.3.0
+sym, /usr/lib/libnvinfer.so.10
+lib, /usr/lib/libnvinfer_plugin.so.10.3.0
+sym, /usr/lib/libnvinfer_plugin.so.10
+lib, /usr/lib/libnvinfer_builder_resource.so.10.3.0
+lib, /usr/lib/libnvonnxparser.so.10.3.0
+sym, /usr/lib/libnvonnxparser.so.10
+
+# =============================================================================
+# Tegra CUDA driver (critical for all GPU operations)
+# =============================================================================
+lib, /usr/lib/libcuda.so.1.1
+sym, /usr/lib/libcuda.so.1
+sym, /usr/lib/libcuda.so
+
+# =============================================================================
+# NvSci libraries (inter-process buffer sharing)
+# =============================================================================
+lib, /usr/lib/libnvscibuf.so.1
+sym, /usr/lib/libnvscibuf.so
+lib, /usr/lib/libnvscicommon.so.1
+sym, /usr/lib/libnvscicommon.so
+lib, /usr/lib/libnvscisync.so.1
+sym, /usr/lib/libnvscisync.so
+lib, /usr/lib/libnvscistream.so.1
+sym, /usr/lib/libnvscistream.so
+lib, /usr/lib/libnvscievent.so
+lib, /usr/lib/libnvsciipc.so
+
+# =============================================================================
+# NVIDIA Management Library (nvidia-smi support)
+# =============================================================================
+lib, /usr/lib/libnvidia-ml.so.1
+sym, /usr/lib/libnvidia-ml.so
+
+# =============================================================================
+# PTX JIT Compiler
+# =============================================================================
+lib, /usr/lib/libnvidia-ptxjitcompiler.so.540.4.0
+sym, /usr/lib/libnvidia-ptxjitcompiler.so.1

--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream-blacksail.csv
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream-blacksail.csv
@@ -1,0 +1,477 @@
+# Device nodes (required for GPU access)
+dev, /dev/nvidiactl
+dev, /dev/nvidia0
+dev, /dev/nvhost-gpu
+dev, /dev/nvhost-ctrl-gpu
+dev, /dev/nvhost-as-gpu
+dev, /dev/nvhost-dbg-gpu
+dev, /dev/nvhost-prof-gpu
+dev, /dev/nvhost-ctxsw-gpu
+dev, /dev/nvhost-sched-gpu
+dev, /dev/nvhost-tsg-gpu
+
+# Video decode device (hardware video decoding)
+dev, /dev/v4l2-nvdec
+
+# DRI devices (for graphics/display if needed)
+dev, /dev/dri/card*
+dev, /dev/dri/renderD*
+dir, /dev/dri/by-path
+
+# CUDA Runtime (required by all CUDA applications)
+sym, /usr/local/cuda-13.2/lib/libcudart.so.12
+lib, /usr/local/cuda-13.2/lib/libcudart.so.12.6.68
+
+# CUDA Headers (required for building/JIT compilation - needed by triton, torch.compile, etc.)
+dir, /usr/local/cuda-13.2/include
+
+# CUDA Binaries (required for JIT compilation - nvcc, ptxas, nvlink, etc.)
+# Triton engine and torch.compile need ptxas for PTX assembly compilation
+dir, /usr/local/cuda-13.2/bin
+
+# CUDA NVVM (NVIDIA LLVM compiler infrastructure)
+# Contains cicc (CUDA intermediate compiler) and libdevice (device intrinsics)
+dir, /usr/local/cuda-13.2/nvvm
+
+# cuBLAS - Linear algebra (REQUIRED by PyTorch)
+sym, /usr/local/cuda-13.2/lib/libcublas.so.12
+lib, /usr/local/cuda-13.2/lib/libcublas.so.12.6.1.4
+sym, /usr/local/cuda-13.2/lib/libcublasLt.so.12
+lib, /usr/local/cuda-13.2/lib/libcublasLt.so.12.6.1.4
+
+# cuDNN - Deep learning primitives (REQUIRED by PyTorch)
+sym, /usr/lib/libcudnn.so.9
+lib, /usr/lib/libcudnn.so.9.3.0
+sym, /usr/lib/libcudnn_ops.so.9
+lib, /usr/lib/libcudnn_ops.so.9.3.0
+sym, /usr/lib/libcudnn_cnn.so.9
+lib, /usr/lib/libcudnn_cnn.so.9.3.0
+sym, /usr/lib/libcudnn_adv.so.9
+lib, /usr/lib/libcudnn_adv.so.9.3.0
+sym, /usr/lib/libcudnn_graph.so.9
+lib, /usr/lib/libcudnn_graph.so.9.3.0
+sym, /usr/lib/libcudnn_engines_precompiled.so.9
+lib, /usr/lib/libcudnn_engines_precompiled.so.9.3.0
+sym, /usr/lib/libcudnn_engines_runtime_compiled.so.9
+lib, /usr/lib/libcudnn_engines_runtime_compiled.so.9.3.0
+sym, /usr/lib/libcudnn_heuristic.so.9
+lib, /usr/lib/libcudnn_heuristic.so.9.3.0
+
+# cuSPARSE - Sparse matrix operations (used by PyTorch sparse tensors)
+sym, /usr/local/cuda-13.2/lib/libcusparse.so.12
+lib, /usr/local/cuda-13.2/lib/libcusparse.so.12.5.3.3
+
+# cuSPARSELt - Lightweight sparse matrix operations
+lib, /usr/lib/libcusparseLt.so.0
+lib, /usr/lib/libcusparseLt.so.0.8.1.1
+
+# cuSOLVER - Linear solvers (used by torch.linalg operations)
+sym, /usr/local/cuda-13.2/lib/libcusolver.so.11
+lib, /usr/local/cuda-13.2/lib/libcusolver.so.11.6.4.69
+sym, /usr/local/cuda-13.2/lib/libcusolverMg.so.11
+lib, /usr/local/cuda-13.2/lib/libcusolverMg.so.11.6.4.69
+
+# cuRAND - Random number generation (used by torch.rand with CUDA)
+sym, /usr/local/cuda-13.2/lib/libcurand.so.10
+lib, /usr/local/cuda-13.2/lib/libcurand.so.10.3.7.68
+
+# cuFFT - Fast Fourier Transform (used by torch.fft)
+sym, /usr/local/cuda-13.2/lib/libcufft.so
+sym, /usr/local/cuda-13.2/lib/libcufft.so.11
+lib, /usr/local/cuda-13.2/lib/libcufft.so.11.2.6.59
+
+# NVRTC - Runtime compilation (used by torch.jit)
+sym, /usr/local/cuda-13.2/lib/libnvrtc.so.12
+lib, /usr/local/cuda-13.2/lib/libnvrtc.so.12.6.68
+sym, /usr/local/cuda-13.2/lib/libnvrtc-builtins.so.12.6
+lib, /usr/local/cuda-13.2/lib/libnvrtc-builtins.so.12.6.68
+
+# nvJitLink - JIT Linker (required by PyTorch JIT compilation and torch.compile)
+sym, /usr/local/cuda-13.2/lib/libnvJitLink.so.12
+lib, /usr/local/cuda-13.2/lib/libnvJitLink.so.12.6.68
+
+# NVTX - NVIDIA Tools Extension for profiling (used by PyTorch profiler)
+sym, /usr/local/cuda-13.2/lib/libnvToolsExt.so.1
+lib, /usr/local/cuda-13.2/lib/libnvToolsExt.so.1.0.0
+
+# CUPTI - CUDA Profiling Tools Interface (used by PyTorch profiler)
+sym, /usr/local/cuda-13.2/lib/libcupti.so.12
+lib, /usr/local/cuda-13.2/lib/libcupti.so.2024.3.1
+
+# NVJPEG - Hardware JPEG encoding/decoding
+sym, /usr/local/cuda-13.2/lib/libnvjpeg.so.12
+lib, /usr/local/cuda-13.2/lib/libnvjpeg.so.12.3.3.54
+
+# NPP - Image processing primitives (used by vision operations)
+sym, /usr/local/cuda-13.2/lib/libnppc.so.12
+lib, /usr/local/cuda-13.2/lib/libnppc.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppial.so.12
+lib, /usr/local/cuda-13.2/lib/libnppial.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppicc.so.12
+lib, /usr/local/cuda-13.2/lib/libnppicc.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppidei.so.12
+lib, /usr/local/cuda-13.2/lib/libnppidei.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppif.so.12
+lib, /usr/local/cuda-13.2/lib/libnppif.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppig.so.12
+lib, /usr/local/cuda-13.2/lib/libnppig.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppim.so.12
+lib, /usr/local/cuda-13.2/lib/libnppim.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppist.so.12
+lib, /usr/local/cuda-13.2/lib/libnppist.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppisu.so.12
+lib, /usr/local/cuda-13.2/lib/libnppisu.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnppitc.so.12
+lib, /usr/local/cuda-13.2/lib/libnppitc.so.12.3.1.54
+sym, /usr/local/cuda-13.2/lib/libnpps.so.12
+lib, /usr/local/cuda-13.2/lib/libnpps.so.12.3.1.54
+
+# Tegra core libraries (libnvrm_gpu, etc.)
+lib, /usr/lib/libnvrm_gpu.so
+lib, /usr/lib/libnvrm_chip.so
+lib, /usr/lib/libnvrm_mem.so
+lib, /usr/lib/libnvrm_sync.so
+lib, /usr/lib/libnvrm_host1x.so
+lib, /usr/lib/libnvdc.so
+lib, /usr/lib/libnvddk_2d_v2.so
+lib, /usr/lib/libnvddk_vic.so
+lib, /usr/lib/libnvimp.so
+lib, /usr/lib/libnvphs.so
+lib, /usr/lib/libnvidia-rmapi-tegra.so.540.4.0
+lib, /usr/lib/libnvidia-tls.so.540.4.0
+lib, /usr/lib/libnvidia-glcore.so.540.4.0
+lib, /usr/lib/libnvidia-glsi.so.540.4.0
+
+# VPI3 - Vision Programming Interface (computer vision acceleration)
+lib, /opt/nvidia/vpi3/lib/aarch64-linux-gnu/libnvvpi.so.3.2.4
+sym, /opt/nvidia/vpi3/lib/aarch64-linux-gnu/libnvvpi.so.3
+
+# Tegra-specific libraries (video processing) - in /usr/lib/ directly on Yocto
+sym, /usr/lib/libnvbufsurface.so
+sym, /usr/lib/libnvbufsurface.so.1
+lib, /usr/lib/libnvbufsurface.so.1.0.0
+sym, /usr/lib/libnvbufsurftransform.so
+sym, /usr/lib/libnvbufsurftransform.so.1
+lib, /usr/lib/libnvbufsurftransform.so.1.0.0
+lib, /usr/lib/libnvbuf_fdmap.so.1.0.0
+sym, /usr/lib/libnvdsbufferpool.so
+sym, /usr/lib/libnvdsbufferpool.so.1
+lib, /usr/lib/libnvdsbufferpool.so.1.0.0
+lib, /usr/lib/libnvid_mapper.so.1.0.0
+
+# NvSci libraries (NVIDIA Software Communication Interface)
+sym, /usr/lib/libnvscibuf.so
+lib, /usr/lib/libnvscibuf.so.1
+sym, /usr/lib/libnvscicommon.so
+lib, /usr/lib/libnvscicommon.so.1
+sym, /usr/lib/libnvscisync.so
+lib, /usr/lib/libnvscisync.so.1
+sym, /usr/lib/libnvscistream.so
+lib, /usr/lib/libnvscistream.so.1
+lib, /usr/lib/libnvscievent.so
+lib, /usr/lib/libnvsciipc.so
+
+# NVMM multimedia libraries (media framework)
+lib, /usr/lib/libnvmm.so
+lib, /usr/lib/libnvmm_utils.so
+lib, /usr/lib/libnvmm_contentpipe.so
+lib, /usr/lib/libnvmm_parser.so
+
+# EGL/OpenGL libraries (for GPU rendering)
+lib, /usr/lib/libEGL_nvidia.so.0
+lib, /usr/lib/libGLESv2_nvidia.so.2
+lib, /usr/lib/libnvidia-eglcore.so.540.4.0
+
+# CUDA driver (critical for all GPU operations)
+sym, /usr/lib/libcuda.so
+sym, /usr/lib/libcuda.so.1
+lib, /usr/lib/libcuda.so.1.1
+
+# TensorRT - Inference optimization (required by torch-tensorrt)
+sym, /usr/lib/libnvinfer.so
+sym, /usr/lib/libnvinfer.so.10
+lib, /usr/lib/libnvinfer.so.10.3.0
+sym, /usr/lib/libnvinfer_plugin.so
+sym, /usr/lib/libnvinfer_plugin.so.10
+lib, /usr/lib/libnvinfer_plugin.so.10.3.0
+lib, /usr/lib/libnvinfer_builder_resource.so.10.3.0
+
+# cuFile - GPUDirect Storage (required by PyTorch 2.8.0)
+sym, /usr/local/cuda-13.2/lib/libcufile.so
+sym, /usr/local/cuda-13.2/lib/libcufile.so.0
+lib, /usr/local/cuda-13.2/lib/libcufile.so.1.11.1
+
+# TensorRT ONNX Parser - Model import (required by torch-tensorrt)
+sym, /usr/lib/libnvonnxparser.so
+sym, /usr/lib/libnvonnxparser.so.10
+lib, /usr/lib/libnvonnxparser.so.10.3.0
+
+# CUDA DLA Runtime - Deep Learning Accelerator
+sym, /usr/local/cuda-13.2/lib/libcudla.so
+sym, /usr/local/cuda-13.2/lib/libcudla.so.1
+lib, /usr/local/cuda-13.2/lib/libcudla.so.1.0.0
+
+# DeepStream SDK 7.1 Libraries (only present if deepstream-8.0 is installed)
+# Environment variable for GStreamer to find DeepStream plugins
+env, GST_PLUGIN_PATH=/usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream
+env, LD_LIBRARY_PATH=/opt/nvidia/deepstream/deepstream-8.0/lib
+
+# Mount entire library directory for DeepStream
+dir, /opt/nvidia/deepstream/deepstream-8.0/lib
+
+# DeepStream symlink
+dir, /opt/nvidia/deepstream/deepstream
+
+# DeepStream GStreamer plugins directories
+dir, /usr/lib/gstreamer-1.0/deepstream
+dir, /usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream
+dir, /usr/lib/aarch64-linux-gnu/nvidia
+
+# DeepStream core libraries
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_meta.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_meta.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_helper.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_batch_jpegenc.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_infer.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_inferutils.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_nvmultiobjecttracker.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_osd.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_msgbroker.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_msgconv.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_msgconv.so.1.0.0
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_yml_parser.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_utils.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_dsanalytics.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_lljpegenc.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_nvtxhelper.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_dewarper.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_infer_server.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_smartrecord.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_inferbase.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_3d_gst.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_dewarper.so
+
+# Tegra container passthrough libraries (provides additional NVIDIA libs for containers)
+dir, /usr/share/nvidia-container-passthrough
+
+# GStreamer NVIDIA custom helper (required by DeepStream)
+# May be in /usr/lib/aarch64-linux-gnu/nvidia/ or /usr/share/nvidia-container-passthrough/
+sym, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so
+lib, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so.1.0.0
+sym, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so
+lib, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so.1.0.0
+# Fallback to container passthrough location
+lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so
+lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so.1.0.0
+lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so
+lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so.1.0.0
+
+# Tegra platform information (required for GPU driver initialization)
+dir, /sys/devices/soc0
+dir, /proc/device-tree
+
+# YAML-CPP library (required by DeepStream plugins)
+lib, /usr/lib/libnvrm_surface.so
+lib, /usr/lib/libnvos.so
+
+# Additional Tegra libraries (pyds dependencies)
+lib, /usr/lib/libnvsocsys.so
+lib, /usr/lib/libnvtegrahv.so
+lib, /usr/lib/libnvvic.so
+lib, /usr/lib/libnvrm_stream.so
+lib, /usr/lib/libnvcolorutil.so
+
+# EGL vendor configuration (required for nvbufsurftransform)
+dir, /usr/share/glvnd/egl_vendor.d
+
+# Additional EGL/GL libraries
+
+# ========================================
+
+lib, /usr/lib/libnvdla_compiler.so
+
+lib, /usr/lib/libnvcudla.so
+
+# ========================================
+
+# ========================================
+# Additional DeepStream Plugin Dependencies
+# ========================================
+
+# NVIDIA DLA runtime
+
+# GStreamer RTSP server
+
+# JSON GLib
+
+# Pango text rendering
+
+# NVIDIA DLA runtime
+lib, /usr/lib/libnvdla_runtime.so
+
+# GStreamer RTSP server
+lib, /usr/lib/libgstrtspserver-1.0.so.0
+lib, /usr/lib/libgstrtspserver-1.0.so.0.2212.0
+
+# JSON GLib
+lib, /usr/lib/libjson-glib-1.0.so.0
+lib, /usr/lib/libjson-glib-1.0.so.0.800.0
+
+# Pango text rendering
+lib, /usr/lib/libpango-1.0.so.0
+lib, /usr/lib/libpango-1.0.so.0.5200.1
+lib, /usr/lib/libpangocairo-1.0.so.0
+lib, /usr/lib/libpangocairo-1.0.so.0.5200.1
+lib, /usr/lib/libpangoft2-1.0.so.0
+lib, /usr/lib/libpangoft2-1.0.so.0.5200.1
+
+# Symlinks for GStreamer plugin dependencies
+sym, /usr/lib/libpango-1.0.so.0
+sym, /usr/lib/libpangocairo-1.0.so.0
+sym, /usr/lib/libpangoft2-1.0.so.0
+sym, /usr/lib/libjson-glib-1.0.so.0
+sym, /usr/lib/libgstrtspserver-1.0.so.0
+
+# FriBidi (BiDirectional text support for Pango)
+sym, /usr/lib/libfribidi.so.0
+lib, /usr/lib/libfribidi.so.0.4.0
+
+# DeepStream dewarper library (needed by deepstream_bins plugin)
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_dewarper.so
+
+# HarfBuzz (text shaping for Pango)
+sym, /usr/lib/libharfbuzz.so.0
+lib, /usr/lib/libharfbuzz.so.0.60830.0
+
+# ==========================================
+# Additional Dependencies for DeepStream Container
+# ==========================================
+
+# YAML C++ library 0.7 (required by DeepStream plugins, different from container's 0.8)
+sym, /usr/lib/libyaml-cpp.so.0.7
+lib, /usr/lib/libyaml-cpp.so.0.7.0
+
+# EGL libraries for GPU-accelerated operations
+sym, /usr/lib/libEGL.so.1
+lib, /usr/lib/libEGL.so.1.1.0
+lib, /usr/lib/libEGL_nvidia.so.0
+lib, /usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0
+
+# ========================================
+# DeepStream 7.1 Complete Dependencies
+# ========================================
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libcivetweb.so.1.16.0
+sym, /opt/nvidia/deepstream/deepstream-8.0/lib/libcivetweb.so.1
+sym, /opt/nvidia/deepstream/deepstream-8.0/lib/libcivetweb.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libcustom_A2Vtemplate.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libcustom_audioimpl.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libcustom_videoimpl.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_alignment_datafilter.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_common.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_depth2point_datafilter.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_depth_datasource.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_gl_datarender.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_gles_ensemble_render.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_glprocess.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_infer_postprocess_lidar_detection.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_lidar_preprocess_datafilter.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_multisensor_mixer.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_sensor_fusion_cluster.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_v2x_infer_custom_postprocess.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_v2x_infer_custom_preprocess.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_3d_video_databridge.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_audio_allocator.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_audiotransform.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_batch_jpegenc.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_csvparser.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_custom_sequence_preprocess.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_dewarper.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_dsanalytics.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_infer.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_infer_custom_parser_audio.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_infercustomparser.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_inferlogger.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_inferutils.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_lidar_custom_postprocess_impl.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_lidar_custom_preprocess_impl.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_lidarfileread.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_lidarfilewrite.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_logger.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_mem_allocator.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_meta.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_mqtt_proto.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_msgbroker.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_msgconv.so.1.0.0
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_msgconv_audio.so.1.0.0
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_nvmultiobjecttracker.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_nvtxhelper.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_opticalflow_dgpu.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_opticalflow_jetson.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_opticalflow_orin.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_osd.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_rest_server.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_riva_asr_grpc.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_riva_audio_proto.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_riva_tts.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_service_maker.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_utils.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_vpicanmatch.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvds_yml_parser.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_3d_gst.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_audio.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_customhelper.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_helper.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_inferbase.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_ipcmeta.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_meta.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_smartrecord.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libnvdsgst_tensor.so
+lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libpostprocess_impl.so
+
+# DeepStream GStreamer plugins directory
+dir, /usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream
+lib, /usr/lib/gstreamer-1.0/deepstream/libcustom2d_preprocess.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libgstnvvideoconvert.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgstA2Vtemplate.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_3dbridge.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_3dfilter.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_3dmixer.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_audiotemplate.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_deepstream_bins.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_dewarper.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_dsanalytics.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_dsexample.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_infer.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_inferaudio.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_logger.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_metamux.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_msgbroker.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_msgconv.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_multistream.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_multistreamtiler.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_nvmultiurisrcbin.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_nvurisrcbin.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_of.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_ofvisual.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_osd.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_postprocess.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_preprocess.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_segvisual.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_speech.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_text_to_speech.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_tracker.so
+lib, /usr/lib/gstreamer-1.0/deepstream/libnvdsgst_videotemplate.so
+
+# GL/GLES libraries for GPU-accelerated operations
+sym, /usr/lib/libGLESv2.so.2
+lib, /usr/lib/libGLESv2.so.2.1.0
+lib, /usr/lib/libGLESv2_nvidia.so.2
+sym, /usr/lib/libGLESv1_CM.so.1
+lib, /usr/lib/libGLESv1_CM.so.1.2.0
+lib, /usr/lib/libGLESv1_CM_nvidia.so.1
+sym, /usr/lib/libGLdispatch.so.0
+lib, /usr/lib/libGLdispatch.so.0.0.0
+
+# DRM devices for EGL/headless GPU operations
+dev-char, /dev/dri/card0
+dev-char, /dev/dri/renderD128

--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/nvidia-container-config_1.0.bb
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/nvidia-container-config_1.0.bb
@@ -10,7 +10,9 @@ WENDYOS_DEEPSTREAM ?= "0"
 
 SRC_URI = " \
     file://l4t.csv \
+    file://l4t-blacksail.csv \
     file://l4t-deepstream.csv \
+    file://l4t-deepstream-blacksail.csv \
     file://devices-wendyos.csv \
     file://wendyos-cdi-generate.service \
     file://wendyos-cuda-detect.service \
@@ -28,13 +30,31 @@ do_install() {
     # Install CSV files to the NVIDIA container runtime config directory
     install -d ${D}${sysconfdir}/nvidia-container-runtime/host-files-for-container.d
 
-    # Install base l4t.csv (CUDA/PyTorch libraries)
-    install -m 0644 ${UNPACKDIR}/l4t.csv ${D}${sysconfdir}/nvidia-container-runtime/host-files-for-container.d/
+    # Install base l4t.csv (CUDA/PyTorch container libraries). Host paths are
+    # BSP-specific, so two variants (same pattern as the DeepStream CSV):
+    #   scarthgap/JP6   -> l4t.csv           (CUDA 12.6 + cuDNN 9.3.0)
+    #   blacksail/JP7.2 -> l4t-blacksail.csv (CUDA 13.2 + cuDNN 9.20.0)
+    # Both install under the same target name so exactly one is active.
+    if [ "${WENDYOS_LAYER_TREE}" = "blacksail" ]; then
+        basecsv="l4t-blacksail.csv"
+    else
+        basecsv="l4t.csv"
+    fi
+    install -m 0644 ${UNPACKDIR}/${basecsv} ${D}${sysconfdir}/nvidia-container-runtime/host-files-for-container.d/l4t.csv
 
     # Install DeepStream CSV if enabled
     if [ "${WENDYOS_DEEPSTREAM}" = "1" ]; then
-        bbnote "Installing DeepStream l4t-deepstream.csv"
-        install -m 0644 ${UNPACKDIR}/l4t-deepstream.csv ${D}${sysconfdir}/nvidia-container-runtime/host-files-for-container.d/
+        # CUDA/DeepStream host paths are BSP-specific, so we ship two CSVs:
+        #   scarthgap/JP6   -> l4t-deepstream.csv           (CUDA 12.6 + DeepStream 7.1)
+        #   blacksail/JP7.2 -> l4t-deepstream-blacksail.csv (CUDA 13.2 + DeepStream 8.0)
+        # Both install under the same target name so exactly one is active.
+        if [ "${WENDYOS_LAYER_TREE}" = "blacksail" ]; then
+            dscsv="l4t-deepstream-blacksail.csv"
+        else
+            dscsv="l4t-deepstream.csv"
+        fi
+        bbnote "Installing DeepStream CSV: ${dscsv}"
+        install -m 0644 ${UNPACKDIR}/${dscsv} ${D}${sysconfdir}/nvidia-container-runtime/host-files-for-container.d/l4t-deepstream.csv
 
         # Create multiarch compatibility symlinks for GStreamer DeepStream plugins
         # This allows the CDI GST_PLUGIN_PATH to work with both Yocto and Debian/Ubuntu conventions

--- a/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/recipes-connectivity/avahi/avahi_%.bbappend
@@ -9,8 +9,18 @@ SRC_URI += " \
     file://90-wendyos.preset \
     "
 
-# Ensure D-Bus support is enabled for proper service publishing
-PACKAGECONFIG += "dbus"
+# Ensure D-Bus support is enabled for proper service publishing.
+# Use :append, NOT += : the recipe sets PACKAGECONFIG with a weak default
+# (??=), and += is an immediate assignment that DISCARDS that default
+# entirely (??= only applies if the var is otherwise unset). On avahi 0.8
+# (scarthgap/wrynose) the default was just "dbus", so += was harmless. But
+# avahi 0.9 (blacksail) added "systemd" to the default AND gates installing
+# avahi-daemon.service on PACKAGECONFIG[systemd]; += "dbus" wiped systemd,
+# so the unit was never installed while SYSTEMD_SERVICE still referenced it
+# -> do_package QA "Didn't find service unit 'avahi-daemon.service'".
+# :append is applied after ??= resolves, so it preserves the recipe default
+# (incl. systemd on 0.9) and is a no-op on 0.8 (whose default has no systemd).
+PACKAGECONFIG:append = " dbus"
 
 # Ensure Avahi compiles with static service file support
 EXTRA_OECONF += " \

--- a/recipes-core/packagegroups/tegra-packagegroup-base.inc
+++ b/recipes-core/packagegroups/tegra-packagegroup-base.inc
@@ -2,11 +2,14 @@
 # This file is included when building for Tegra machines
 
 # Tegra-specific tools and hardware support.
-# tegra-flash-reboot ships only on scarthgap meta-tegra (Orin / tegra234).
-# r38.4.x meta-tegra (Thor / tegra264) has no such recipe, so gate it.
+# tegra-flash-reboot ships ONLY on scarthgap meta-tegra (Orin / tegra234 /
+# JP6). Neither Thor (tegra264) nor the JP7.2/blacksail tree has the recipe
+# (blacksail's tegra-flash-init does not RDEPEND on it), so gate on BOTH the
+# SoC and the scarthgap layer tree — a bare tegra234 check would wrongly pull
+# it on blacksail Orin ("Nothing PROVIDES tegra-flash-reboot").
 RDEPENDS:${PN}:append = " \
     efibootmgr \
-    ${@'tegra-flash-reboot' if 'tegra234' in d.getVar('MACHINEOVERRIDES').split(':') else ''} \
+    ${@'tegra-flash-reboot' if ('tegra234' in d.getVar('MACHINEOVERRIDES').split(':') and (d.getVar('WENDYOS_LAYER_TREE') or '') == 'scarthgap') else ''} \
     tegra-tools-tegrastats \
     "
 

--- a/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
+++ b/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
@@ -81,8 +81,18 @@ FILES:${PN} = "/usr/local/bin/wendy-agent \
                /var/lib/wendyos-agent \
                /var/lib/wendy-agent"
 
-# Skip QA checks for pre-built binary
-INSANE_SKIP:${PN} += "already-stripped"
+# Skip QA checks for the pre-built, vendored binary:
+#   already-stripped - upstream ships a stripped release binary.
+#   buildpaths       - the agent is a Go binary built in WendyOS's own CI
+#                      (also GitHub Actions), so it embeds /home/runner/...
+#                      build paths that we cannot trim out of a binary we did
+#                      not compile. blacksail promotes buildpaths to a fatal
+#                      ERROR_QA, which is why this only surfaces on the cold
+#                      blacksail Jetson builds. The embedded path is inert
+#                      debug metadata on-device. Proper fix is upstream
+#                      building the agent with `go build -trimpath`; drop this
+#                      skip once releases ship trimmed binaries.
+INSANE_SKIP:${PN} += "already-stripped buildpaths"
 
 # Runtime dependencies
 # curl/wget needed for auto-updater, tar for extraction

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -5,15 +5,15 @@ wendyos-update binary plus the boot-verify and auto-commit systemd units. The \
 board-specific behaviour lives behind a connector (tegrauefi for Jetson); the \
 engine, artifact format and CLI are board-agnostic. Replaces the Mender client \
 on platforms without meta-mender support (e.g. JetPack 7 / wrynose)."
-HOMEPAGE = "https://github.com/wendylabsinc/wendy-os-update"
+HOMEPAGE = "https://github.com/wendylabsinc/wendyos-update"
 
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=32329fcd0da888dcffa77ba65b409d5e"
 
-GO_IMPORT = "github.com/wendylabsinc/wendy-os-update"
+GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
-SRCREV = "a1f8d0f3b89d368630f99a5f4eda26bbdf5837ea"
+SRCREV = "ac85bad0e49763a2ba81cddc5bf7b8f8092c8324"
 
 inherit go-mod systemd
 

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -82,7 +82,7 @@ install -m 0755 "${tmp_s5}/s5cmd" /usr/local/bin/s5cmd
 rm -rf "${tmp_s5}"
 /usr/local/bin/s5cmd version
 
-# Go toolchain. Needed to build wendy-os-update (the OTA tool) and to run
+# Go toolchain. Needed to build wendyos-update (the OTA tool) and to run
 # its host-side `wendyos-update pack` from the build container / CI. Ubuntu
 # 24.04's apt 'golang' is ~1.22 — too old for the tool's go.mod (go 1.26)
 # — so install the official tarball to /usr/local/go (the upstream


### PR DESCRIPTION
### JetPack 7.2 / L4T R39.2.0 (blacksail) for Jetson + DeepStream 8.0

Moves the Jetson boards onto **JetPack 7.2** / **L4T R39.2.0** (Yocto "blacksail") - the first JP7 line that supports Thor (t264) and the Orin family (t234) together - toward unifying the fleet off the split scarthgap (r36) + wrynose (r38) setup. Isolated under repos/blacksail via WENDYOS_LAYER_TREE. The scarthgap / wrynose paths on main are untouched, so the validated fallback stays intact.

Main changes:
  - **Thor (t264):** flip to the blacksail tree + r39.2 
     meta-oe/meta-virt `LAYERSERIES_COMPAT` bridged (`blacksail-compat.inc`) until upstream declares blacksail
  - **Orin / Orin-Nano (t234):** migrate all four boards onto blacksail
  - **DeepStream 8.0:** vendored recipe (until meta-tegra-community forward-ports it to r39.2)
  - **`yaml-cpp-080`** built shared, blacksail container CSVs. Enabled on both SoCs.
  - **wendyos-update:** all Jetson boards use the new WendyOS update solution
