### PR TITLE
fix(kernel): enable USB-serial bridge drivers (ch341/cp210x/ftdi/pl2303) [WDY-1610]

### DIFF
--- a/meta-tegra-extensions-jp6/recipes-kernel/linux/linux-jammy-nvidia-tegra/usb-serial.cfg
+++ b/meta-tegra-extensions-jp6/recipes-kernel/linux/linux-jammy-nvidia-tegra/usb-serial.cfg
@@ -1,0 +1,27 @@
+# Host-side USB-serial adapter support (WDY-1610).
+#
+# The stock L4T/Tegra kernel does not enable CONFIG_USB_SERIAL_CH341 (WCH
+# CH340/CH341) or CONFIG_USB_SERIAL_PL2303. As a result a CH340 adapter (e.g.
+# the Yahboom ROSMASTER R2 drive board, 1a86:7522) enumerates on the USB bus
+# but no /dev/ttyUSB* node is created, so the wendy-agent serial entitlement
+# fails to bind it:
+#   "serial device /dev/ttyUSB0 unavailable ... lstat: no such file or directory"
+#
+# This is the jp6 (kernel 5.15 / linux-jammy) twin of the jp7 fragment. Built-in
+# (=y) rather than modules: it guarantees the driver binds on hotplug without
+# depending on /lib/modules + udev/depmod module auto-load being present and
+# working on the minimal image. NOTE: confirmed missing on jp7 hardware; jp6 is
+# enabled here by parity (same NVIDIA L4T defconfig gap) but not yet verified on
+# a jp6 device. Flip back to =m if module auto-load is confirmed working.
+
+# USB-serial core — required by every usb-serial bridge driver below.
+CONFIG_USB_SERIAL=y
+
+# CDC-ACM class devices (Arduino Uno/Mega, many MCUs) -> /dev/ttyACM*
+CONFIG_USB_ACM=y
+
+# Common USB-serial bridge chips -> /dev/ttyUSB*
+CONFIG_USB_SERIAL_CH341=y       # WCH CH340/CH341 (Yahboom ROSMASTER R2, many ESP/Arduino clones)
+CONFIG_USB_SERIAL_CP210X=y      # Silicon Labs CP210x
+CONFIG_USB_SERIAL_FTDI_SIO=y    # FTDI FT232/FT2232 etc.
+CONFIG_USB_SERIAL_PL2303=y      # Prolific PL2303

--- a/meta-tegra-extensions-jp6/recipes-kernel/linux/linux-jammy-nvidia-tegra_%.bbappend
+++ b/meta-tegra-extensions-jp6/recipes-kernel/linux/linux-jammy-nvidia-tegra_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += " \
     file://usb-gadget.cfg \
+    file://usb-serial.cfg \
     file://0001-crypto-scatterwalk-Backport-memcpy_sglist.patch \
     file://0002-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch \
     file://0003-crypto-algif_aead-Revert-to-operating-out-of-place-CVE-2026-31431.patch \

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/usb-serial.cfg
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/usb-serial.cfg
@@ -1,0 +1,28 @@
+# Host-side USB-serial adapter support (WDY-1610).
+#
+# The stock L4T/Tegra kernel (verified on JP7 / kernel 6.8.12-l4t-r39.2.0)
+# enables USB_SERIAL + a handful of bridge drivers as MODULES but does NOT
+# enable CONFIG_USB_SERIAL_CH341 (WCH CH340/CH341) or CONFIG_USB_SERIAL_PL2303
+# at all. As a result a CH340 adapter (e.g. the Yahboom ROSMASTER R2 drive
+# board, 1a86:7522) enumerates on the USB bus but no /dev/ttyUSB* node is
+# created, so the wendy-agent serial entitlement fails to bind it:
+#   "serial device /dev/ttyUSB0 unavailable ... lstat: no such file or directory"
+#
+# Built-in (=y) rather than modules: it guarantees the driver binds on hotplug
+# without depending on /lib/modules + udev/depmod module auto-load being present
+# and working on the minimal image (the stock drivers are =m but were observed
+# never loaded). Promoting the core + bridge drivers to =y removes that variable
+# entirely. Flip any of these back to =m if you have confirmed module
+# auto-loading works end-to-end and want to keep the kernel image smaller.
+
+# USB-serial core — required by every usb-serial bridge driver below.
+CONFIG_USB_SERIAL=y
+
+# CDC-ACM class devices (Arduino Uno/Mega, many MCUs) -> /dev/ttyACM*
+CONFIG_USB_ACM=y
+
+# Common USB-serial bridge chips -> /dev/ttyUSB*
+CONFIG_USB_SERIAL_CH341=y       # WCH CH340/CH341 (Yahboom ROSMASTER R2, many ESP/Arduino clones)
+CONFIG_USB_SERIAL_CP210X=y      # Silicon Labs CP210x
+CONFIG_USB_SERIAL_FTDI_SIO=y    # FTDI FT232/FT2232 etc.
+CONFIG_USB_SERIAL_PL2303=y      # Prolific PL2303

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
@@ -17,6 +17,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
     file://usb-gadget.cfg \
     file://usb-gadget-builtin.cfg \
