### PR TITLE
feat(runtime): make crun the default OCI runtime

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -113,6 +113,18 @@ LICENSE_FLAGS_ACCEPTED += "commercial"
 # Add virtualization support for NVIDIA Container Toolkit
 DISTRO_FEATURES:append = " virtualization"
 
+# Add seccomp support. Required by the crun OCI runtime recipe
+# (REQUIRED_DISTRO_FEATURES = "systemd seccomp"); also enables seccomp
+# enforcement system-wide.
+DISTRO_FEATURES:append = " seccomp"
+
+# Use crun as the OCI container runtime instead of runc. crun is a fast,
+# low-memory C implementation and a drop-in for the runc CLI the
+# containerd-shim-runc-v2 shim invokes. The crun bbappend exposes it under the
+# "runc" binary name (update-alternatives) and RPROVIDES virtual-runc, so
+# containerd's ${VIRTUAL-RUNTIME_container_runtime} dependency resolves to crun.
+VIRTUAL-RUNTIME_container_runtime = "crun"
+
 # Add polkit for rtkit support (real-time audio priority)
 DISTRO_FEATURES:append = " polkit"
 

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -125,6 +125,13 @@ DISTRO_FEATURES:append = " seccomp"
 # containerd's ${VIRTUAL-RUNTIME_container_runtime} dependency resolves to crun.
 VIRTUAL-RUNTIME_container_runtime = "crun"
 
+# crun's bbappend declares PROVIDES += "virtual/runc". The default preferred
+# provider for that virtual is runc(-opencontainers), so without this override
+# bitbake skips the crun recipe ("PREFERRED_PROVIDER_virtual/runc set to runc,
+# not crun") and crun becomes unbuildable. Make crun win the selection so it
+# fully replaces runc as the build- and runtime-level OCI runtime.
+PREFERRED_PROVIDER_virtual/runc = "crun"
+
 # Add polkit for rtkit support (real-time audio priority)
 DISTRO_FEATURES:append = " polkit"
 

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -113,9 +113,9 @@ LICENSE_FLAGS_ACCEPTED += "commercial"
 # Add virtualization support for NVIDIA Container Toolkit
 DISTRO_FEATURES:append = " virtualization"
 
-# Add seccomp support. Required by the crun OCI runtime recipe
-# (REQUIRED_DISTRO_FEATURES = "systemd seccomp"); also enables seccomp
-# enforcement system-wide.
+# Add seccomp support. crun's PACKAGECONFIG enables its seccomp backend when
+# this DISTRO_FEATURE is present; it also enables seccomp enforcement
+# system-wide.
 DISTRO_FEATURES:append = " seccomp"
 
 # Use crun as the OCI container runtime instead of runc. crun is a fast,
@@ -124,6 +124,12 @@ DISTRO_FEATURES:append = " seccomp"
 # "runc" binary name (update-alternatives) and RPROVIDES virtual-runc, so
 # containerd's ${VIRTUAL-RUNTIME_container_runtime} dependency resolves to crun.
 VIRTUAL-RUNTIME_container_runtime = "crun"
+
+# meta-virtualization's scarthgap branch is frozen at crun v1.14.3 (2024-02-26).
+# recipes-containers/crun/crun_git.bb in this layer vendors the current release
+# (1.28.0, 2026-05-27); pin to it so bitbake picks it over the stale upstream
+# version. Update alongside that recipe when bumping crun.
+PREFERRED_VERSION_crun = "1.28.0+git"
 
 # crun's bbappend declares PROVIDES += "virtual/runc". The default preferred
 # provider for that virtual is runc(-opencontainers), so without this override

