### PR TITLE
jetson-agx-thor: fix boot-loop from non-32768 ext4 blocks_per_group

### DIFF
--- a/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
@@ -68,5 +68,23 @@ IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INIT
 # slots are sized from the rootfs image by the auto-derived redundant layout.
 IMAGE_ROOTFS_SIZE = "16384"
 
+# Round the rootfs ext4 image up to a 128 MiB (== 32768 4K-block) multiple so
+# blocks_per_group is always 32768. NVIDIA's UEFI ext4 reader (EDK2 Ext4Pkg
+# Ext4Dxe, Superblock.c) rejects any filesystem with blocks_per_group !=
+# 8*blocksize (32768 for 4K blocks) with EFI_UNSUPPORTED, so L4TLauncher then
+# cannot read /boot/extlinux/extlinux.conf and the board boot-loops. The rootfs
+# is content-sized (IMAGE_ROOTFS_SIZE above is only a ~16 MiB floor, so du x
+# IMAGE_OVERHEAD_FACTOR wins), and its block count occasionally lands just past a
+# 32768-block boundary, where mke2fs shrinks blocks_per_group (runt-group
+# avoidance, e.g. to 32736) even if "-g 32768" is passed. Aligning the image size
+# up to a 32768-block multiple leaves a full final group, so mke2fs keeps 32768.
+# Scoped to pn-wendyos-image only: a machine-wide alignment also rounds the ESP
+# image (tegra-espimage) up past its 64 MiB IMAGE_ROOTFS_MAXSIZE and fails the
+# build. IMAGE_ROOTFS_ALIGNMENT (KiB) also feeds TEGRA_BLBLOCKSIZE, so pin the
+# latter (for this image) to its current 4 KiB value so mksparse / the flash
+# helper are unchanged.
+IMAGE_ROOTFS_ALIGNMENT:pn-wendyos-image = "131072"
+TEGRA_BLBLOCKSIZE:pn-wendyos-image = "4096"
+
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "jetson-agx-thor"

--- a/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-agx-thor-devkit-nvme-wendyos.conf
@@ -60,12 +60,15 @@ IMAGE_FSTYPES:tegra = "tegraflash-tar"
 IMAGE_FSTYPES:pn-tegra-minimal-initramfs:tegra = "${INITRAMFS_FSTYPES}"
 IMAGE_FSTYPES:pn-tegra-initrd-flash-initramfs:tegra = "${TEGRA_INITRD_FLASH_INITRAMFS_FSTYPES}"
 
-# Root filesystem image size (MB). Overrides the 8192 (8GB) default from
-# recipes-core/images/wendyos-image.bb. Thor runs the wendyos-update OTA
-# stack (WENDYOS_OTA = "wendy"), so the Mender-only flash-image-sizes.inc
-# sizing path does not apply here — without this override Thor would inherit
-# the 8GB default, which is tight once more features land. The two A/B rootfs
-# slots are sized from the rootfs image by the auto-derived redundant layout.
+# Minimum rootfs size, in KiB — get_rootfs_size() in oe-core image.bbclass
+# compares this against du(rootfs)/1024 (KiB), and oe_mkext234fs writes the image
+# with `dd ... bs=1024`. This raises the wendyos-image.bb default of 8192 KiB
+# (8 MiB) to 16384 KiB (16 MiB). Both are floors far below the real content, so
+# the rootfs is effectively content-sized (du * IMAGE_OVERHEAD_FACTOR dominates);
+# this does NOT pin a fixed image size. Thor runs the wendyos-update OTA stack
+# (WENDYOS_OTA = "wendy"), not Mender, so the Mender flash-image-sizes.inc path
+# does not apply. The two A/B rootfs slots are sized from the rootfs image by the
+# auto-derived redundant layout.
 IMAGE_ROOTFS_SIZE = "16384"
 
 # Round the rootfs ext4 image up to a 128 MiB (== 32768 4K-block) multiple so


### PR DESCRIPTION
Some Thor nightly builds boot-loop and drop to the UEFI shell with L4TLauncher reporting `Failed to open boot\extlinux\extlinux.conf: Not Found`.

This happens because rootfs ext4 is occasionally formatted with `blocks_per_group != 32768`, which NVIDIA's UEFI ext4 driver refuses to mount:

https://github.com/NVIDIA/edk2-platforms/blob/769396d8912cda9db3554b27ba943254e8119024/Features/Ext4Pkg/Ext4Dxe/Superblock.c#L258-L261

From the outside this occurs "randomly" but it's a deterministic function of `mke2fs` to tweak this downward when the total size of the image will result in a tiny trailing group.

**Fix:** Force rootfs size alignment so it is always readable by this ext4 driver. Also fixes nearby comments about which units are in use.

This has been tested by creating local WendyOS builds where the only difference is `blocks_per_group`: 32768 vs 32736. When it's 32768 the Thor boots normally; the other causes the boot loop.