### PR TITLE
wendyos-update: bump SRCREV to main (tegra slot confirm) for nightly

### DIFF
--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -24,14 +24,21 @@ GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 GO_SRCURI_DESTSUFFIX ?= "${@os.path.join(os.path.basename(d.getVar('S')), 'src', d.getVar('GO_IMPORT')) + '/'}"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
+# 627463ef (main, PR #4): tegrauefi MarkGood now confirms the booted slot with
+# `nvbootctrl -t rootfs mark-boot-successful`. WendyOS does not ship NVIDIA's
+# nv_update_verifier.service, so nothing was confirming a healthy boot — the
+# Tegra A/B trial never completed, so a slot that dies before userspace stayed
+# active instead of the firmware falling back (hard brick). This closes the
+# confirm half of the trial cycle (RPi already disarms its U-Boot trial in
+# MarkGood). Builds on:
 # 8bba71c6: ubootenv refuses a slot swap when /boot is not a mountpoint, so the
 # trial arm can no longer silently no-op against a shadow uboot.env on the rootfs
-# (pairs with the /boot-by-LABEL + nofail fstab change, WDY-1768). Builds on
+# (pairs with the /boot-by-LABEL + nofail fstab change, WDY-1768).
 # 16614b4b: WDY-1742 verify-boot fix (BootIsCompromised checks only the booted
 # slot — kills the Orin Nano stale-inactive-slot false-positive, validated
 # against the real r39.2 efivar format) + structured per-slot `status` and the
 # `switch` verb.
-SRCREV = "8bba71c67152a717c300ffffca445bef276a09dd"
+SRCREV = "627463ef30ca7f8251475560c83fd90cdb21ee16"
 
 inherit go-mod systemd
 


### PR DESCRIPTION
## What

Bump the `wendyos-update` recipe `SRCREV` from `8bba71c` to `627463ef`
(wendyos-update `main`, incl. PR #4) so the **nightly build** picks up the
Tegra A/B fix.

## Why

`627463ef` adds `nvbootctrl -t rootfs mark-boot-successful` to `tegrauefi.MarkGood()`
— the trial-boot **confirm** step. It had been delegated to NVIDIA's
`nv_update_verifier.service`, which this image does **not** ship, so nothing
ever confirmed a healthy boot. The result: a slot that dies before userspace
(bad kernel/DTB, NVMe/PCIe that never enumerates) stayed active forever instead
of the firmware reverting to the previous slot — a hard brick, seen on both a
Jetson Orin Nano and a Thor after OTA. The confirm closes the trial cycle (RPi
already disarms its U-Boot trial in `MarkGood`).

Nightly = `build.yml` on `main`, so merging this bumps the updater in the next
nightly.

## ⚠️ Still needs on-device verification

This is the tool half. It relies on the firmware actually decrementing
`retry_count` and falling back at 0 — the rootfs-redundancy layout is enabled on
all Jetson boards (`USE_REDUNDANT_FLASH_LAYOUT_DEFAULT=1`), but end-to-end
fallback could not be verified without hardware access. Validate on a nightly
image: arm a trial into a slot that never confirms, reboot, confirm the firmware
reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVh91Kk9oxPbYpnhdNPPh
