### PR TITLE
fix(rpi5): keep rc4 U-Boot fleet-wide, compile out the SD preboot PCIe hang

### DIFF
--- a/meta-rpi-extensions/recipes-bsp/u-boot/files/rpi5-bootdelay.cfg
+++ b/meta-rpi-extensions/recipes-bsp/u-boot/files/rpi5-bootdelay.cfg
@@ -3,10 +3,12 @@
 # Stock rpi_arm64 runs a 2s countdown that polls stdin for an abort key. On
 # BCM2712 that poll wedges the board hard at the U-Boot logo before the banner
 # ever prints -- a known upstream symptom on RPi5 across 2024.04/2025.04/master
-# (forums.raspberrypi.com t=387528), so it applies to the SD machine's stock
-# 2026.04 as much as the nvme machine's v2026.07-rc4 (see the bbappend). It is
-# the reason nightlies stopped booting on rpi5-sd while the Mender-based
-# 0.16.x images (whose U-Boot integration also sets BOOTDELAY=-2) boot fine.
+# (forums.raspberrypi.com t=387528), so it is NOT specific to the v2026.07-rc4
+# both rpi5 machines now run (see the bbappend). It is one of two wedges that
+# stopped nightlies booting on rpi5-sd while the Mender-based 0.16.x images
+# (whose U-Boot integration also sets BOOTDELAY=-2, verified in the 0.16.0
+# binary) boot fine; the other is rc4's live preboot `pci enum`, fixed for the
+# SD machine in sd-boot.cfg.
 #
 # -2 = autoboot immediately, no delay, no stdin check (-1 would DISABLE
 # autoboot and drop to the prompt). Trade-off: boot can no longer be

--- a/meta-rpi-extensions/recipes-bsp/u-boot/files/sd-boot.cfg
+++ b/meta-rpi-extensions/recipes-bsp/u-boot/files/sd-boot.cfg
@@ -1,0 +1,46 @@
+# SD-boot U-Boot config for the Raspberry Pi 5 (BCM2712), SD machine only.
+#
+# rpi_arm64_defconfig ships CONFIG_PREBOOT="pci enum; usb start;". Through
+# U-Boot v2025.04 that was a no-op on the Pi 5 (no BCM2712 PCIe driver), but
+# the v2026.07-rc4 bump (see the SRCREV in the bbappend) brought the brand-new
+# brcmstb/BCM2712 PCIe support, so `pci enum` now drives real hardware init on
+# every boot -- BEFORE autoboot ever reaches boot.scr. That driver hangs some
+# Pi 5 boards there: a fresh-flashed SD image dies in the firmware->U-Boot
+# window with no uboot.env written and boot.scr never executed (reproduced on
+# a CanaKit Pi 5 with nightly-20260701T190856; the same card boots fine when
+# config.txt chain-loads the kernel directly, bypassing U-Boot). Boards used
+# for the original rc4 SD validation boot fine, so the hang is board/EEPROM/
+# PCIe-link dependent. This is one of TWO independent Pi 5 boot wedges in the
+# window before boot.scr -- the other is the autoboot countdown's stdin poll,
+# fixed separately by rpi5-bootdelay.cfg (CONFIG_BOOTDELAY=-2, both rpi5
+# machines). Working 0.16.x images had neither wedge live: 2025.04's preboot
+# was inert and Mender shipped BOOTDELAY=-2.
+#
+# Downgrading to stock 2026.04 instead is NOT an option: it never booted a
+# Pi 5 SD in this repo (blacksail bring-up history, re-confirmed in the field
+# when PR #154 tried exactly that), so the fix is rc4 + these fragments.
+#
+# Compile preboot out entirely for the SD machine. Nothing SD boot needs is
+# lost:
+#   - the boot path is mmc-only (bootflow scan -> boot.scr -> ext4load from
+#     the rootfs slot); no PCIe involved.
+#   - `usb start` is dead weight on the Pi 5 without `pci enum` anyway: the
+#     USB-A ports sit behind the RP1 southbridge, which is itself a PCIe
+#     device. Headless devices have no U-Boot USB console use either.
+#   - Linux-side PCIe/NVMe access from the SD image (dtparam=pciex1 in
+#     config.txt, used for SSH-based NVMe flashing) is untouched: the kernel
+#     does its own PCIe bring-up regardless of U-Boot.
+#
+# Scope: applied via SRC_URI:append:raspberrypi5-wendyos (the exact MACHINE),
+# NOT :raspberrypi5 -- the NVMe machine's MACHINEOVERRIDES include
+# raspberrypi5, and NVMe boot REQUIRES its own PREBOOT ("pci enum; nvme scan;
+# usb start;" from nvme-boot.cfg, validated on hardware). RPi3/4 are separate
+# machines on U-Boot 2025.04 and never see this fragment. The deletable
+# rpi5-sd-scarthgap fallback shares this MACHINE name and would also get
+# preboot disabled -- harmless there (same mmc-only boot path).
+#
+# Remove once the BCM2712 PCIe driver hang is fixed upstream and a repinned
+# U-Boot has been re-validated on boards that exhibit the hang (not only on
+# the boards that already booted rc4).
+
+# CONFIG_USE_PREBOOT is not set

