### PR TITLE
fix(rpi): enable IMX477 ribbon (+ IMX219) camera on Pi 3/4 (WDY-1603)

### DIFF
--- a/conf/machine/raspberrypi3-64-wendyos.conf
+++ b/conf/machine/raspberrypi3-64-wendyos.conf
@@ -7,6 +7,25 @@ require conf/machine/include/raspberrypi-common-wendyos.inc
 # so the default stays off.
 WENDYOS_USB_GADGET ?= "0"
 
+# RPi3 boot config (consumed by rpi-config_%.bbappend). ORDER MATTERS — the
+# firmware processes these top-to-bottom and a later camera overlay overrides
+# the single bcm2835 unicam CSI endpoint set by an earlier one:
+# - dtoverlay=imx477 (FIRST): explicitly load the IMX477 sensor overlay. UNLIKE
+#   the Pi 5 (whose RP1 detects this ribbon), the Pi 3 VideoCore firmware does
+#   NOT recognise it via camera_auto_detect (same root cause confirmed on a
+#   Pi 4, including a cold boot), so without an explicit overlay the sensor
+#   never probes and libcamera enumerates zero cameras (WDY-1603).
+# - camera_auto_detect=1 (LAST): lets an auto-detectable module (e.g. an
+#   official IMX219 Camera Module) override the imx477 endpoint above so the
+#   same image supports both sensors; the orphaned imx477 node then just fails
+#   to probe. It is a no-op for the non-detectable IMX477 ribbon, which the
+#   explicit overlay already covers. NOTE: a *non-detectable* third-party IMX219
+#   ribbon would not be picked up here and would need a first-boot i2c probe.
+#   Pairs with the libcamera stack (libcamera + libcamerasrc + the rpi/vc4
+#   pipeline) from packagegroup-wendyos-rpi and the meta-rpi-extensions libcamera
+#   bbappend. Pi3 has no PCIe, so unlike the Pi 5 conf there is no dtparam=pciex1.
+RPI_EXTRA_CONFIG = "dtoverlay=imx477\ncamera_auto_detect=1\n"
+
 # Mini UART on GPIO 14/15 (upstream default for RPi3): Bluetooth keeps the
 # PL011 (ttyAMA0), serial console runs on ttyS0. Mini-UART baud rate is
 # derived from the VPU clock and can drift under heavy CPU load, so serial

--- a/conf/machine/raspberrypi4-64-wendyos.conf
+++ b/conf/machine/raspberrypi4-64-wendyos.conf
@@ -5,6 +5,25 @@ require conf/machine/include/raspberrypi-common-wendyos.inc
 # RPi4 has an OTG-capable USB-C port — enable gadget by default.
 WENDYOS_USB_GADGET ?= "1"
 
+# RPi4 boot config (consumed by rpi-config_%.bbappend). ORDER MATTERS — the
+# firmware processes these top-to-bottom and a later camera overlay overrides
+# the single bcm2835 unicam CSI endpoint set by an earlier one:
+# - dtoverlay=imx477 (FIRST): explicitly load the IMX477 sensor overlay. UNLIKE
+#   the Pi 5 (whose RP1 detects this ribbon), the Pi 4 VideoCore firmware does
+#   NOT recognise it via camera_auto_detect — confirmed on a Pi 4, including a
+#   cold boot — so without an explicit overlay the sensor never probes and
+#   libcamera enumerates zero cameras (WDY-1603).
+# - camera_auto_detect=1 (LAST): lets an auto-detectable module (e.g. an
+#   official IMX219 Camera Module) override the imx477 endpoint above so the
+#   same image supports both sensors; the orphaned imx477 node then just fails
+#   to probe. It is a no-op for the non-detectable IMX477 ribbon, which the
+#   explicit overlay already covers. NOTE: a *non-detectable* third-party IMX219
+#   ribbon would not be picked up here and would need a first-boot i2c probe.
+#   Pairs with the libcamera stack (libcamera + libcamerasrc + the rpi/vc4
+#   pipeline) from packagegroup-wendyos-rpi and the meta-rpi-extensions libcamera
+#   bbappend. Pi4 has no PCIe, so unlike the Pi 5 conf there is no dtparam=pciex1.
+RPI_EXTRA_CONFIG = "dtoverlay=imx477\ncamera_auto_detect=1\n"
+
 # Mini UART on GPIO 14/15 (upstream default for RPi4): Bluetooth keeps the
 # PL011 (ttyAMA0), serial console runs on ttyS0. Mini-UART baud rate is
 # derived from the VPU clock and can drift under heavy CPU load, so serial


### PR DESCRIPTION
## Context

WDY-1603: a CSI ribbon camera (IMX477) **fails to stream on Raspberry Pi 3 and 4** — it didn't appear in `wendy device camera list` and `wendy device camera view` failed with `libcamera::CameraManager::cameras() is empty`.

## Root cause (verified on a Pi 4, incl. cold boot)

The firmware never creates the CSI sensor device-tree node → `unicam`/the sensor driver never binds → libcamera's `rpi/vc4` pipeline enumerates zero cameras.

The original theory ("just add `camera_auto_detect=1`, like Pi 5") was **disproved on-device**: with only `camera_auto_detect=1`, even after a true **cold power-cycle** with the camera reseated, the sensor still didn't probe. Unlike the Pi 5 — whose RP1 firmware detects this ribbon — the **Pi 4 VideoCore firmware does not recognise it via auto-detect**. Adding an explicit `dtoverlay=imx477` made it probe immediately (`imx477 10-001a: Device found is imx477`, `/dev/video0` = unicam, `cam --list` shows `imx477`) and `wendy device camera view` streamed **H.264 1280×1080@30**.

## Change

```
RPI_EXTRA_CONFIG = "dtoverlay=imx477\ncamera_auto_detect=1\n"
```
in `conf/machine/raspberrypi3-64-wendyos.conf` and `raspberrypi4-64-wendyos.conf`.

**Order matters** — the firmware applies these top-to-bottom and a later camera overlay overrides the single unicam CSI endpoint set by an earlier one:
- `dtoverlay=imx477` **first** → the non-detectable IMX477 ribbon always works (verified).
- `camera_auto_detect=1` **last** → an auto-detectable module (e.g. an official IMX219 Camera Module) loads its overlay last and overrides the imx477 endpoint, so **one image supports both sensors**; the orphaned imx477 node just fails to probe. No-op for the IMX477 ribbon.

### Supported / not supported
- ✅ IMX477 ribbon — verified on-device.
- ✅ Auto-detectable IMX219 (official Camera Module) — *expected* via auto-detect override (not hardware-tested here; no IMX219 on hand).
- ❌ A *non-detectable* third-party IMX219 ribbon — would hit the same auto-detect gap as the IMX477 and need a first-boot i2c probe (possible follow-up).

## Scope / safety

Pi 5 and Jetson confs untouched. Only the two Pi 3/4 machine confs change. The libcamera `rpi/vc4` pipeline + IPA + tuning, kernel unicam/sensor modules, and the `v4l2h264enc` encoder are already in the image. Set per-conf so the Pi 5 conf is byte-for-byte unchanged; no `dtparam=pciex1` (Pi 3/4 have no PCIe).

## Pairs with

wendylabsinc/WendyOS#1070 — the agent-side fixes (camera-list cleanup + the `v4l2h264enc` H.264-level pin the Pi 4 hardware encoder needs). **Both are required** for `camera view` to work on Pi 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)