### PR TITLE
wendyos-update: bump SRCREV (per-boot confirm — stops the Jetson watchdog reboot loop)

### DIFF
--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -24,13 +24,19 @@ GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 GO_SRCURI_DESTSUFFIX ?= "${@os.path.join(os.path.basename(d.getVar('S')), 'src', d.getVar('GO_IMPORT')) + '/'}"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
-# 627463ef (main, PR #4): tegrauefi MarkGood now confirms the booted slot with
-# `nvbootctrl -t rootfs mark-boot-successful`. WendyOS does not ship NVIDIA's
-# nv_update_verifier.service, so nothing was confirming a healthy boot — the
-# Tegra A/B trial never completed, so a slot that dies before userspace stayed
-# active instead of the firmware falling back (hard brick). This closes the
-# confirm half of the trial cycle (RPi already disarms its U-Boot trial in
-# MarkGood). Builds on:
+# 61c46bc4 (main, PR #5): the boot verifier confirms EVERY healthy boot to the
+# firmware (`nvbootctrl -t rootfs mark-boot-successful`, connector.BootConfirmer).
+# With rootfs A/B redundancy enabled, Jetson UEFI arms a boot-validation
+# watchdog on every boot and resets the SoC ~2 min into userspace unless the
+# boot is confirmed; stock L4T confirms from nv_update_verifier.service, which
+# this image does not ship. PR #4 confirmed only at commit, so ordinary boots
+# still watchdog-rebooted (observed right after "Starting Wendy Agent"),
+# burning firmware retries and flip-flopping slots. A boot the firmware
+# flagged unhealthy is deliberately NOT confirmed, so pre-userspace failures
+# still auto-fall-back. Builds on:
+# 627463ef (PR #4): tegrauefi MarkGood confirms the booted slot with
+# `nvbootctrl -t rootfs mark-boot-successful` at commit time — the trial-cycle
+# confirm half (RPi already disarms its U-Boot trial in MarkGood).
 # 8bba71c6: ubootenv refuses a slot swap when /boot is not a mountpoint, so the
 # trial arm can no longer silently no-op against a shadow uboot.env on the rootfs
 # (pairs with the /boot-by-LABEL + nofail fstab change, WDY-1768).
@@ -38,7 +44,7 @@ SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_
 # slot — kills the Orin Nano stale-inactive-slot false-positive, validated
 # against the real r39.2 efivar format) + structured per-slot `status` and the
 # `switch` verb.
-SRCREV = "627463ef30ca7f8251475560c83fd90cdb21ee16"
+SRCREV = "61c46bc157a2e89c633b1cf0faf257f2e535af5c"
 
 inherit go-mod systemd
 


### PR DESCRIPTION
## What

Bump the `wendyos-update` recipe `SRCREV` `627463ef` → `61c46bc1`
(wendyos-update `main`, incl. [PR #5](https://github.com/wendylabsinc/wendyos-update/pull/5))
so the next nightly ships the **per-boot firmware confirm**.

## Why

Jetson UEFI arms a boot-validation watchdog on **every** boot when rootfs A/B
redundancy is enabled (all our Jetson boards) and resets the SoC ~2 minutes
into userspace unless the boot is confirmed with
`nvbootctrl mark-boot-successful`. Stock L4T confirms via
`nv_update_verifier.service`, which this image does not ship. The previous bump
(#153, updater PR #4) confirmed only at **commit**, so ordinary boots still
watchdog-rebooted — observed on the current nightly as a reboot right after
"Starting Wendy Agent" — burning firmware retries and flip-flopping slots.

With PR #5 the early-boot verify unit confirms every healthy boot; a boot the
firmware flagged unhealthy is deliberately NOT confirmed, so a slot that dies
before userspace still burns its retries and UEFI falls back on its own.

## Verification on device

Flash the nightly and let it sit >5 minutes: the ~2-minute reboots should be
gone, and `nvbootctrl -t rootfs dump-slots-info` should show the running slot
back at full retry_count with status normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVh91Kk9oxPbYpnhdNPPh
