### PR TITLE
feat(tegra): bring up Bluetooth on Jetson AGX Thor [UNVERIFIED]

### DIFF
--- a/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
@@ -5,6 +5,11 @@
 # L4T 38.4.0. Phase 1 (no Mender, no OTA).
 MACHINEOVERRIDES =. "jetson-agx-thor-devkit:"
 
+# Advertise Bluetooth support so BT-gated packaging behaves like the RPi
+# machines. The hardware bring-up (kernel modules, firmware, hci0 autoload)
+# is pulled in by bluetooth-config via packagegroup-wendyos-tegra.
+MACHINE_FEATURES:append = " bluetooth"
+
 # Inherit from upstream meta-tegra Thor DevKit machine config
 # (P3834-0008 module on P4071-0000 carrier). Pulls in
 # conf/machine/include/tegra264.inc which sets SOC_FAMILY = "tegra264",

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/bluetooth.cfg
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/bluetooth.cfg
@@ -1,0 +1,30 @@
+# Bluetooth stack bring-up for Jetson AGX Thor.
+#
+# UNVERIFIED on Thor hardware. The AGX Thor DevKit's wifi/BT module had not
+# been confirmed at authoring time; these symbols enable the BlueZ-facing
+# kernel side for the controller family used on the AGX Orin DevKit (a Realtek
+# combo whose BT half enumerates over USB), plus the generic UART transport as
+# a fallback for serdev-attached controllers. If the board ships a different
+# controller, adjust the vendor driver here and the firmware package in
+# bluetooth-config to match. Without this fragment the NVIDIA defconfig leaves
+# the BT subsystem off, so no hci0 device is created and BlueZ exposes no
+# adapter (Adapter1 / LEAdvertisingManager1 absent on D-Bus).
+
+# Core Bluetooth subsystem (BR/EDR + LE).
+CONFIG_BT=m
+CONFIG_BT_BREDR=y
+CONFIG_BT_LE=y
+
+# HCI USB transport — Realtek/Broadcom combo cards expose BT over USB.
+CONFIG_BT_HCIBTUSB=m
+CONFIG_BT_HCIBTUSB_RTL=y
+CONFIG_BT_HCIBTUSB_BCM=y
+
+# HCI UART transport — fallback for UART/serdev-attached controllers.
+CONFIG_BT_HCIUART=m
+CONFIG_BT_HCIUART_H4=y
+CONFIG_BT_HCIUART_LL=y
+
+# Vendor firmware/driver helpers loaded on top of the transports.
+CONFIG_BT_RTL=m
+CONFIG_BT_BCM=m

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
@@ -14,9 +14,13 @@
 # be redundant on 6.8 but doesn't hurt.
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+# bluetooth.cfg enables the BT subsystem (off in the NVIDIA defconfig) so the
+# controller registers as hci0 and BlueZ can expose an adapter. UNVERIFIED on
+# Thor hardware — see the fragment header for the controller assumptions.
 SRC_URI += " \
     file://usb-gadget.cfg \
     file://usb-gadget-builtin.cfg \
+    file://bluetooth.cfg \
     file://0001-crypto-scatterwalk-Backport-memcpy_sglist.patch \
     file://0002-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch \
     file://0003-crypto-algif_aead-Revert-to-operating-out-of-place-CVE-2026-31431.patch \

--- a/meta-tegra-extensions/recipes-connectivity/bluetooth-config/bluetooth-config/bluetooth-modules.conf
+++ b/meta-tegra-extensions/recipes-connectivity/bluetooth-config/bluetooth-config/bluetooth-modules.conf
@@ -1,0 +1,6 @@
+# Autoload the USB HCI transport at boot so a Realtek/Broadcom combo BT radio
+# registers as hci0. btusb pulls the matching vendor driver (btrtl/btbcm) via
+# the firmware-request path once it binds the controller. If the AGX Thor
+# DevKit turns out to use a UART/serdev-attached controller instead, replace
+# this with the relevant transport (hci_uart) plus a btattach service.
+btusb

--- a/meta-tegra-extensions/recipes-connectivity/bluetooth-config/bluetooth-config_1.0.bb
+++ b/meta-tegra-extensions/recipes-connectivity/bluetooth-config/bluetooth-config_1.0.bb
@@ -1,0 +1,36 @@
+SUMMARY = "Bluetooth controller bring-up for WendyOS Tegra"
+DESCRIPTION = "Autoloads the USB HCI transport and pulls in the kernel \
+Bluetooth modules and controller firmware so the BT radio registers as hci0 \
+and BlueZ exposes an adapter (Adapter1 / LEAdvertisingManager1) on D-Bus."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI = "file://bluetooth-modules.conf"
+
+S = "${UNPACKDIR}"
+
+# Tegra-only: the controller assumptions and firmware here target the Jetson
+# AGX Thor / Orin combo cards. COMPATIBLE_MACHINE keeps it off other machines
+# even though only the Tegra packagegroup pulls it.
+COMPATIBLE_MACHINE = "(tegra)"
+
+do_install() {
+    install -d ${D}${sysconfdir}/modules-load.d
+    install -m 0644 ${UNPACKDIR}/bluetooth-modules.conf ${D}${sysconfdir}/modules-load.d/
+}
+
+# Kernel modules built by the bluetooth.cfg fragment in the jp7
+# linux-noble-nvidia-tegra bbappend. btusb pulls btrtl/btbcm at probe time;
+# list btrtl explicitly so the .ko is guaranteed present in the image.
+RDEPENDS:${PN} += " \
+    kernel-module-btusb \
+    kernel-module-btrtl \
+    "
+
+# Controller firmware. UNVERIFIED: assumes a Realtek combo, as on the AGX Orin
+# DevKit. linux-firmware-rtl-bt ships rtl_bt/*.bin. Swap for the matching
+# vendor package (e.g. linux-firmware-broadcom-bcm / linux-firmware-intel-bt)
+# once the AGX Thor DevKit's BT controller is confirmed on hardware.
+RDEPENDS:${PN} += " linux-firmware-rtl-bt"

