### PR TITLE
Bump version to 0.16.1

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -83,7 +83,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.16.0"
+DISTRO_VERSION = "0.16.1"
 # DISTRO_CODENAME is inherited from poky.conf (require'd above), which
 # sets it to the active oe-core series ("scarthgap", "wrynose", ...).
 # Don't override here or it gets stuck on a stale value across series.


### PR DESCRIPTION
## Summary
Bumps `DISTRO_VERSION` from `0.16.0` to `0.16.1` in `conf/distro/wendyos.conf`. This is the single source of truth for the OS version; `SDK_VERSION` derives from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)