### PR TITLE
ci(jetson): scope NVMe image + flash-work per MACHINE to stop cross-board image bleed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -647,7 +647,13 @@ jobs:
           MACHINE: ${{ steps.vars.outputs.machine }}
           STORAGE: ${{ matrix.storage }}
         run: |
-          FLASH_WORKDIR="$GITHUB_WORKSPACE/flash-work"
+          # Per-MACHINE, freshly wiped staging dir. A fixed shared path
+          # ($GITHUB_WORKSPACE/flash-work) on persistent snapshot runners with no
+          # cleanup let one Jetson's extracted tegraflash-tar leak into the next
+          # build, so an AGX image could be assembled and shipped under the Orin
+          # Nano key. Scope by MACHINE and wipe so every build starts clean.
+          FLASH_WORKDIR="$GITHUB_WORKSPACE/flash-work/${MACHINE}"
+          rm -rf "$FLASH_WORKDIR"
           mkdir -p "$FLASH_WORKDIR"
 
           # All Jetsons run the wendy/blacksail OTA stack (WENDYOS_OTA=wendy):
@@ -666,9 +672,14 @@ jobs:
           # type="sdcard"> block, not external-flash.xml.in, and the blacksail
           # bundle no longer ships dosdcard.sh to build it). For those the
           # tegraflash-tar bundle itself is the flash artifact — nothing to do.
+          # Write the offline NVMe image into the MACHINE-scoped deploy dir, not a
+          # fixed workspace path, so the upload step can never pick up another
+          # Jetson's image. Remove any prior copy first.
+          NVME_IMG="$DEPLOY_DIR/wendyos-image-${MACHINE}-nvme.img"
+          rm -f "$NVME_IMG"
           if [[ -f "$FLASH_WORKDIR/external-flash.xml.in" && "$DEVICE" != "jetson-agx-thor" ]]; then
             python3 "$GITHUB_WORKSPACE/wendyos/scripts/make-thor-nvme-img.py" \
-              "$FLASH_WORKDIR" "$GITHUB_WORKSPACE/wendyos-nvme.img"
+              "$FLASH_WORKDIR" "$NVME_IMG"
           else
             echo "No offline NVMe image for $DEVICE (storage=$STORAGE); the tegraflash-tar is the flash artifact."
           fi
@@ -680,9 +691,10 @@ jobs:
         if: github.event_name != 'pull_request' && matrix.device == 'jetson-agx-thor'
         env:
           UPLOAD_VERSION: ${{ needs.detect-changes.outputs.version }}
+          MACHINE: ${{ steps.vars.outputs.machine }}
         run: |
           set -euo pipefail
-          FLASH_WORKDIR="$GITHUB_WORKSPACE/flash-work"   # extracted tegraflash-tar from the previous step
+          FLASH_WORKDIR="$GITHUB_WORKSPACE/flash-work/${MACHINE}"   # MACHINE-scoped, matches the generate step
           sudo dpkg --add-architecture i386
           sudo apt-get update -qq
           sudo apt-get install -y -qq libc6:i386 libstdc++6:i386 zlib1g:i386 device-tree-compiler zstd
@@ -714,9 +726,14 @@ jobs:
 
           BMAP_FILE=""
           if [[ "$MACHINE" != raspberry* && "$STORAGE" == "nvme" && "$DEVICE" != "jetson-agx-thor" ]]; then
-            # wendyos-nvme.img: built from the tegraflash-tar bundle by
-            # make-thor-nvme-img.py.
-            IMAGE_FILE="$GITHUB_WORKSPACE/wendyos-nvme.img"
+            # MACHINE-scoped image written by the generate step (never a fixed
+            # shared path). Fail hard if this run did not produce it, rather than
+            # uploading a stale image left behind by another Jetson build.
+            IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}-nvme.img"
+            if [[ ! -f "$IMAGE_FILE" ]]; then
+              echo "::error::NVMe image not produced this run for ${DEVICE} (${MACHINE}): ${IMAGE_FILE} missing. Refusing to upload a possibly-stale image." >&2
+              exit 1
+            fi
             bmaptool create "$IMAGE_FILE" > "${IMAGE_FILE}.bmap"
             BMAP_FILE="${IMAGE_FILE}.bmap"
           elif [[ "$MACHINE" != raspberry* && ( "$STORAGE" == "emmc" || "$DEVICE" == "jetson-agx-thor" ) ]]; then