--- a/meta-rpi-extensions/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-rpi-extensions/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,21 +1,31 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-# === RPi5 (BCM2712) NVMe-over-U-Boot: v2026.07-rc4 + DMA patch, nvme only ===
+# === RPi5 (BCM2712): U-Boot v2026.07-rc4 fleet-wide + boot-wedge fixes ===
 #
-# RPi5 NVMe boot via U-Boot needs two things missing from oe-core v2026.04:
+# RPi5 U-Boot needs two things missing from oe-core v2026.04:
 #   1. the BCM2712 PCIe driver (brcm,bcm2712-pcie + bcm2712_cfg), mainline ~June
-#      2026, ships in v2026.07;
+#      2026, ships in v2026.07 -- required for NVMe boot;
 #   2. our drivers/nvme/nvme.c phys->bus DMA fix (files/0001-nvme-phys-to-bus.patch,
 #      not upstream): BCM2712 inbound dma-ranges maps PCIe bus 0x10_00000000 ->
 #      CPU 0x0, and stock nvme.c programs raw CPU phys, so nvme_init times out
 #      (-110). The patch translates every controller DMA address + recovers the
 #      DMA constraints. VALIDATED on hardware (SD-less NVMe boot + A/B OTA).
-# The rc4 bump is scoped to :raspberrypi5-nvme -- the ONLY machine that needs
-# PCIe in U-Boot. The SD machine boots from mmc and stays on the stock blacksail
-# oe-core U-Boot (2026.04): a fleet-wide :raspberrypi5 bump shipped an -rc
-# bootloader to boards that gained nothing from it, and forced rc4 onto the
-# wrong source for any raspberrypi5 machine on a non-2026.04 recipe (the old
-# CAVEAT re rpi5-*-scarthgap fallbacks -- resolved by this scoping).
+#
+# rc4 applies to the WHOLE rpi5 family (SD + NVMe), not just NVMe. PR #154
+# briefly scoped it to :raspberrypi5-nvme and returned the SD machine to stock
+# 2026.04, but 2026.04 never booted a Pi 5 SD in this repo (the original
+# blacksail bring-up could not boot until the rc4 bump, and the field report
+# after #154 merged was another dead board), so the scoping was reverted. rc4
+# is the only version bench-validated on Pi 5 here; its two known BOOT WEDGES
+# are fixed by config fragments instead of a downgrade:
+#   - sd-boot.cfg (SD machine only): compile out CONFIG_USE_PREBOOT. rc4's new
+#     BCM2712 PCIe driver made the stock preboot "pci enum; usb start;" live,
+#     and it hangs some boards (CanaKit Pi 5, fresh flash) before boot.scr.
+#     NVMe keeps its own required PREBOOT from nvme-boot.cfg.
+#   - rpi5-bootdelay.cfg (both machines, from #154): CONFIG_BOOTDELAY=-2. The
+#     autoboot countdown's stdin poll is a known Pi 5 wedge across U-Boot
+#     versions; Mender-based 0.16.x shipped -2 (verified in the 0.16.0 binary)
+#     and never hit it, nightlies shipped the default 2 and did.
 # See docs/docs-ext/rpi5-nvme.md.
 #
 # No gating needed beyond the machine overrides:
