### PR TITLE
ci: fix bootstrap missing-origin failure + isolate build TMPDIR scratch per job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,28 +338,43 @@ jobs:
       #      those steps (surfaces on non-PR builds, which run them).
       #
       # A bind mount would give a real path for both, but the runner has no
-      # passwordless sudo. So: set TMPDIR explicitly to the real scratch path
-      # (pseudo uses the canonical /wendy/build-tmp, never a symlink) AND also
-      # symlink build/tmp -> /wendy/build-tmp so the shell-level upload steps'
+      # passwordless sudo. So: set TMPDIR explicitly to a real scratch path
+      # (pseudo uses the canonical dir, never a symlink) AND also symlink
+      # build/tmp -> that path so the shell-level upload steps'
       # $GITHUB_WORKSPACE/build/tmp/deploy paths still resolve. Bitbake never
       # uses the symlink (TMPDIR is pinned), so pseudo stays happy.
+      #
+      # The /wendy scratch is bind-mounted from the box and SHARED by every job
+      # container scheduled on it (exactly like the /opt/wendy-cache pool). A
+      # fixed TMPDIR=/wendy/build-tmp therefore lets two concurrent jobs on the
+      # same box drive bitbake against one TMPDIR — an unsupported config that
+      # corrupts both builds (work/, buildstats/ and hosttools/ vanish mid-run
+      # with FileNotFoundError). Give each job its own real subdirectory, keyed
+      # by the same PRIV_TAG the repos snapshot uses, so the scratch is isolated
+      # per job just like repos/.
       - name: Back build/tmp with the platform NVMe scratch
+        env:
+          PRIV_TAG: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.device }}-${{ matrix.storage }}
         run: |
           set -euo pipefail
-          # Pin TMPDIR to the real scratch path for bitbake/pseudo.
+          # Per-job real scratch path for bitbake/pseudo. Clear any stale dir a
+          # prior run with the same tag might have left (tag is unique per run
+          # attempt, so this only matters after a re-run of the same attempt).
+          scratch="/wendy/build-tmp/$PRIV_TAG"
+          rm -rf "$scratch"
+          mkdir -p "$scratch"
           {
             echo ''
-            echo '# wendy-ci: back TMPDIR with the platform NVMe scratch'
-            echo 'TMPDIR = "/wendy/build-tmp"'
+            echo '# wendy-ci: back TMPDIR with the platform NVMe scratch (per-job)'
+            echo "TMPDIR = \"$scratch\""
           } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
           # Alias build/tmp -> the same path so upload steps that read
           # $GITHUB_WORKSPACE/build/tmp/deploy resolve to the real artifacts.
           # bootstrap created build/ but not build/tmp yet (bitbake makes it on
           # first run); clear any stray dir/symlink, then symlink onto scratch.
-          mkdir -p /wendy/build-tmp
           rm -rf "$GITHUB_WORKSPACE/build/tmp"
-          ln -sfn /wendy/build-tmp "$GITHUB_WORKSPACE/build/tmp"
-          echo "TMPDIR pinned to /wendy/build-tmp; build/tmp aliased to it"
+          ln -sfn "$scratch" "$GITHUB_WORKSPACE/build/tmp"
+          echo "TMPDIR pinned to $scratch; build/tmp aliased to it"
 
       - name: Enable debug for nightly builds
         # Release images are production builds — no debug tools by default.
@@ -758,6 +773,16 @@ jobs:
         env:
           PRIV_TAG: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.device }}-${{ matrix.storage }}
         run: rm -rf "/opt/wendy-cache/wendyos-builder/repos/runs/$PRIV_TAG"
+
+      # Remove this job's private TMPDIR from the shared /wendy scratch. Unlike
+      # sstate/downloads (persistent caches), TMPDIR is disposable per-build
+      # working state, and the scratch is shared across job containers on the
+      # box, so leaving it behind would accumulate and eventually fill the pool.
+      - name: Release platform scratch
+        if: always()
+        env:
+          PRIV_TAG: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.device }}-${{ matrix.storage }}
+        run: rm -rf "/wendy/build-tmp/$PRIV_TAG"
 
   # ---------------------------------------------------------------------------
   # publish: the ONLY writer of GCS manifests. Build jobs upload files and

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -254,8 +254,11 @@ function clone_repos() {
             return 1
         }
 