--- a/recipes-containers/crun/crun/0001-libocispec-correctly-parse-JSON-schema-references.patch
+++ b/recipes-containers/crun/crun/0001-libocispec-correctly-parse-JSON-schema-references.patch
@@ -1,0 +1,43 @@
+From 30ff5f092bc9799b7037f94fe415ae98f447013a Mon Sep 17 00:00:00 2001
+From: Bruce Ashfield <bruce.ashfield@gmail.com>
+Date: Fri, 17 Oct 2025 11:03:41 -0400
+Subject: [PATCH] libocispec: correctly parse JSON schema references
+
+The `generate.py` script was failing to parse JSON schema references that
+use a `#` to separate the file path from the fragment. The script was
+incorrectly splitting the reference at `#/`, which caused `FileNotFoundError`
+for local references (e.g. `#definitions/uint32`) and for references
+to other files (e.g. `config-solaris.json#/solaris`).
+
+This commit fixes the `splite_ref_name` function to correctly split the
+reference at the `#` character, and handles both local and remote
+references properly.
+
+Upstream-Status: Inappropriate [configuration specific]
+
+Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
+---
+ src/ocispec/generate.py | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/ocispec/generate.py b/src/ocispec/generate.py
+index 530d69d..75bed78 100755
+--- a/src/ocispec/generate.py
++++ b/src/ocispec/generate.py
+@@ -150,7 +150,12 @@ def splite_ref_name(ref):
+     Interface: None
+     History: 2019-06-17
+     """
+-    tmp_f, tmp_r = ref.split("#/") if '#/' in ref else (ref, "")
++    if '#' in ref:
++        parts = ref.split('#', 1)
++        tmp_f = parts[0]
++        tmp_r = parts[1].lstrip('/')
++    else:
++        tmp_f, tmp_r = ref, ""
+     return tmp_f, tmp_r
+ 
+ 
+-- 
+2.39.2
+

--- a/recipes-containers/crun/crun/0002-libocispec-fix-array-items-parsing.patch
+++ b/recipes-containers/crun/crun/0002-libocispec-fix-array-items-parsing.patch
@@ -1,0 +1,31 @@
+From: Bruce Ashfield <bruce.ashfield@gmail.com>
+Date: Fri, 17 Oct 2025 12:00:00 -0400
+Subject: [PATCH] libocispec: fix array items parsing
+
+The `generate.py` script fails when an array's `items` property is an
+array of schemas, which is valid according to the JSON schema spec.
+This commit adds a check to handle this case by using the first schema
+in the array.
+
+Upstream-Status: Inappropriate [configuration specific]
+
+Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
+
+---
+ src/ocispec/generate.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/ocispec/generate.py b/src/ocispec/generate.py
+--- a/src/ocispec/generate.py
++++ b/src/ocispec/generate.py
+@@ -423,6 +423,10 @@
+     History: 2019-06-17
+     """
+     cur = node_info.cur
++
++    if isinstance(cur["items"], list):
++        # If items is a list, use the first element as the item schema.
++        cur["items"] = cur["items"][0]
+ 
+     if 'allOf' in cur["items"]:
+         return gen_all_arr_typnode(node_info, src, typ, refname)

--- a/recipes-containers/crun/crun_%.bbappend
+++ b/recipes-containers/crun/crun_%.bbappend
@@ -1,0 +1,21 @@
+# Make crun a drop-in replacement for runc on WendyOS.
+#
+# The base crun recipe (meta-virtualization) installs only /usr/bin/crun. To
+# replace runc system-wide we need crun to:
+#   1. Satisfy the virtual-runc dependency that containerd-opencontainers pulls
+#      in via ${VIRTUAL-RUNTIME_container_runtime}.
+#   2. Be reachable under the "runc" binary name, since containerd-shim-runc-v2
+#      (and nerdctl / ctr) exec a binary literally named "runc" by default.
+
+# Resolve containerd's RDEPENDS on virtual-runc to crun.
+RPROVIDES:${PN} += "virtual-runc"
+PROVIDES += "virtual/runc"
+
+# Expose crun under the "runc" name via update-alternatives so /usr/bin/runc
+# resolves to crun for every consumer. Using alternatives (rather than a bare
+# symlink) keeps the swap clean if runc-opencontainers is ever reintroduced.
+inherit update-alternatives
+ALTERNATIVE_PRIORITY = "100"
+ALTERNATIVE:${PN} = "runc"
+ALTERNATIVE_LINK_NAME[runc] = "${bindir}/runc"
+ALTERNATIVE_TARGET[runc] = "${bindir}/crun"