+    file://usb-serial.cfg \
     file://0001-crypto-scatterwalk-Backport-memcpy_sglist.patch \
     file://0002-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch \
     file://0003-crypto-algif_aead-Revert-to-operating-out-of-place-CVE-2026-31431.patch \


### PR DESCRIPTION
## Problem

A CH340 USB-serial adapter (Yahboom ROSMASTER R2 drive board, `1a86:7522`) enumerates on the USB bus of a WendyOS Jetson but **no `/dev/ttyUSB*` node is created**, so the `wendy-agent` serial entitlement can't bind it:

```
serial device /dev/ttyUSB0 unavailable (need a real, connected tty node):
lstat /dev/ttyUSB0: no such file or directory
```

This is not a CLI/agent/entitlement bug (that's [WDY-1550](https://linear.app/wendylabsinc/issue/WDY-1550), shipped) — the agent bind-mounts an *existing* host node, and the node never gets created because the driver isn't in the kernel.

## Root cause (confirmed on hardware)

Diagnosed on `wendy-rc-car` via a throwaway container reading `/proc/config.gz` (kernel-global, no host shell needed):

- Kernel `6.8.12-l4t-r39.2.0` → **JetPack 7** (`linux-noble`).
- `CONFIG_USB_SERIAL=m`, `USB_ACM/CP210X/FTDI_SIO=m` are present as modules…
- …but **`CONFIG_USB_SERIAL_CH341` and `CONFIG_USB_SERIAL_PL2303` are absent entirely** — the CH340's driver was never built. No `ch341.ko` exists, so there is no runtime workaround.

## Fix

Add a `usb-serial.cfg` kernel config fragment enabling the USB-serial core, CDC-ACM, and the common bridge chips (`ch341`, `cp210x`, `ftdi_sio`, `pl2303`), wired into the kernel `SRC_URI`:

- **jp7** (`linux-noble`, 6.8) — the verified target.
- **jp6** (`linux-jammy`, 5.15) — enabled by parity against the same NVIDIA L4T defconfig gap (not yet verified on a jp6 device).

Built-in (`=y`) rather than modules, so the drivers bind on hotplug without depending on `/lib/modules` + udev/depmod module auto-load being present and working on the minimal image (the stock `=m` drivers were observed never loaded). Flip back to `=m` if module auto-load is confirmed working and a smaller kernel is wanted.

## Validation

⚠️ **Requires a kernel image rebuild + reflash to take effect** — config fragments only apply at image build time. Acceptance check after flashing:

- Plug the CH340 → `/dev/ttyUSB0` appears automatically.
- A container with `{ "type": "serial", "device": "ttyUSB0" }` deploys and `open()`s the port.

Closes WDY-1610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)