### PR TITLE
gstreamer/deepstream config fixes

### DIFF
--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/files/fix-cdi-gstreamer-paths.sh
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/files/fix-cdi-gstreamer-paths.sh
@@ -27,8 +27,8 @@ fi
 # Add GST_PLUGIN_PATH environment variable if not present
 # This tells GStreamer inside the container where to find DeepStream plugins
 if ! grep -q "GST_PLUGIN_PATH=" "$CDI_SPEC"; then
-    # Add GST_PLUGIN_PATH after NVIDIA_VISIBLE_DEVICES
-    sed -i 's|NVIDIA_VISIBLE_DEVICES=void|NVIDIA_VISIBLE_DEVICES=void\n  - GST_PLUGIN_PATH=/usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream|g' "$CDI_SPEC"
+    # Insert GST_PLUGIN_PATH as a sibling of NVIDIA_VISIBLE_DEVICES
+    sed -i -E 's|^([[:space:]]*)- NVIDIA_VISIBLE_DEVICES=void$|\1- NVIDIA_VISIBLE_DEVICES=void\n\1- GST_PLUGIN_PATH=/usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream|' "$CDI_SPEC"
     echo "Added GST_PLUGIN_PATH to CDI spec"
 fi
 

--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream-blacksail.csv
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream-blacksail.csv
@@ -361,8 +361,6 @@ lib, /usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0
 # DeepStream 7.1 Complete Dependencies
 # ========================================
 lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libcivetweb.so.1.16.0
-sym, /opt/nvidia/deepstream/deepstream-8.0/lib/libcivetweb.so.1
-sym, /opt/nvidia/deepstream/deepstream-8.0/lib/libcivetweb.so
 lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libcustom_A2Vtemplate.so
 lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libcustom_audioimpl.so
 lib, /opt/nvidia/deepstream/deepstream-8.0/lib/libcustom_videoimpl.so

--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream-blacksail.csv
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream-blacksail.csv
@@ -256,9 +256,7 @@ dir, /usr/share/nvidia-container-passthrough
 
 # GStreamer NVIDIA custom helper (required by DeepStream)
 # May be in /usr/lib/aarch64-linux-gnu/nvidia/ or /usr/share/nvidia-container-passthrough/
-sym, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so
 lib, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so.1.0.0
-sym, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so
 lib, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so.1.0.0
 # Fallback to container passthrough location
 lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so

--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
@@ -361,8 +361,6 @@ lib, /usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0
 # DeepStream 7.1 Complete Dependencies
 # ========================================
 lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so.1.16.0
-sym, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so.1
-sym, /opt/nvidia/deepstream/deepstream-7.1/lib/libcivetweb.so
 lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcustom_A2Vtemplate.so
 lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcustom_audioimpl.so
 lib, /opt/nvidia/deepstream/deepstream-7.1/lib/libcustom_videoimpl.so

--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-deepstream.csv
@@ -256,9 +256,7 @@ dir, /usr/share/nvidia-container-passthrough
 
 # GStreamer NVIDIA custom helper (required by DeepStream)
 # May be in /usr/lib/aarch64-linux-gnu/nvidia/ or /usr/share/nvidia-container-passthrough/
-sym, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so
 lib, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so.1.0.0
-sym, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so
 lib, /usr/lib/aarch64-linux-gnu/nvidia/libgstnvdsseimeta.so.1.0.0
 # Fallback to container passthrough location
 lib, /usr/share/nvidia-container-passthrough/usr/lib/aarch64-linux-gnu/nvidia/libgstnvcustomhelper.so


### PR DESCRIPTION
These small bugs were preventing the CUDA device being available on Thor, since deepstream is enabled for that WendyOS target.

* The patch-up of `/etc/cdi/nvidia.yaml` had a hard-coded indent of 2 spaces; on my build it is 8, so now it captures the correct indent automatically. There are better ways to edit YAML but I'll leave that out of scope for now.
* Some of the gstreamer CSV entries were requesting to create symlinks inside directories that are bound read-only, which causes container creation to fail. Since we're binding the whole host directory (which is why it's read-only), we get the symlinks for free so this isn't necessary.