### PR TITLE
build.yml: generate flashable images for blacksail Orin tegraflash-tar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -551,8 +551,6 @@ jobs:
 
       - name: Install flashable image dependencies (Jetson only)
         if: github.event_name != 'pull_request' && startsWith(matrix.device, 'jetson-')
-        env:
-          DEVICE: ${{ matrix.device }}
         run: |
           sudo apt-get update
           # simg2img (android-sdk-libsparse-utils) converts Android sparse ext4
@@ -567,74 +565,35 @@ jobs:
         env:
           DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
           MACHINE: ${{ steps.vars.outputs.machine }}
-          DEVICE: ${{ matrix.device }}
           STORAGE: ${{ matrix.storage }}
         run: |
           FLASH_WORKDIR="$GITHUB_WORKSPACE/flash-work"
           mkdir -p "$FLASH_WORKDIR"
 
-          # Two artifact families depending on the OTA stack (WENDYOS_OTA):
-          #   wendy  (JP7.2/blacksail — all tegra234 Orins + tegra264 Thor):
-          #          IMAGE_FSTYPES emits a single 'tegraflash-tar' bundle that
-          #          does NOT ship the doexternal.sh / dosdcard.sh helper
-          #          scripts. make-thor-nvme-img.py reimplements their offline
-          #          GPT image creation by parsing external-flash.xml.in and
-          #          writing each partition's binary at the correct sector
-          #          offset. The resulting wendyos-{nvme,sd}.img is the primary
-          #          artifact for `wendy os install` (dd-based provisioning);
-          #          the tegraflash-tar bundle remains the recovery-flash one.
-          #   mender (legacy JP6/scarthgap): the original 'tegraflash.tar.gz'
-          #          tarball that bundles doexternal.sh / dosdcard.sh.
-          # Branch on which artifact the build actually produced rather than on
-          # the device name, so moving a board between stacks needs no CI change.
+          # All Jetsons run the wendy/blacksail OTA stack (WENDYOS_OTA=wendy):
+          # IMAGE_FSTYPES emits a single 'tegraflash-tar' bundle that does NOT
+          # ship the doexternal.sh / dosdcard.sh helper scripts.
+          # make-thor-nvme-img.py reimplements their offline GPT image creation
+          # by parsing external-flash.xml.in and writing each partition's binary
+          # at the correct sector offset. The resulting wendyos-{nvme,sd}.img is
+          # the primary artifact for `wendy os install` (dd-based provisioning);
+          # the tegraflash-tar bundle remains the recovery-flash artifact.
           TEGRAFLASH_TAR="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
-          if [[ -f "$TEGRAFLASH_TAR" ]]; then
-            tar -xf "$TEGRAFLASH_TAR" -C "$FLASH_WORKDIR"
-            # external-flash.xml.in describes the external boot/root device
-            # (NVMe or SD). eMMC builds are internal-only and ship no such
-            # layout — for them the tegraflash-tar bundle itself is the
-            # recovery/flash artifact, so there is no offline disk image to build.
-            if [[ -f "$FLASH_WORKDIR/external-flash.xml.in" ]]; then
-              case "$STORAGE" in
-                sd) OUT="$GITHUB_WORKSPACE/wendyos-sd.img" ;;
-                *)  OUT="$GITHUB_WORKSPACE/wendyos-nvme.img" ;;
-              esac
-              python3 "$GITHUB_WORKSPACE/wendyos/scripts/make-thor-nvme-img.py" \
-                "$FLASH_WORKDIR" "$OUT"
-            else
-              echo "No external-flash.xml.in in bundle (storage=$STORAGE); the tegraflash-tar is the flash artifact, skipping offline image."
-            fi
-            exit 0
+          tar -xf "$TEGRAFLASH_TAR" -C "$FLASH_WORKDIR"
+          # external-flash.xml.in describes the external boot/root device (NVMe
+          # or SD). eMMC builds are internal-only and ship no such layout — for
+          # them the tegraflash-tar bundle itself is the recovery/flash artifact,
+          # so there is no offline disk image to build.
+          if [[ -f "$FLASH_WORKDIR/external-flash.xml.in" ]]; then
+            case "$STORAGE" in
+              sd) OUT="$GITHUB_WORKSPACE/wendyos-sd.img" ;;
+              *)  OUT="$GITHUB_WORKSPACE/wendyos-nvme.img" ;;
+            esac
+            python3 "$GITHUB_WORKSPACE/wendyos/scripts/make-thor-nvme-img.py" \
+              "$FLASH_WORKDIR" "$OUT"
+          else
+            echo "No external-flash.xml.in in bundle (storage=$STORAGE); the tegraflash-tar is the flash artifact, skipping offline image."
           fi
