### PR TITLE
Bump version to 0.16.2

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -83,7 +83,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.16.1"
+DISTRO_VERSION = "0.16.2"
 # DISTRO_CODENAME is inherited from poky.conf (require'd above), which
 # sets it to the active oe-core series ("scarthgap", "wrynose", ...).
 # Don't override here or it gets stuck on a stale value across series.


### PR DESCRIPTION
0.16.1 was just released (promoted from `nightly-20260701T221005`, which carries the per-boot firmware confirm from #156 — fixes the Jetson UEFI boot-validation-watchdog reboot loop after `wendy os update`). Bump main so nightlies build as the next version; `promote.yml` requires `DISTRO_VERSION` at the promoted nightly to match the release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aNFWXEax9qHDA6CYmUK18