### PR TITLE
rpi: mount /boot by LABEL on GPT fstabs

### DIFF
--- a/meta-rpi-extensions/files/wic/rpi-wendy-ab.wks
+++ b/meta-rpi-extensions/files/wic/rpi-wendy-ab.wks
@@ -27,9 +27,12 @@
 #     grow-data-part (see the plan — wendyos-data-setup's format-trigger does
 #     NOT fire on a wic-preformatted fs). Do NOT add expand-rootfs to an A/B
 #     image: it would grow rootfsA over rootfsB.
-#   - rootfsB/data get wic-generated PARTUUIDs (they are referenced by
-#     partlabel/number, not UUID); boot/config/rootfsA keep the stable
-#     partuuid-rpi values.
+#   - boot/config/rootfsA carry partuuid-rpi UUIDs; rootfsB/data get
+#     wic-generated ones. NOTE these UUIDs are NOT stable across builds
+#     (partuuid-rpi caches them per build dir), so nothing the rootfs carries
+#     across an OTA may reference them: /boot is mounted by LABEL, not PARTUUID
+#     (WDY-1768), and the slots are selected by partlabel/number. The --uuid
+#     here only stamps the GPT entry; it is no longer load-bearing for mounting.
 bootloader --ptable gpt
 part /boot   --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot    --active --align 4096 --size 128M --uuid "${WENDYOS_BOOT_PARTUUID}"
 part         --ondisk mmcblk0 --fstype=vfat --label config  --align 4096 --size ${WENDYOS_CONFIG_PART_SIZE_MB}M --uuid "${WENDYOS_CONFIG_PARTUUID}"

--- a/recipes-core/base-files/files/rpi-fstab
+++ b/recipes-core/base-files/files/rpi-fstab
@@ -1,3 +1,3 @@
-PARTUUID=RPI_BOOT_UUID  /boot  vfat    defaults          0 2
+LABEL=boot              /boot  vfat    defaults,nofail   0 2
 PARTUUID=RPI_ROOT_UUID  /      ext4    defaults,noatime  0 1
 LABEL=config  /config  vfat  defaults,nofail  0 0

--- a/recipes-core/base-files/files/rpi-wendy-fstab
+++ b/recipes-core/base-files/files/rpi-wendy-fstab
@@ -15,10 +15,12 @@ tmpfs                   /var/volatile  tmpfs  defaults              0 0
 # /boot is the shared FAT boot partition (firmware + u-boot + boot.scr +
 # uboot.env). It must stay mounted: the ubootenv connector edits
 # /boot/uboot.env via fw_setenv (see wendyos-fw-env / fw_env.config).
+# Referenced by LABEL, not a per-build PARTUUID: OTA writes only the rootfs
+# slot (never re-partitions), so a baked PARTUUID drifts and emergency-boots.
 #
 # /data is grown to fill the card on first boot by grow-data-part, which reads
 # this entry; it resolves LABEL=data to the device. /config is the FAT
 # provisioning partition.
-PARTUUID=RPI_BOOT_UUID  /boot    vfat  defaults              0 2
+LABEL=boot              /boot    vfat  defaults,nofail       0 2
 LABEL=config            /config  vfat  defaults,nofail       0 0
 LABEL=data              /data    ext4  defaults,noatime,nofail  0 2

--- a/recipes-core/base-files/rpi-base-files.inc
+++ b/recipes-core/base-files/rpi-base-files.inc
@@ -11,11 +11,11 @@ SRC_URI:append = " \
     file://rpi-wendy-mbr-fstab \
     "
 
-# RPi4/5 boot from a GPT image and reference partitions by PARTUUID (rpi-fstab,
-# placeholders RPI_BOOT_UUID / RPI_ROOT_UUID get substituted below).
-# RPi3 boots from MBR (BCM2837 GPU bootrom limitation) and references
-# partitions by filesystem label; the MBR template has no placeholders, so the
-# substitution sed lines below are no-ops on that path.
+# RPi4/5 boot from a GPT image. /boot is referenced by filesystem LABEL (stable
+# across builds — see WDY-1768); only the rootfs "/" still uses a substituted
+# PARTUUID placeholder (RPI_ROOT_UUID, rpi-fstab only). RPi3 boots from MBR
+# (BCM2837 GPU bootrom limitation) and references partitions by label too; its
+# MBR template has no placeholder, so the RPI_ROOT_UUID sed is a no-op there.
 #
 # Pinned to :raspberrypi3-64 to mirror the override used in rpi-cmdline.bbappend
 # (see comment there). WendyOS only ships the 64-bit RPi3 image; if a 32-bit
@@ -23,9 +23,10 @@ SRC_URI:append = " \
 RPI_FSTAB_TEMPLATE = "rpi-fstab"
 RPI_FSTAB_TEMPLATE:raspberrypi3-64 = "rpi-mbr-fstab"
 