-
-          TEGRAFLASH_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz"
-          tar -xzf "$TEGRAFLASH_FILE" -C "$FLASH_WORKDIR"
-          # The SD/eMMC tegraflash tarballs don't bundle config-partition.fat32.img
-          # (it's only included via the NVMe external XML path). Without it, the
-          # tegrasign step can't process images_list.xml fully and never writes
-          # signed/flash.xml.tmp, causing generateflashindex to fail.
-          if [[ "$STORAGE" != "nvme" && ! -f "$FLASH_WORKDIR/config-partition.fat32.img" ]]; then
-            cp "$DEPLOY_DIR/config-partition.fat32.img" "$FLASH_WORKDIR/"
-          fi
-          # For SD/eMMC machines PARTITION_LAYOUT_EXTERNAL="" causes mender_flash_layout_adjust
-          # to be a no-op, leaving the literal string DATAFILE in flash.xml.bin. tegrasign
-          # then fails to write signed/flash.xml.tmp because no file named DATAFILE exists.
-          # Provide it so tegrasign can produce signed/flash.xml.tmp and generateflashindex
-          # can build flash.idx from it.
-          if [[ "$STORAGE" != "nvme" ]]; then
-            DATAIMG=$(find "$DEPLOY_DIR" -maxdepth 1 -name "wendyos-image-*.dataimg" -print -quit 2>/dev/null || true)
-            if [[ -n "$DATAIMG" && ! -f "$FLASH_WORKDIR/DATAFILE" ]]; then
-              cp "$DATAIMG" "$FLASH_WORKDIR/DATAFILE"
-            fi
-          fi
-          cd "$FLASH_WORKDIR"
-          case "$STORAGE" in
-            nvme)  sudo ./doexternal.sh -s 64G "$GITHUB_WORKSPACE/wendyos-nvme.img" ;;
-            # eMMC uses sdmmc_user device type; meta-tegra never generates dosdcard.sh for it.
-            # The tegraflash tarball is the correct recovery-flash artifact for eMMC.
-            emmc) : ;;
-            sd)   sudo ./dosdcard.sh "$GITHUB_WORKSPACE/wendyos-sd.img" ;;
-          esac
 
       - name: Upload image and emit manifest entry
         if: github.event_name != 'pull_request'
@@ -648,22 +607,17 @@ jobs:
         run: |
           TOKEN=$(gcloud auth print-access-token)
 
-          # Resolve the tegraflash bundle name once: wendy/blacksail builds emit
-          # '.tegraflash-tar'; legacy mender builds emit '.tegraflash.tar.gz'.
-          # Used below for the eMMC image and the Jetson recovery file.
+          # The wendy/blacksail OTA stack emits a single tegraflash-tar bundle;
+          # it doubles as the eMMC image and the Jetson recovery-flash artifact.
           TEGRAFLASH_BUNDLE=""
           if [[ "$MACHINE" != raspberry* ]]; then
-            if [[ -f "$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar" ]]; then
-              TEGRAFLASH_BUNDLE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
-            else
-              TEGRAFLASH_BUNDLE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz"
-            fi
+            TEGRAFLASH_BUNDLE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
           fi
 
           BMAP_FILE=""
           if [[ "$MACHINE" != raspberry* && "$STORAGE" == "nvme" ]]; then
