### PR TITLE
bootstrap: fetch SRCREV by SHA when not reachable via refs (+ ci build-image docs note)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -311,11 +311,21 @@ function clone_repos() {
         fi
 
         # we need to checkout (either new clone or update)
-        git checkout "${srcrev}" >> "${LOG_FILE}" 2>&1 || {
-            printf "[error] Failed to checkout %s in '%s'\n" "${srcrev}" "${folder}"
-            cd ..
-            return 1
-        }
+        if ! git checkout "${srcrev}" >> "${LOG_FILE}" 2>&1; then
+            # The SRCREV may not be reachable from any current branch tip — e.g.
+            # the upstream branch it lived on was deleted or force-pushed (as
+            # happened with meta-tegra's wip-l4t-r39.2.0 branch). A plain clone /
+            # `git fetch origin` only retrieves current refs, so the pinned
+            # commit is absent locally even though the object still exists on the
+            # server. Fetch it directly by SHA, then retry the checkout.
+            printf "[refetch] '%s': %s not reachable via refs; fetching by SHA\n" "${folder}" "${srcrev}"
+            if ! { git fetch origin "${srcrev}" >> "${LOG_FILE}" 2>&1 && \
+                   git checkout "${srcrev}" >> "${LOG_FILE}" 2>&1; }; then
+                printf "[error] Failed to checkout %s in '%s'\n" "${srcrev}" "${folder}"
+                cd ..
+                return 1
+            fi
+        fi
 
         cd ..
     done

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,26 @@
+# CI runner image — read before editing
+
+> **The CI build runner image is being migrated to `wendylabsinc/ci`.**
+> Make build-environment changes there, not here.
+
+WendyOS-Builder CI is moving from the AWS/RunsOn model (the custom AMI defined in
+this directory) to the self-hosted GitHub Actions platform in
+[`wendylabsinc/ci`](https://github.com/wendylabsinc/ci). On that platform the
+build runner is a **container image** defined by the tenant at
+`repositories/WendyOS-Builder/` (its `Dockerfile` + `install-build-deps.sh`).
+
+**Where changes to the "build image" go:**
+
+| Change | Make it in |
+|---|---|
+| Build-environment packages / toolchain (the runner image contents) | `wendylabsinc/ci` → `repositories/WendyOS-Builder/install-build-deps.sh` |
+| Runner resources, cache, isolation, labels, timeouts | `wendylabsinc/ci` → `repositories/WendyOS-Builder/configuration.yaml` |
+| Launcher / host behaviour (PID limits, sysctls, cgroups, tmpdir) | `wendylabsinc/ci` (launcher + platform modules) |
+
+`ci/packer/` and `.github/workflows/build-ami.yml` (the AWS AMI path) remain
+**only** until the `build.yml` cutover lands, then they are removed. Until then,
+if you must touch a build dependency for the legacy AMI, mirror the same change
+into the `wendylabsinc/ci` copy so the two don't diverge.
+
+See `wendylabsinc/ci/docs/onboarding.md` and `docs/architecture.md` for the
+platform model.

--- a/ci/packer/wendyos-builder.pkr.hcl
+++ b/ci/packer/wendyos-builder.pkr.hcl
@@ -1,5 +1,10 @@
 # Packer template for the WendyOS CI runner AMI.
 #
+# NOTE: this AWS/RunsOn AMI is being replaced by the self-hosted runner image in
+# wendylabsinc/ci (repositories/WendyOS-Builder/). Make build-runner-image
+# changes there; this template is legacy and removed at the build.yml cutover.
+# See ci/README.md.
+#
 # Bakes the Yocto host prerequisites (apt packages, locales) into a custom
 # Ubuntu 24.04 AMI so the GitHub Actions build matrix can skip the per-run
 # `docker build` + apt-get cycle entirely. Optionally pre-clones the upstream

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -5,6 +5,11 @@
 # ci/packer/wendyos-builder.pkr.hcl (CI runner AMI), so the package list
 # stays in one place.
 #
+# NOTE: the CI *build runner image* is migrating to wendylabsinc/ci. New
+# build-environment package changes for CI should be made there
+# (repositories/WendyOS-Builder/install-build-deps.sh); mirror them here only
+# for the legacy AWS AMI until the build.yml cutover. See ci/README.md.
+#
 # Idempotent: safe to re-run. Must be invoked as root (or via sudo).
 
 set -euo pipefail


### PR DESCRIPTION
## bootstrap: fetch SRCREV by SHA when not reachable via refs

`clone_repos` checks out each layer's pinned `SRCREV` after a plain `git clone` /
`git fetch origin`, which only retrieves **current branch tips**. When the
upstream branch a pinned commit lived on is deleted or force-pushed, the commit
is absent locally and `git checkout <srcrev>` fails — even though the object
still exists on the server and is fetchable by explicit SHA.

Concretely: the Jetson `meta-tegra` pin `d0b2f4d…` lives on `wip-l4t-r39.2.0`,
which no longer exists on OE4T/meta-tegra. Fresh clones can't reach it via refs.
The AWS CI only builds Jetson today because its AMI baked the object while the
branch still existed — **a fresh AMI rebuild would break identically.** The
self-hosted platform (fresh clones) surfaced it.

**Fix:** when the checkout fails, fall back to `git fetch origin <srcrev>`
(fetch-by-SHA) and retry. Verified the commit is fetchable by SHA. Benefits both
the platform and the AWS AMI's next rebuild.

Validated: on the self-hosted platform, Jetson Orin bootstrap now clears the
`meta-tegra` checkout and the full build + `simg2img` packaging succeed.

## docs(ci): build-runner-image changes belong in wendylabsinc/ci

Adds `ci/README.md` plus pointer headers in `scripts/install-build-deps.sh` and
`ci/packer/wendyos-builder.pkr.hcl`, so the team and agents make CI build-image
changes in `wendylabsinc/ci` (the tenant image) rather than only the legacy AWS
AMI path, which is removed at the `build.yml` cutover.

## Testing

`bash -n bootstrap.sh` clean. Behaviour validated on-platform (Orin build green
end-to-end, including the previously-failing `meta-tegra` checkout).
