### PR TITLE
ci: separate WENDYOS_SSHD from WENDYOS_DEBUG in nightly builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,12 @@ on:
         required: false
         default: ""
       debug:
-        description: "Enable WENDYOS_DEBUG and WENDYOS_SSHD (debug tools + SSH) on all devices. Auto-enabled on nightly builds; use this to opt in on release builds triggered by promote.yml."
+        description: "Enable WENDYOS_DEBUG (debug tools) on all devices. Auto-enabled on nightly builds; use this to opt in on release builds triggered by promote.yml."
+        type: boolean
+        required: false
+        default: false
+      sshd:
+        description: "Enable WENDYOS_SSHD (SSH server) on all devices. Must be set explicitly — not auto-enabled on nightly builds."
         type: boolean
         required: false
         default: false
@@ -408,17 +413,27 @@ jobs:
         # creation; the repo cache seeds repos/ from the AMI's bake-time clones.
         run: ./wendyos/bootstrap.sh
 
-      - name: Enable debug and SSH for nightly builds
-        # Release images are production builds — no debug tools, no SSH by default.
-        # Nightly and workflow_dispatch builds get both so developers can SSH into
-        # CI-flashed devices and use debug tooling out of the box. Release builds
+      - name: Enable debug for nightly builds
+        # Release images are production builds — no debug tools by default.
+        # Nightly and workflow_dispatch builds get debug tooling so CI-flashed
+        # devices include diagnostic utilities out of the box. Release builds
         # triggered by promote.yml can opt in via inputs.debug.
         if: (needs.detect-changes.outputs.is-release != 'true' && github.event_name != 'pull_request') || inputs.debug == true
         run: |
           {
             echo ''
-            echo '# Nightly CI: enable debug tooling and SSH on all devices'
+            echo '# Nightly CI: enable debug tooling on all devices'
             echo 'WENDYOS_DEBUG = "1"'
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+
+      - name: Enable SSH when explicitly requested
+        # SSH is disabled by default (WENDYOS_SSHD ??= "0" in common.inc).
+        # Pass inputs.sshd = true on workflow_dispatch or promote.yml to opt in.
+        if: inputs.sshd == true
+        run: |
+          {
+            echo ''
+            echo '# CI: enable SSH server on all devices (explicitly requested)'
             echo 'WENDYOS_SSHD = "1"'
           } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -13,7 +13,12 @@ on:
         required: false
         default: ""
       debug:
-        description: "Enable debug tools and SSH in the release build (WENDYOS_DEBUG + WENDYOS_SSHD)."
+        description: "Enable debug tools in the release build (WENDYOS_DEBUG)."
+        type: boolean
+        required: false
+        default: false
+      sshd:
+        description: "Enable SSH server in the release build (WENDYOS_SSHD)."
         type: boolean
         required: false
         default: false
@@ -111,13 +116,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           DEBUG_FLAG: ${{ inputs.debug }}
+          SSHD_FLAG: ${{ inputs.sshd }}
         run: |
           # GITHUB_TOKEN tag pushes don't trigger other workflows (GitHub limitation),
           # so we explicitly dispatch build.yml on the release tag here.
           gh workflow run build.yml \
             --ref "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --field debug="$DEBUG_FLAG"
+            --field debug="$DEBUG_FLAG" \
+            --field sshd="$SSHD_FLAG"
 
       - name: Send Discord announcement
         if: steps.create_release.outputs.created == 'true'


### PR DESCRIPTION
## Summary

- SSH (`WENDYOS_SSHD`) is no longer auto-enabled on nightly builds; it now requires an explicit opt-in via the new `sshd` boolean input
- Debug tooling (`WENDYOS_DEBUG`) continues to be auto-enabled on nightlies
- Both `build.yml` and `promote.yml` gain a separate `sshd` input; `promote.yml` forwards it to `build.yml`

## Test plan

- [ ] Trigger a nightly (push to main) — verify SSH is absent, debug tools present
- [ ] Trigger `build.yml` with `sshd = true` — verify SSH is included
- [ ] Trigger `promote.yml` with `sshd = true` — verify it propagates to `build.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2qLDagmiX44t73416jzRk