-            # wendyos-nvme.img: blacksail Jetsons build it via
-            # make-thor-nvme-img.py; legacy mender NVMe builds via doexternal.sh.
+            # wendyos-nvme.img: built from the tegraflash-tar bundle by
+            # make-thor-nvme-img.py.
             IMAGE_FILE="$GITHUB_WORKSPACE/wendyos-nvme.img"
             bmaptool create "$IMAGE_FILE" > "${IMAGE_FILE}.bmap"
             BMAP_FILE="${IMAGE_FILE}.bmap"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -555,12 +555,12 @@ jobs:
           DEVICE: ${{ matrix.device }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y device-tree-compiler
-          # simg2img converts Android sparse ext4 images to raw; needed by
-          # make-thor-nvme-img.py to write APP/APP_b into the Thor NVMe image.
-          if [[ "$DEVICE" == "jetson-agx-thor" ]]; then
-            sudo apt-get install -y android-sdk-libsparse-utils
-          fi
+          # simg2img (android-sdk-libsparse-utils) converts Android sparse ext4
+          # images to raw; make-thor-nvme-img.py needs it to write APP/APP_b into
+          # the offline disk image. Every blacksail Jetson (Thor + all Orins on
+          # WENDYOS_OTA=wendy) now builds its NVMe/SD image via that script, so
+          # install it for all Jetson devices rather than Thor alone.
+          sudo apt-get install -y device-tree-compiler android-sdk-libsparse-utils
 
       - name: Generate flashable image (Jetson)
         if: github.event_name != 'pull_request' && startsWith(matrix.device, 'jetson-')
@@ -573,18 +573,37 @@ jobs:
           FLASH_WORKDIR="$GITHUB_WORKSPACE/flash-work"
           mkdir -p "$FLASH_WORKDIR"
 
-          if [[ "$DEVICE" == "jetson-agx-thor" ]]; then
-            # Thor (JP7/L4T r38.4.x / T264): the tegraflash-tar bundle does not
-            # include doexternal.sh.  make-thor-nvme-img.py reimplements the same
-            # offline GPT image creation by parsing external-flash.xml.in and
-            # writing each partition's binary at the correct sector offset.
-            # The resulting wendyos-nvme.img is the primary artifact for
-            # `wendy os install` (dd-based provisioning); the tegraflash-tar
-            # bundle remains available as the recovery-flash artifact.
-            TEGRAFLASH_TAR="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
+          # Two artifact families depending on the OTA stack (WENDYOS_OTA):
+          #   wendy  (JP7.2/blacksail — all tegra234 Orins + tegra264 Thor):
+          #          IMAGE_FSTYPES emits a single 'tegraflash-tar' bundle that
+          #          does NOT ship the doexternal.sh / dosdcard.sh helper
+          #          scripts. make-thor-nvme-img.py reimplements their offline
+          #          GPT image creation by parsing external-flash.xml.in and
+          #          writing each partition's binary at the correct sector
+          #          offset. The resulting wendyos-{nvme,sd}.img is the primary
+          #          artifact for `wendy os install` (dd-based provisioning);
+          #          the tegraflash-tar bundle remains the recovery-flash one.
+          #   mender (legacy JP6/scarthgap): the original 'tegraflash.tar.gz'
+          #          tarball that bundles doexternal.sh / dosdcard.sh.
+          # Branch on which artifact the build actually produced rather than on
+          # the device name, so moving a board between stacks needs no CI change.
+          TEGRAFLASH_TAR="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
+          if [[ -f "$TEGRAFLASH_TAR" ]]; then
             tar -xf "$TEGRAFLASH_TAR" -C "$FLASH_WORKDIR"
-            python3 "$GITHUB_WORKSPACE/wendyos/scripts/make-thor-nvme-img.py" \
-              "$FLASH_WORKDIR" "$GITHUB_WORKSPACE/wendyos-nvme.img"
+            # external-flash.xml.in describes the external boot/root device
+            # (NVMe or SD). eMMC builds are internal-only and ship no such
+            # layout — for them the tegraflash-tar bundle itself is the
+            # recovery/flash artifact, so there is no offline disk image to build.
+            if [[ -f "$FLASH_WORKDIR/external-flash.xml.in" ]]; then
+              case "$STORAGE" in
+                sd) OUT="$GITHUB_WORKSPACE/wendyos-sd.img" ;;
+                *)  OUT="$GITHUB_WORKSPACE/wendyos-nvme.img" ;;
+              esac
+              python3 "$GITHUB_WORKSPACE/wendyos/scripts/make-thor-nvme-img.py" \
+                "$FLASH_WORKDIR" "$OUT"
+            else
+              echo "No external-flash.xml.in in bundle (storage=$STORAGE); the tegraflash-tar is the flash artifact, skipping offline image."
+            fi
             exit 0
           fi
 
@@ -629,17 +648,29 @@ jobs:
         run: |
           TOKEN=$(gcloud auth print-access-token)
 
+          # Resolve the tegraflash bundle name once: wendy/blacksail builds emit
+          # '.tegraflash-tar'; legacy mender builds emit '.tegraflash.tar.gz'.
+          # Used below for the eMMC image and the Jetson recovery file.
+          TEGRAFLASH_BUNDLE=""
+          if [[ "$MACHINE" != raspberry* ]]; then
+            if [[ -f "$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar" ]]; then
+              TEGRAFLASH_BUNDLE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
+            else
+              TEGRAFLASH_BUNDLE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz"
+            fi
+          fi
+
           BMAP_FILE=""
           if [[ "$MACHINE" != raspberry* && "$STORAGE" == "nvme" ]]; then