### PR DESCRIPTION
## Summary

The offline Jetson **NVMe `.img`** — the artifact `wendy install` bmap-writes to a drive (attach NVMe over USB → provision → return to device) — is assembled at **fixed, non-machine-scoped workspace paths** with no cleanup, so on our persistent snapshot runners one Jetson's image can be published under another Jetson's key. Because every `.img` is uploaded under the generic name `wendyos-nvme.img.zip`, the wrong bytes are invisible in the manifest and filename.

Net effect: an **AGX Orin image was shipped under `jetson-orin-nano`**, flashing the AGX device tree onto Orin Nano hardware.

## How we found it

A device (`wendyos-attic`, an Orin Nano Super) booted with:
- `Machine model: NVIDIA Jetson AGX Orin Developer Kit` while SMBIOS said `Jetson Orin Nano … Super`
- `dce: DCE ucode abort`, then ~62s of stacked DCE timeouts → `RmInitAdapter failed` (dead GPU)
- BPMP I2C sensor probe failures (`ina3221`/`lm90`/`nvvrs11`), i.e. wrong carrier-board DT

The user **selected Orin Nano** in `wendy install`, so this was not operator error. Tracing the pipeline:
- **Publisher/CLI code is correct** — board keys map cleanly; the `jetson-orin-nano` manifest points at `images/jetson-orin-nano/…/wendyos-nvme.img.zip`.
- **CI build is the break:** the `.img` is built at `\$GITHUB_WORKSPACE/wendyos-nvme.img` and staged in `\$GITHUB_WORKSPACE/flash-work` — both fixed paths, never cleaned, on `runs-on/snapshot` runners whose build tree persists across jobs. A stale AGX `wendyos-nvme.img` (or a contaminated `flash-work`) gets uploaded under `--device jetson-orin-nano`.

## Fix

- **`flash-work`**: scope per `MACHINE` and `rm -rf` before extract, in both the *Generate flashable image* and *Build Thor flashpack* steps (added `MACHINE` to the latter's env).
- **NVMe `.img`**: write into the `MACHINE`-scoped `DEPLOY_DIR` as `wendyos-image-${MACHINE}-nvme.img`; remove any prior copy first.
- **Upload**: read that `MACHINE`-scoped path and **fail hard** if this run didn't produce it, instead of silently uploading a stale image.

## Not affected

`.wendy`/`.mender` OTA, the tegraflash recovery bundle, RPi `.sdimg`/`.wic`, and the SBOM are all read from the `MACHINE`-scoped `DEPLOY_DIR` (the `.wendy`/`.mender` glob is additionally scoped to `wendyos-image-${MACHINE}*`). Verified during the audit.

## Remediation for already-published images

This prevents recurrence but does not rewrite bad artifacts already in GCS. The currently-published `jetson-orin-nano` `.img` should be **re-verified / rebuilt** (its bytes may be AGX) before trusting it, and affected devices reflashed.

## Follow-ups (not in this PR)

- The *Generate* step references `\$DEVICE`, which isn't in that step's `env`, so it's empty there — harmless today but worth tidying.
- Consider a build-time **content assertion** (verify the produced image's extlinux FDT / DTB matches `MACHINE`) as defense-in-depth — that would catch any future mismatch loudly regardless of cause.

## Test plan

- [ ] Trigger a build; confirm `jetson-orin-nano` and `jetson-agx-orin` NVMe jobs each write/upload their own `wendyos-image-<machine>-nvme.img`.
- [ ] Confirm the upload step fails loudly if the NVMe image is absent.
- [ ] Download the new `jetson-orin-nano` `.img`, confirm it carries `tegra234-p3768-0000+p3767-0005-nv-super.dtb`, flash an Orin Nano, confirm fast boot + working GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)