### PR TITLE
rpi5: build rootfs filesystem at 8 GiB (was ~1.1 GB)

### DIFF
--- a/conf/machine/raspberrypi5-wendyos.conf
+++ b/conf/machine/raspberrypi5-wendyos.conf
@@ -17,6 +17,17 @@ WENDYOS_OTA = "wendy"
 WKS_FILE = "rpi-wendy-ab.wks"
 IMAGE_FSTYPES:append = " wic"
 
+# Rootfs filesystem size (KiB). The default is content-sized (~1.1 GB via
+# du * IMAGE_OVERHEAD_FACTOR over the tiny IMAGE_ROOTFS_SIZE floor), which is
+# tight for on-device work. Build the ext4 to fill the A/B rootfs slot: each
+# rootfsA/rootfsB partition in rpi-wendy-ab.wks is 8192M, so size the
+# filesystem to a matching 8 GiB (block-aligned: 8388608 KiB = 2097152 x 4K
+# blocks). This is the FILESYSTEM size, not the partition; the A/B slots are
+# never grown at runtime (the fs is not resized to the partition on an A/B
+# image — see rpi-wendy-ab.wks), so it must be built at the target size here.
+# 8 GiB = 8 * 1024 * 1024 KiB.
+IMAGE_ROOTFS_SIZE = "8388608"
+
 # RPi5 has a dedicated USB-C peripheral controller (BCM2712 dwc2 at
 # /sys/class/udc/1000480000.usb, separate from the RP1 xHCI host ports
 # on USB-A). Enable gadget by default. See


### PR DESCRIPTION
## What
Set `IMAGE_ROOTFS_SIZE = "8388608"` (8 GiB) for `raspberrypi5-wendyos` so the RPi5 wendy-OTA rootfs ext4 is built at 8 GiB instead of content-sized (~1.1 GB, which is tight on-device).

## Why this is the right lever
The rootfs partition isn't the constraint — `rpi-wendy-ab.wks` already provisions each `rootfsA`/`rootfsB` A/B partition at `8192M`. The **filesystem** was being built content-sized and never grown to fill the slot (A/B images must not resize the rootfs at runtime). So the fix is the build-time filesystem size. 8 GiB is block-aligned (2097152 × 4K) and matches the 8192M slot exactly.

## Scope / safety
- Machine-scoped to `raspberrypi5-wendyos` — the Mender RPi3/4 path is untouched.
- Filesystem size only; no partition-layout change.

## Verification
Build-time change — not bitbake-verified locally. The **nightly** build of the RPi5 image is the verification: confirm the produced rootfs/`.wendy` artifact is ~8 GiB and the wic image builds cleanly into the 8192M slot. Takes effect on-device after a rebuild + reflash/OTA (the running A/B slot stays ~1.1 GB until it receives the new rootfs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)