-            # Covers Thor (wendyos-nvme.img from make-thor-nvme-img.py) and all
-            # other NVMe Jetsons (wendyos-nvme.img from doexternal.sh).
+            # wendyos-nvme.img: blacksail Jetsons build it via
+            # make-thor-nvme-img.py; legacy mender NVMe builds via doexternal.sh.
             IMAGE_FILE="$GITHUB_WORKSPACE/wendyos-nvme.img"
             bmaptool create "$IMAGE_FILE" > "${IMAGE_FILE}.bmap"
             BMAP_FILE="${IMAGE_FILE}.bmap"
           elif [[ "$MACHINE" != raspberry* && "$STORAGE" == "emmc" ]]; then
             # No offline disk image for eMMC (meta-tegra doesn't generate dosdcard.sh for
-            # sdmmc_user devices). The tegraflash tarball is the recovery-flash artifact.
-            IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz"
+            # sdmmc_user devices). The tegraflash bundle is the recovery-flash artifact.
+            IMAGE_FILE="$TEGRAFLASH_BUNDLE"
           elif [[ "$MACHINE" != raspberry* && "$STORAGE" == "sd" ]]; then
             IMAGE_FILE="$GITHUB_WORKSPACE/wendyos-sd.img"
             bmaptool create "$IMAGE_FILE" > "${IMAGE_FILE}.bmap"
@@ -684,13 +715,10 @@ jobs:
 
           # For all Jetson targets, include the tegraflash bundle as the recovery file
           # (used for USB recovery-mode flashing via tegraflash.py / initrd-flash).
-          # Thor uses .tegraflash-tar (JP7/r38.4.x renamed the type); others use .tegraflash.tar.gz.
-          if [[ "$MACHINE" != raspberry* ]]; then
-            if [[ "$DEVICE" == "jetson-agx-thor" ]]; then
-              ARGS+=(--recovery-file "$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar")
-            else
-              ARGS+=(--recovery-file "$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash.tar.gz")
-            fi
+          # wendy/blacksail builds use .tegraflash-tar (JP7/r38.4.x renamed the
+          # type); legacy mender builds use .tegraflash.tar.gz — resolved above.
+          if [[ -n "$TEGRAFLASH_BUNDLE" ]]; then
+            ARGS+=(--recovery-file "$TEGRAFLASH_BUNDLE")
           fi
 
           # Devices with multiple storage variants pass --storage so the manifest


### PR DESCRIPTION
## Problem

The JP7.2 merge (#130) moved all tegra234 Orins onto `WENDYOS_OTA=wendy` (`conf/template/include/local/tegra-t234.inc`). On that stack `IMAGE_FSTYPES:tegra` emits a single `tegraflash-tar` bundle instead of the legacy `tegraflash.tar.gz`.

The CI "Generate flashable image (Jetson)" step only special-cased `jetson-agx-thor` for the `tegraflash-tar` path; every other Jetson still hardcoded `tar -xzf …tegraflash.tar.gz`. So all four Orin builds failed:

```
tar: …/wendyos-image-jetson-agx-orin-devkit-nvme-wendyos.tegraflash.tar.gz: Cannot open: No such file or directory
```

(agx-orin nvme + emmc, orin-nano nvme + sd — all at this exact step; the bitbake "Build image" step itself succeeded). The only build.yml change in the merge was the AWS-credentials refresh; the flashable-image + upload steps were missed.

## Fix

With both tegra234 and tegra264 now on `WENDYOS_OTA=wendy`, **no matrix entry produces `tegraflash.tar.gz` anymore**, so the flashable step collapses to the `tegraflash-tar` path and the legacy `doexternal.sh` / `dosdcard.sh` / `config-partition` / `DATAFILE` handling is removed as dead code:

- Extract `…tegraflash-tar`; when the bundle carries `external-flash.xml.in` (NVMe/SD) build the offline disk image via `make-thor-nvme-img.py` (`nvme`→`wendyos-nvme.img`, `sd`→`wendyos-sd.img`). eMMC is internal-only and ships no external layout, so the bundle itself is the flash artifact (no offline image).
- Upload step resolves the bundle name directly to `.tegraflash-tar` for the eMMC image and the Jetson recovery file (drops the Thor-only special case).
- `simg2img` is installed for all Jetson devices, since every board now uses `make-thor-nvme-img.py`.

`make-thor-nvme-img.py` is already generic (parses `external-flash.xml.in`; its docstring notes it reimplements `doexternal.sh` "for Orin/Nano"), so reusing it for the Orins is the intended path.

> Note: the machine confs keep the `else 'tegraflash mender dataimg'` branch as a switchable capability, so a future mender Jetson is still possible — it would just need its CI handling re-added.

## Verification

Needs a real build run to confirm the blacksail Orin `tegraflash-tar` bundles contain `external-flash.xml.in` for nvme/sd and produce valid `wendyos-{nvme,sd}.img`. If an SD bundle turns out not to ship the layout, the flashable step degrades gracefully (logs + skips) rather than hard-failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)