@@ -24,21 +34,34 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 #     the wildcard filename matches their recipe (NO dangling append -- a
 #     version-pinned u-boot_2026.04.bbappend would dangle on those builds).
 #
-# Repin rc4 -> v2026.07 stable when it ships (due ~early July 2026), and drop
-# the DMA patch once the BCM2712 NVMe fix is upstream. See
-# project_rpi_blacksail_migration_plan.
+# CAVEAT (restored with the fleet-wide rc4): a raspberrypi5 machine on a
+# U-Boot != 2026.04 recipe (the deletable rpi5-*-scarthgap fallback boards,
+# U-Boot 2025.04) would get rc4 forced onto the wrong source. Those boards are
+# NOT in the CI matrix; if one ever needs to build, move these overrides into
+# a blacksail-only include rather than gating here.
+#
+# Repin rc4 -> v2026.07 stable when it ships (due ~early July 2026), drop the
+# DMA patch once the BCM2712 NVMe fix is upstream, and re-evaluate sd-boot.cfg
+# once the PCIe-driver hang is fixed upstream (see that file's removal
+# condition). See project_rpi_blacksail_migration_plan.
 
-SRC_URI:raspberrypi5-nvme = "git://source.denx.de/u-boot/u-boot.git;protocol=https;branch=master"
-SRCREV:raspberrypi5-nvme = "1296a428c67cf103eca482d4a63349661c1b799f"
+SRC_URI:raspberrypi5 = "git://source.denx.de/u-boot/u-boot.git;protocol=https;branch=master"
+SRCREV:raspberrypi5 = "1296a428c67cf103eca482d4a63349661c1b799f"
 
 # Skip the autoboot countdown on BOTH rpi5 machines (raspberrypi5-nvme carries
 # the raspberrypi5 override). The countdown's stdin poll wedges BCM2712 hard at
-# the U-Boot logo before the banner prints; the symptom is reported upstream
-# across 2024.04/2025.04/master, so it is NOT rc4-specific -- the stock 2026.04
-# the SD machine now runs needs this as much as rc4 does. 0.16.x Mender images
-# boot because their U-Boot integration sets the same -2. See rpi5-bootdelay.cfg
-# for the trade-off (autoboot can no longer be interrupted from serial).
+# the U-Boot logo; the symptom is reported upstream across 2024.04/2025.04/
+# master, so it is NOT rc4-specific. 0.16.x Mender images boot because their
+# U-Boot integration sets the same -2. See rpi5-bootdelay.cfg for the
+# trade-off (autoboot can no longer be interrupted from serial).
 SRC_URI:append:raspberrypi5 = " file://rpi5-bootdelay.cfg"
+
+# SD machine only: compile out CONFIG_USE_PREBOOT ("pci enum; usb start;") --
+# the second Pi 5 boot wedge; see sd-boot.cfg for the full story + removal
+# condition. Scoped to the exact MACHINE, not :raspberrypi5: the NVMe
+# machine's MACHINEOVERRIDES include raspberrypi5, and NVMe boot needs its own
+# PREBOOT ("pci enum; nvme scan; ..." from nvme-boot.cfg).
+SRC_URI:append:raspberrypi5-wendyos = " file://sd-boot.cfg"
 
 SRC_URI:append:raspberrypi5-nvme = " \
     file://nvme-boot.cfg \


### PR DESCRIPTION
## Problem

