### PR TITLE
image: no console login on monitor+keyboard unless WENDYOS_DEBUG

### DIFF
--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -37,6 +37,20 @@ WENDYOS_DEBUG_FEATURES ?= " \
     "
 IMAGE_FEATURES += "${@oe.utils.ifelse(d.getVar('WENDYOS_DEBUG') == '1', d.getVar('WENDYOS_DEBUG_FEATURES'), '')}"
 
+# No interactive login on an attached monitor+keyboard unless WENDYOS_DEBUG = "1".
+# systemd ships an enabled getty@tty1.service, and logind spawns further gettys
+# on VT switch (autovt@ttyN resolves to the getty@ template). Root is already
+# locked on release builds (no empty-root-password above), but the prompt itself
+# is still an attack surface on a product device, so drop the enablement symlink
+# and mask the template — masking getty@.service masks every instance, including
+# logind's autovt spawns. Serial consoles (serial-getty@, SERIAL_CONSOLES) are
+# deliberately untouched so UART access stays available for field debugging.
+disable_vt_login() {
+    rm -f ${IMAGE_ROOTFS}${sysconfdir}/systemd/system/getty.target.wants/getty@tty1.service
+    ln -sf /dev/null ${IMAGE_ROOTFS}${sysconfdir}/systemd/system/getty@.service
+}
+ROOTFS_POSTPROCESS_COMMAND += "${@oe.utils.ifelse(d.getVar('WENDYOS_DEBUG') == '1', '', 'disable_vt_login;')}"
+
 # Optional runtime package management (rpm/dnf in the rootfs).
 # Disabled by default — image is updated atomically via Mender A/B.
 # Set WENDYOS_ENABLE_PACKAGE_MANAGEMENT = "1" in local.conf or distro to enable.


### PR DESCRIPTION
## Summary

Release images (`WENDYOS_DEBUG != "1"`) no longer present a getty login prompt on an attached monitor+keyboard.

A `disable_vt_login` ROOTFS_POSTPROCESS step in `wendyos-image.bb`:
- removes the `getty.target.wants/getty@tty1.service` enablement symlink that oe-core's systemd recipe installs, and
- masks the `getty@.service` template, which masks every instance — including the `autovt@ttyN` gettys logind would otherwise spawn on VT switch (Ctrl+Alt+Fn).

Root is already locked on release builds (no `empty-root-password`; CI never sets `WENDYOS_DEBUG`), so the prompt was never a working login — but it is still an attack surface and looks unfinished on a product device.

Deliberately untouched:
- **Serial consoles** (`serial-getty@`, `SERIAL_CONSOLES`) — UART access stays available for field debugging.
- **Debug builds** (`bootstrap.sh --debug` → `WENDYOS_DEBUG = "1"`) keep the console login.

## Testing

- [ ] Boot a release-built image with HDMI + keyboard attached: no login prompt, no getty on Ctrl+Alt+F2.
- [ ] Serial console still shows a login prompt.
- [ ] `bootstrap.sh --debug` build still shows the tty1 login.

Unverified on hardware so far — needs a flashed release image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmNrQxFBxCwYtEJpWUKSkC