### PR TITLE
home.mount: create the /data/home bind source (x-systemd.mkdir)

### DIFF
--- a/recipes-core/systemd-mount-home/files/home.mount
+++ b/recipes-core/systemd-mount-home/files/home.mount
@@ -13,7 +13,14 @@ Before=local-fs.target
 What=/data/home
 Where=/home
 Type=none
-Options=bind
+# x-systemd.mkdir creates the /data/home bind source before mounting. On a
+# freshly initialised /data (first boot, or after data-init reinitialises a
+# bad fs) the source does not exist yet, and a bind mount of a missing source
+# fails — leaving /home as the empty rootfs skeleton and breaking the wendy
+# user's persistent home (and, via linger, user@1000.service). Every other
+# /data bind mount (var-lib-containerd, var-lib-tee, var-lib-wendy, var-log)
+# already uses this; home.mount was the lone exception.
+Options=bind,x-systemd.mkdir
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
## Problem

`home.mount` bind-mounts `/data/home` → `/home`, but **nothing creates
`/data/home` before it**. On a freshly initialised `/data` (first boot, or after
`wendyos-data-init` reinitialises a fs that failed validation) the source
directory doesn't exist, and a bind mount of a missing source fails.

The fallout cascades:
- `/home` stays the empty rootfs skeleton (`useradd -m`), so the `wendy` user has
  no persistent home;
- `wendyos-user-setup.sh` enables **linger** for `wendy`, so `user@1000.service`
  is auto-started early on every boot — and comes up against the broken home →
  **"Failed to start User Manager for UID 1000"**.

Observed on a jetson-orin-nano reboot-looping during an OTA, where each failed
boot reinitialises `/data` and re-hits the missing source.

## Fix

Add `x-systemd.mkdir` to `home.mount`'s options so the `/data/home` source is
created before the bind. **Every other `/data` bind mount already does this** —
`var-lib-containerd`, `var-lib-tee`, `var-lib-wendy`, `var-log` — and nothing
else in the tree creates their `/data/*` sources, which is exactly how they
survive a fresh-`/data` first boot. `home.mount` was the lone exception.

## Note

This fixes the definite fresh-`/data` failure mode. If a device still logs the
`user@1000` failure with `/home` correctly mounted, `systemctl status
user@1000.service` / `journalctl -b -u user@1000.service` on that device will
show the residual cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVh91Kk9oxPbYpnhdNPPh