--- a/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
+++ b/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
@@ -22,7 +22,12 @@ RDEPENDS:${PN} = " \
     tegra-bootcontrol-overlay \
     setup-nv-boot-control \
     packagegroup-nvidia-container \
+    bluetooth-config \
     "
+# bluetooth-config brings up the BT controller (kernel modules + firmware +
+# autoload) so it registers as hci0 and BlueZ exposes an adapter. The userspace
+# bluez5 stack ships from the shared image; this packagegroup adds the
+# hardware-facing pieces, mirroring how meta-rpi-extensions pulls pi-bluetooth.
 
 # Conditional UEFI capsule package installation
 # Controlled by WENDYOS_UPDATE_BOOTLOADER


### PR DESCRIPTION
> ⚠️ **UNVERIFIED — best-effort, not built or flashed.** Needs validation on AGX Thor hardware before merge. Opened as a draft for that reason.

## Problem

BLE is unavailable on the Jetson AGX Thor (`wendyos-true-raven`, WendyOS 0.15.4). The `wendy-agent` BLE error was the entry point:

```
BLE advertising unavailable error=register advertisement: Method "RegisterAdvertisement"
with signature "oa{sv}" on interface "org.bluez.LEAdvertisingManager1" doesn't exist
```

Diagnosed end-to-end over the agent's own D-Bus connection (via `bluetooth_scan` + the agent's OTLP telemetry — no SSH, no injected logs):

- Powering the adapter fails with `Method "Set" ... on interface "org.freedesktop.DBus.Properties" doesn't exist`. Every D-Bus object implements `Properties`, so this means **`/org/bluez/hci0` does not exist** — BlueZ has **no adapter**.
- `GetManagedObjects` carries **no** `org.bluez.LEAdvertisingManager1` on any path.

So `bluetoothd` runs (the image ships `bluez5`), but the **BT controller is never brought up** → no `hci0` → no adapter on D-Bus.

## Root cause

The Tegra image has no Bluetooth hardware bring-up. Contrast with the RPi machines, which work:

| | RPi (works) | Thor (before this PR) |
|---|---|---|
| `MACHINE_FEATURES bluetooth` | ✅ | ❌ |
| Controller attach | `pi-bluetooth` ships `hciuart.service` | ❌ none |
| BT kernel modules / firmware | present | ❌ none enabled |

## Change

Mirror the RPi bring-up for Tegra:

1. **`bluetooth.cfg`** kernel fragment — enables `CONFIG_BT` + USB/UART HCI transports + Realtek/Broadcom vendor drivers (off in the NVIDIA defconfig). Wired into the jp7 `linux-noble-nvidia-tegra` bbappend alongside the existing `usb-gadget` fragments.
2. **`bluetooth-config`** recipe (`meta-tegra-extensions/recipes-connectivity`) — autoloads `btusb` via `modules-load.d` and `RDEPENDS` the BT kernel modules + controller firmware (`linux-firmware-rtl-bt`). Mirrors the `usb-gadget-modules` recipe pattern.
3. **`packagegroup-wendyos-tegra`** installs `bluetooth-config`.
4. **Thor machine conf** sets `MACHINE_FEATURES bluetooth`.

## ⚠️ What needs verifying on hardware

- **Controller identity.** The vendor driver (`BT_RTL`/`BT_BCM`) and firmware package (`linux-firmware-rtl-bt`) **assume a Realtek combo**, as on the AGX Orin DevKit. If the AGX Thor DevKit uses a different controller, swap the driver + firmware package to match.
- **Attach mechanism.** Assumes USB-enumerated BT (`btusb`). If it's UART/serdev-attached, the `hci_uart` transport is enabled as a fallback but will additionally need a `btattach` service with the correct UART node.
- **Kconfig symbols.** Confirm all symbols land in the 6.8 `.config` (no `do_kernel_configcheck` warnings).
- **Acceptance:** after flashing, `hci0` appears, `busctl introspect org.bluez /org/bluez/hci0` shows `LEAdvertisingManager1`, and `wendy-agent` logs `BLE advertisement registered`.

## Related

Agent-side companion (already correct, independent of this): wendylabsinc/WendyOS#1062 — discovers the LE-advertising adapter instead of assuming `hci0` and turns the cryptic D-Bus error into a clear "no adapter implements LEAdvertisingManager1" message. That PR is what localized this to the OS image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)