--- a/recipes-containers/crun/crun_git.bb
+++ b/recipes-containers/crun/crun_git.bb
@@ -1,0 +1,80 @@
+DESCRIPTION = "A fast and low-memory footprint OCI Container Runtime fully written in C."
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+PRIORITY = "optional"
+
+# Vendored from meta-virtualization master (crun 1.28.0, 2026-05-27) because the
+# scarthgap branch of meta-virtualization is frozen at crun v1.14.3 (2024-02-26).
+# Shipping a ~2-year-old runtime as WendyOS's default OCI runtime is undesirable,
+# so we pin the current release here and select it via PREFERRED_VERSION_crun in
+# conf/distro/wendyos.conf. Revisit on the next meta-virtualization SRCREV bump:
+# if upstream scarthgap gains a comparable crun, drop this recipe and its patches.
+SRCREV_crun = "7e45b26ba9524290af70ffe645911f7e032d6913"
+SRCREV_libocispec = "8034d0ecd27f646ba3ffae5ff24db234ce062825"
+SRCREV_ispec = "13cff54902ec9ad6320cbc487a685b66fcd67171"
+SRCREV_rspec = "6999a89a76a0329f440d5740497bedb9dd431297"
+SRCREV_yajl = "f344d21280c3e4094919fd318bc5ce75da91fc06"
+
+SRCREV_FORMAT = "crun_rspec"
+# Use literal "git" destsuffixes and an explicit S (scarthgap style) rather than
+# master's ${BB_GIT_DEFAULT_DESTSUFFIX} so this parses cleanly on scarthgap.
+SRC_URI = "git://github.com/containers/crun.git;branch=main;name=crun;protocol=https \
+           git://github.com/containers/libocispec.git;branch=main;name=libocispec;destsuffix=git/libocispec;protocol=https \
+           git://github.com/opencontainers/runtime-spec.git;branch=main;name=rspec;destsuffix=git/libocispec/runtime-spec;protocol=https \
+           git://github.com/opencontainers/image-spec.git;branch=main;name=ispec;destsuffix=git/libocispec/image-spec;protocol=https \
+           git://github.com/containers/yajl.git;branch=main;name=yajl;destsuffix=git/libocispec/yajl;protocol=https \
+           file://0001-libocispec-correctly-parse-JSON-schema-references.patch;patchdir=libocispec \
+           file://0002-libocispec-fix-array-items-parsing.patch;patchdir=libocispec \
+          "
+
+PV = "1.28.0+git"
+S = "${WORKDIR}/git"
+
+inherit autotools-brokensep pkgconfig features_check
+
+# crun ships a GNUmakefile that aborts if ./configure hasn't run yet,
+# which breaks autotools_preconfigure's "make clean" on rebuild.
+CLEANBROKEN = "1"
+
+# WendyOS exposes crun under the "runc" name via update-alternatives in
+# crun_%.bbappend (RPROVIDES virtual-runc, PROVIDES virtual/runc). Disable the
+# recipe's own bare crun->runc symlink so it does not collide with the
+# alternatives-managed ${bindir}/runc link.
+CRUN_AS_RUNC = ""
+
+PACKAGECONFIG ??= " \
+    caps external-yajl man \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seccomp', 'seccomp', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)} \
+"
+
+PACKAGECONFIG[caps] = "--enable-caps,--disable-caps,libcap"
+PACKAGECONFIG[external-yajl] = "--disable-embedded-yajl,--enable-embedded-yajl,yajl"
+# whether to regenerate manpages that are already present in the repo
+PACKAGECONFIG[man] = ",,go-md2man-native"
+PACKAGECONFIG[seccomp] = "--enable-seccomp,--disable-seccomp,libseccomp"
+PACKAGECONFIG[systemd] = "--enable-systemd,--disable-systemd,systemd"
+
+DEPENDS = "m4-native json-c"
+DEPENDS:append:libc-musl = " argp-standalone"
+
+do_configure:prepend () {
+    # extracted from autogen.sh in crun source. This avoids
+    # git submodule fetching.
+    mkdir -p m4
+    autoreconf -fi
+}
+
+do_install() {
+    oe_runmake 'DESTDIR=${D}' install
+    if [ -n "${CRUN_AS_RUNC}" ]; then
+        ln -sr "${D}/${bindir}/crun" "${D}${bindir}/runc"
+    fi
+}
+
+# When crun provides /usr/bin/runc symlink, it conflicts with the runc package
+RCONFLICTS:${PN} = "${@'runc' if d.getVar('CRUN_AS_RUNC') else ''}"
+
+REQUIRED_DISTRO_FEATURES:class-native ?= ""
+DEPENDS:class-native += "yajl libcap go-md2man m4 libseccomp"
+BBCLASSEXTEND = "native"