-        # check if repo already exists
-        if [[ -d "./${folder}" ]]; then
+        # check if repo already exists — and is a usable git checkout. A bare
+        # directory or a repo missing its .git (e.g. a partially-populated seed
+        # on the shared CI cache) can't be reconciled in place, so drop it and
+        # fall through to a fresh clone.
+        if [[ -d "./${folder}" ]] && git -C "./${folder}" rev-parse --git-dir >/dev/null 2>&1; then
             # repo exists - verify it's at the correct revision
             cd "${folder}"
 
@@ -266,7 +269,13 @@ function clone_repos() {
             current_url=$(git remote get-url origin 2>/dev/null || true)
             if [[ "${current_url}" != "${url}" ]]; then
                 printf "[reurl] '%s' %s -> %s\n" "${folder}" "${current_url:-<none>}" "${url}"
-                git remote set-url origin "${url}" >> "${LOG_FILE}" 2>&1 || {
+                # set-url only rewrites an existing remote; when origin is
+                # absent (current_url empty) it must be added instead.
+                if [[ -z "${current_url}" ]]; then
+                    git remote add origin "${url}" >> "${LOG_FILE}" 2>&1
+                else
+                    git remote set-url origin "${url}" >> "${LOG_FILE}" 2>&1
+                fi || {
                     printf "[error] Failed to set origin URL for '%s'\n" "${folder}"
                     cd ..
                     return 1
@@ -313,8 +322,11 @@ function clone_repos() {
             # need to update to target revision
             printf "[update] '%s' to %s\n" "${folder}" "${srcrev}"
         else
-            # repo doesn't exist - clone it
+            # repo doesn't exist (or a stale non-git directory survived from a
+            # previous run) - clone it. git clone refuses a non-empty target, so
+            # clear any leftover directory first.
             printf "[clone] '%s' at %s\n" "${url}" "${srcrev}"
+            rm -rf "./${folder}"
             git clone "${url}" "${folder}" >> "${LOG_FILE}" 2>&1 || {
                 return 1
             }


### PR DESCRIPTION
Two fixes needed to get the `Build WendyOS Images` workflow green on `main`/nightly.

## 1. Bootstrap fails when a cached repo has no origin remote

The `main` run [28646554702](https://github.com/wendylabsinc/WendyOS-Builder/actions/runs/28646554702) failed for **every** board at *Bootstrap build environment*:

```
[reurl] 'meta-lts-mixins' <none> -> https://git.yoctoproject.org/meta-lts-mixins
[error] Failed to set origin URL for 'meta-lts-mixins'
Yocto setup failed!
```

`bootstrap.sh` reconciled the origin URL with `git remote set-url origin`, which only rewrites an **existing** remote and fails with `No such remote 'origin'` when the cached checkout has none. The shared seed's `meta-lts-mixins` was in exactly that state.

Fix: add `origin` when absent, `set-url` only when present; and treat an existing-but-not-a-git-repo directory as missing → re-clone (clearing it first, since `git clone` refuses a non-empty target). This also self-heals the corrupted seed on the next `main` run.

## 2. Build TMPDIR scratch not isolated per job

With #1 fixed, 8/9 boards built; `jetson-agx-orin (emmc)` then failed at `do_image` with `work/`, `buildstats/` and `hosttools/` under `/wendy/build-tmp` disappearing mid-build (`FileNotFoundError`), and the retry died in 2s against the wrecked tree.

`/wendy` is a box-level NVMe scratch bind-mounted into every job container on that box — the same sharing model as `/opt/wendy-cache`, which is why `repos/` already uses a per-job reflink snapshot. The TMPDIR backing added in `01f5510f` pinned `TMPDIR` to a fixed shared `/wendy/build-tmp` with no isolation, so two concurrent jobs on one box drove bitbake against a single TMPDIR — unsupported, and it corrupts both builds.

Fix: each job gets its own `/wendy/build-tmp/<PRIV_TAG>` scratch (keyed by the same `run_id-attempt-device-storage` tag `repos/` uses) — still a real canonical path (pseudo-safe), still symlinked as `build/tmp` so upload/deploy paths resolve. Added an `always()` cleanup so the disposable per-job TMPDIR doesn't accumulate on the shared pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)