### PR TITLE
ci: upload wendyos-update (.wendy) OTA artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -737,8 +737,15 @@ jobs:
             ARGS+=(--bmap-file "$BMAP_FILE")
           fi
 
-          # Include Mender OTA artifact if the build produced one
-          OTA_FILE=$(find "$DEPLOY_DIR" -maxdepth 1 -name "wendyos-image-${MACHINE}*.mender" -print -quit 2>/dev/null || true)
+          # Include the OTA update artifact if the build produced one. A board
+          # runs either the Mender stack (.mender) or the wendyos-update stack
+          # (.wendy), never both — it is gated by WENDYOS_OTA — so both feed the
+          # same --ota-update slot / ota_update_path; the device's OTA client
+          # interprets the artifact. Neither extension is recompressed by the
+          # publisher (only .img/.wic/.sdimg are), so each uploads as-is.
+          OTA_FILE=$(find "$DEPLOY_DIR" -maxdepth 1 \
+            \( -name "wendyos-image-${MACHINE}*.mender" -o -name "wendyos-image-${MACHINE}*.wendy" \) \
+            -print -quit 2>/dev/null || true)
           if [[ -n "$OTA_FILE" ]]; then
             ARGS+=(--ota-update "$OTA_FILE")
           fi


### PR DESCRIPTION
## What

Teach the build/publish workflow to collect and upload the `.wendy` OTA artifact, not just `.mender`.

## Why

Boards on the wendyos-update OTA stack (`WENDYOS_OTA = "wendy"`: Raspberry Pi 3/4/5, Jetson Thor) already build a `.wendy` artifact (`classes/image_types_wendy.bbclass` → `wendyos-update pack`) into `build/tmp/deploy/images/<machine>/`. But the "Upload image and emit manifest entry" step only ran `find ... *.mender`, so the `.wendy` file was discarded with the runner — never uploaded, never recorded in any manifest.

## How

A board runs **either** the Mender stack **or** the wendyos-update stack, never both (gated by `WENDYOS_OTA`). So both artifacts feed the same `--ota-update` slot / `ota_update_path`; the device's OTA client interprets the artifact it receives.

The `find` now matches `.mender` **or** `.wendy`. The publisher (`tools/publisher`) needs **no change**: `compressFile` only recompresses `.img`/`.wic`/`.sdimg`, so `.wendy` uploads byte-for-byte like `.mender` today, including the storage-specific `nvme_ota_update_path` handling for RPi 5 sd vs nvme via `applyOTAUpdate`.

Resulting manifest entry for a wendy-stack board:
```json
"ota_update_path": "images/raspberry-pi-5/<version>/wendyos-image-...rootfs.wendy",
"ota_update_checksum": "...",
"ota_update_size_bytes": ...
```

## Validation

- `find` logic exercised across 4 cases: only-`.wendy`, only-`.mender`, neither (flag omitted), wrong-machine (not matched) — all correct.
- `build.yml` parses as YAML; no new actionlint findings in the edited block.

## Consumer follow-up

The device OTA client / wendy CLI (separate `wendyos-update` repo) must treat `ota_update_path` generically and not assume a `.mender` extension. If it currently branches on the extension, it needs to accept `.wendy` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)