--- a/recipes-containers/crun/crun_git.bb
+++ b/recipes-containers/crun/crun_git.bb
@@ -16,19 +16,37 @@ SRCREV_rspec = "6999a89a76a0329f440d5740497bedb9dd431297"
 SRCREV_yajl = "f344d21280c3e4094919fd318bc5ce75da91fc06"
 
 SRCREV_FORMAT = "crun_rspec"
-# Use literal "git" destsuffixes and an explicit S (scarthgap style) rather than
-# master's ${BB_GIT_DEFAULT_DESTSUFFIX} so this parses cleanly on scarthgap.
+# Nest the vendored sub-repos under the crun git checkout via
+# ${BB_GIT_DEFAULT_DESTSUFFIX} (upstream master's form). On blacksail
+# bitbake.conf sets it to "${BP}" and the crun repo unpacks there; on scarthgap
+# the older fetcher ignores the variable and unpacks crun to "git", so the
+# BB_GIT_DEFAULT_DESTSUFFIX ?= "git" fallback below resolves these destsuffixes
+# to the same "git/libocispec..." tree. S is handled tree-aware below.
+BB_GIT_DEFAULT_DESTSUFFIX ?= "git"
 SRC_URI = "git://github.com/containers/crun.git;branch=main;name=crun;protocol=https \
-           git://github.com/containers/libocispec.git;branch=main;name=libocispec;destsuffix=git/libocispec;protocol=https \
-           git://github.com/opencontainers/runtime-spec.git;branch=main;name=rspec;destsuffix=git/libocispec/runtime-spec;protocol=https \
-           git://github.com/opencontainers/image-spec.git;branch=main;name=ispec;destsuffix=git/libocispec/image-spec;protocol=https \
-           git://github.com/containers/yajl.git;branch=main;name=yajl;destsuffix=git/libocispec/yajl;protocol=https \
+           git://github.com/containers/libocispec.git;branch=main;name=libocispec;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/libocispec;protocol=https \
+           git://github.com/opencontainers/runtime-spec.git;branch=main;name=rspec;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/libocispec/runtime-spec;protocol=https \
+           git://github.com/opencontainers/image-spec.git;branch=main;name=ispec;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/libocispec/image-spec;protocol=https \
+           git://github.com/containers/yajl.git;branch=main;name=yajl;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/libocispec/yajl;protocol=https \
            file://0001-libocispec-correctly-parse-JSON-schema-references.patch;patchdir=libocispec \
            file://0002-libocispec-fix-array-items-parsing.patch;patchdir=libocispec \
           "
 
 PV = "1.28.0+git"