-# The wendy A/B fstab is GPT (PARTUUID=RPI_BOOT_UUID for /boot) on RPi4/5; RPi3's
-# MBR variant references /boot by LABEL instead (PARTUUID won't resolve on MBR —
-# see rpi-wendy-mbr-fstab). Same :raspberrypi3-64 pin rationale as above.
+# The wendy A/B fstab references /boot by LABEL on both GPT (RPi4/5) and MBR
+# (RPi3): a baked PARTUUID drifts across builds since OTA only rewrites the
+# rootfs slot and never re-partitions (WDY-1768), and PARTUUID won't resolve on
+# MBR anyway. Same :raspberrypi3-64 pin rationale as above.
 RPI_WENDY_FSTAB_TEMPLATE = "rpi-wendy-fstab"
 RPI_WENDY_FSTAB_TEMPLATE:raspberrypi3-64 = "rpi-wendy-mbr-fstab"
 
@@ -34,11 +35,9 @@ do_install:append() {
         # wendyos-update A/B layout (RPi3/4/5): no Mender postprocess to generate
         # fstab. Install our A/B fstab (no "/" entry — the kernel mounts the
         # slot via boot-ab.cmd.in's root=; /boot stays mounted for fw_setenv's
-        # uboot.env; /data + /config by label). On RPi4/5 (GPT) RPI_BOOT_UUID is
-        # substituted for /boot; on RPi3 (MBR) the template uses LABEL=boot and
-        # the sed is a harmless no-op. /config and /data always use LABEL=.
+        # uboot.env). /boot, /config and /data are all referenced by LABEL, so
+        # there is no placeholder to substitute on this path (WDY-1768).
         install -m 0644 ${UNPACKDIR}/${RPI_WENDY_FSTAB_TEMPLATE} ${D}${sysconfdir}/fstab
-        sed -i "s/RPI_BOOT_UUID/${WENDYOS_BOOT_PARTUUID}/g" ${D}${sysconfdir}/fstab
     elif [ "${WENDYOS_RPI_UBOOT}" = "1" ]; then
         # Mender-managed MBR layout: boot/A/B/extended{config,data}. The
         # poky-stock /etc/fstab (already installed by base-files's own
@@ -49,14 +48,15 @@ do_install:append() {
         # /config entries that don't match this layout, so we skip it here.
         :
     else
+        # /boot and /config are referenced by LABEL; only the rootfs "/" uses a
+        # substituted PARTUUID here (WDY-1768).
         install -m 0644 ${UNPACKDIR}/${RPI_FSTAB_TEMPLATE} ${D}${sysconfdir}/fstab
-        sed -i "s/RPI_BOOT_UUID/${WENDYOS_BOOT_PARTUUID}/g" ${D}${sysconfdir}/fstab
         sed -i "s/RPI_ROOT_UUID/${WENDYOS_ROOT_PARTUUID}/g" ${D}${sysconfdir}/fstab
     fi
 }
 
 # Trigger a rebuild whenever the inputs to fstab generation change
-do_install[vardeps] += " WENDYOS_BOOT_PARTUUID WENDYOS_ROOT_PARTUUID RPI_FSTAB_TEMPLATE RPI_WENDY_FSTAB_TEMPLATE WENDYOS_RPI_UBOOT WENDYOS_OTA"
+do_install[vardeps] += " WENDYOS_ROOT_PARTUUID RPI_FSTAB_TEMPLATE RPI_WENDY_FSTAB_TEMPLATE WENDYOS_RPI_UBOOT WENDYOS_OTA"
 
 # systemd persistent log
 # If /var/log is a symlink into /var/volatile/log, journald cannot persist logs

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -24,11 +24,14 @@ GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 GO_SRCURI_DESTSUFFIX ?= "${@os.path.join(os.path.basename(d.getVar('S')), 'src', d.getVar('GO_IMPORT')) + '/'}"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
+# 8bba71c6: ubootenv refuses a slot swap when /boot is not a mountpoint, so the
+# trial arm can no longer silently no-op against a shadow uboot.env on the rootfs
+# (pairs with the /boot-by-LABEL + nofail fstab change, WDY-1768). Builds on
 # 16614b4b: WDY-1742 verify-boot fix (BootIsCompromised checks only the booted
 # slot — kills the Orin Nano stale-inactive-slot false-positive, validated
-# against the real r39.2 efivar format) + structured per-slot `status` and a new
-# `switch` verb. The fix is why the tegra verify-mask bbappend is now gone.
-SRCREV = "16614b4be4875163c965a5ee4174b1ed068ad813"
+# against the real r39.2 efivar format) + structured per-slot `status` and the
+# `switch` verb.
+SRCREV = "8bba71c67152a717c300ffffca445bef276a09dd"
 
 inherit go-mod systemd
 


### PR DESCRIPTION
**Problem:** The GPT RPi fstabs (`rpi-wendy-fstab`, `rpi-fstab`) mounted `/boot` by a per-build `PARTUUID`. OTA rewrites only the rootfs slot and never re-partitions, so an OTA'd slot's baked `/boot` PARTUUID drifts from the device's real boot partition → `/boot` mount times out → systemd **emergency mode** → no network/agent → the new slot is unreachable, can't be committed, and rolls back (`failed`).

**Fix:** Mount `/boot` by `LABEL=boot` (+ `nofail`) in both GPT fstabs, matching the MBR variant and the existing `/config`//`/data` entries. Build-independent, so OTA'd slots always mount `/boot`.

**Verified:** OTA'd the rebuilt image onto an rpi4's inactive slot it booted to multi-user, stayed reachable over the USB-gadget link, and committed cleanly (previously dropped to an emergency shell).

Refs: WDY-1768