Fresh-flashed `rpi5-sd` nightlies (since the blacksail migration, still broken after #154) die before Linux ever runs. Forensics on a flashed card (CanaKit Pi 5, `nightly-20260701T190856`, 128 GB SD) show the failure is in the firmware → U-Boot window:

- partition layout, GPT names, boot files, `boot.scr`, and the config-partition provisioning seed are all correct;
- `uboot.env` was never created — the **first** thing `boot.scr` does on a fresh flash is `saveenv`, so the boot script never executed even once;
- the `data` partition was never grown — first-boot services never ran;
- **bypass test:** the same card boots to a discoverable system when `config.txt` chain-loads the kernel directly (`kernel=Image` + `root=/dev/mmcblk0p3 rw`), proving kernel/rootfs/fstab/identity are all healthy and convicting the U-Boot stage.

## Root cause: two independent Pi 5 wedges, both live on nightlies, neither live on 0.16.x

Verified by comparing the flashed nightly U-Boot binary against the working 0.16.0 binary:

| | 0.16.x (works) | nightly rc4 (hangs) |
|---|---|---|
| preboot `pci enum` | inert — U-Boot 2025.04 has no BCM2712 PCIe driver | **live** — rc4's brand-new (June 2026, "still churning") driver runs before `boot.scr`, board/EEPROM/PCIe-link dependent |
| autoboot countdown | `bootdelay=-2` (Mender integration, verified in the 0.16.0 binary) | `bootdelay=2` — stdin poll is a known BCM2712 wedge across 2024.04/2025.04/master ([forum t=387528](https://forums.raspberrypi.com/viewtopic.php?t=387528)) |

This also explains why the original rc4 SD validation passed on one bench while other boards wedge: both hangs are hardware/setup-dependent.

## Changes

- **`sd-boot.cfg` (new, SD machine only):** compile out `CONFIG_USE_PREBOOT`. SD boot is mmc-only; `usb start` is dead weight on Pi 5 without `pci enum` (USB-A sits behind RP1, itself a PCIe device); Linux-side PCIe (`dtparam=pciex1`, NVMe-over-SSH flashing) is untouched. Scoped to the exact MACHINE `raspberrypi5-wendyos` — **not** `:raspberrypi5`, because the NVMe machine's `MACHINEOVERRIDES` include `raspberrypi5` and NVMe boot requires its own PREBOOT.
- **Keep #154's `rpi5-bootdelay.cfg`** (`CONFIG_BOOTDELAY=-2`, both rpi5 machines) — its diagnosis of the countdown wedge is confirmed by the binary comparison above.
- **Revert #154's rc4→nvme-only scoping** (`SRC_URI`/`SRCREV` back to `:raspberrypi5`): stock 2026.04 never booted a Pi 5 SD in this repo — the blacksail bring-up was stuck until the rc4 bump, #154 itself noted it was never hardware-validated, and the field report after #154 merged was another dead board. rc4 is the only bench-validated version; its wedges are fixed by the fragments instead of a downgrade. This restores the scarthgap-fallback CAVEAT in the bbappend.

## No-regression scope

- **rpi5-nvme:** behavior unchanged — rc4 + NVMe DMA patch + hardware-validated `PREBOOT="pci enum; nvme scan; usb start;"` from `nvme-boot.cfg`; additionally gains `BOOTDELAY=-2` (needs it for the same stdin-poll reason).
- **RPi3/4:** separate machines (`raspberrypi3-64-*`/`raspberrypi4-64-*`) on U-Boot 2025.04 via meta-lts-mixins; every override here is `raspberrypi5*`-scoped.
- Fragment mechanism: oe-core `u-boot-configure.inc` merges SRC_URI `.cfg` fragments via `merge_config.sh` (same path as the validated `nvme-boot.cfg`).

## Testing

- [ ] CI build of rpi5-sd + rpi5-nvme
- [ ] Hardware boot test on the CanaKit Pi 5 that reproduces the hang (fresh flash of the CI artifact)
- [ ] Hardware boot test on the #154 author's board (second known-failing sample)
- [ ] Regression: rpi5-nvme SD-less boot + A/B OTA (unchanged rc4 + patch + nvme-boot.cfg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)