-S = "${WORKDIR}/git"
+
+# Source dir for the git fetch — tree-dependent (see libpisp for the same split):
+#   - blacksail+: leave S unset. bitbake.conf defaults it to ${UNPACKDIR}/${BP}
+#     and BB_GIT_DEFAULT_DESTSUFFIX to ${BP}, so the crun checkout lands exactly
+#     there. Do NOT set S to anything mentioning WORKDIR — newer oe-core's
+#     do_qa_unpack fatals on S = "${WORKDIR}/git" (and on any "${WORKDIR}" in S),
+#     and it scans the raw S string, so even an unused branch would trip it.
+#   - scarthgap: the older fetcher unpacks crun to ${WORKDIR}/git and its default
+#     S doesn't point there, so set it (no such check on scarthgap). Setting it
+#     from anonymous python keeps the WORKDIR token out of S on blacksail.
+python () {
+    if 'scarthgap' in (d.getVar('LAYERSERIES_CORENAMES') or '').split():
+        d.setVar('S', '${WORKDIR}/git')
+}
 
 inherit autotools-brokensep pkgconfig features_check
 

--- a/recipes-core/packagegroups/packagegroup-wendyos-container.bb
+++ b/recipes-core/packagegroups/packagegroup-wendyos-container.bb
@@ -8,7 +8,7 @@ inherit packagegroup
 # Core container runtime packages
 RDEPENDS:${PN} = " \
     containerd-opencontainers \
-    runc-opencontainers \
+    crun \
     cni \
     cni-config \
     iptables \


### PR DESCRIPTION
## What

Replace **runc** with **crun** ([containers/crun](https://github.com/containers/crun)) as the default OCI runtime for all boards built via wendyos-builder (Jetson, RPi, QEMU; `DISTRO=wendyos`). crun is a fast, low-memory C implementation of the OCI runtime spec and a drop-in for the runc CLI that `containerd-shim-runc-v2` invokes.

## Why it's a clean swap

- The shim (`containerd-shim-runc-v2`) is a generic OCI shim — "runc" is just legacy naming. It execs a binary named `runc`; we point that name at crun.
- **GPU is unaffected.** On Jetson the agent injects NVIDIA CDI device/mount/env edits into the OCI spec *before* containerd sees it (`applyCDIGPU`), so any compliant runtime honors them — crun included. No runtime↔GPU coupling.
- The agent pins no runtime when creating containers, so this is config/packaging only — **no Go changes**.

## Changes (all Yocto)

- `conf/distro/wendyos.conf`: add `seccomp` to `DISTRO_FEATURES` (required by the crun recipe's `features_check`; also enables seccomp enforcement) and set `VIRTUAL-RUNTIME_container_runtime = "crun"`.
- `recipes-containers/crun/crun_%.bbappend` *(new)*: `RPROVIDES virtual-runc` (resolves containerd's `${VIRTUAL-RUNTIME_container_runtime}` dep) and expose crun under the `runc` name via `update-alternatives`, so containerd / nerdctl / ctr all resolve to crun.
- `recipes-core/packagegroups/packagegroup-wendyos-container.bb`: `runc-opencontainers` → `crun`.

The crun recipe already ships in meta-virtualization (`recipes-containers/crun/crun_git.bb`, v1.14.3 + CVE-2025-24965 patch) — it was just never selected.

## Scope note

This covers all targets built through wendyos-builder (the unified `DISTRO=wendyos` build). The legacy standalone layers `meta-wendyos-rpi` / `meta-wendyos-virtual` (`edgeos-rpi`/`edgeos-vm` distros) do not inherit `wendyos.conf` and stay on runc — companion changes there were deferred.

## Verification

Not built locally (heavy). Relying on the **nightly build** to exercise it. On-device checks after nightly: `readlink -f /usr/bin/runc` → crun, run a container, and a CUDA workload on Jetson to confirm GPU via CDI under crun.

Design doc: `specs/2026-06-30-crun-default-runtime-design.md` (wendyos repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)