### PR TITLE
ci(jetson): fix Thor/AGX-Orin image packaging + diagnose scratch vanish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -588,7 +588,27 @@ jobs:
           # at the correct sector offset. The resulting wendyos-nvme.img is the
           # primary artifact for `wendy os install` (dd-based provisioning);
           # the tegraflash-tar bundle remains the recovery-flash artifact.
-          TEGRAFLASH_TAR="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
+          #
+          # Resolve the bundle by glob rather than a hard-coded name: on
+          # r38.4.x/JP7 (Thor, tegra264) the deployed artifact is not always the
+          # plain "wendyos-image-${MACHINE}.tegraflash-tar" the older Jetsons
+          # emit — tegra-common.inc defaults IMAGE_FSTYPES to "tegraflash-tar.zst"
+          # and the "latest" symlink is not guaranteed. Accept the compressed
+          # variant too (GNU tar auto-detects zstd on extraction). The ls below
+          # is a diagnostic: it records exactly what the image class deposited so
+          # a future naming change is obvious in the log instead of a bare
+          # "Cannot open" from tar.
+          echo "tegraflash artifacts in $DEPLOY_DIR:"
+          ls -la "$DEPLOY_DIR"/*.tegraflash-tar* 2>/dev/null || echo "  (none matched *.tegraflash-tar*)"
+          TEGRAFLASH_TAR=$(find "$DEPLOY_DIR" -maxdepth 1 \
+            \( -name "wendyos-image-${MACHINE}.tegraflash-tar" \
+               -o -name "wendyos-image-${MACHINE}.tegraflash-tar.zst" \) \
+            -print -quit)
+          [[ -n "$TEGRAFLASH_TAR" ]] || {
+            echo "::error::no tegraflash-tar bundle for ${MACHINE} in ${DEPLOY_DIR}"
+            exit 1
+          }
+          echo "Extracting tegraflash bundle: $TEGRAFLASH_TAR"
           tar -xf "$TEGRAFLASH_TAR" -C "$FLASH_WORKDIR"
           # external-flash.xml.in describes the external NVMe boot/root device.
           # eMMC builds are internal-only and ship no such layout; the SD-card

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -570,6 +570,12 @@ jobs:
           DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
           MACHINE: ${{ steps.vars.outputs.machine }}
           STORAGE: ${{ matrix.storage }}
+          # DEVICE was previously unset here, so the `"$DEVICE" != "jetson-agx-thor"`
+          # guard below silently evaluated true for every device — dead code. It
+          # did not bite while Thor failed earlier (at the tar extraction), but
+          # once that is fixed Thor would wrongly attempt the offline-NVMe-image
+          # generation. Set it so the guard actually distinguishes Thor.
+          DEVICE: ${{ matrix.device }}
         run: |
           # Per-MACHINE, freshly wiped staging dir. A fixed shared path
           # ($GITHUB_WORKSPACE/flash-work) on persistent snapshot runners with no
@@ -628,6 +634,25 @@ jobs:
             echo "No offline NVMe image for $DEVICE (storage=$STORAGE); the tegraflash-tar is the flash artifact."
           fi
 
+          # Diagnose the AGX-Orin-only failure where a deploy-dir artifact that
+          # exists during this step is gone by the upload step: the offline
+          # .img (nvme) and the tegraflash bundle (emmc) both vanished from the
+          # shared /wendy scratch on the 64 GiB AGX Orin builds, while the
+          # smaller orin-nano build survived — the signature of scratch
+          # exhaustion, not a naming bug. build/tmp is a symlink onto the
+          # SHARED /wendy mount, so record disk + dir state here (and verify the
+          # image we just wrote is actually still present) instead of surfacing
+          # a bare "not produced" three steps later with no context.
+          echo "== post-generate scratch state for ${MACHINE} =="
+          df -h "$DEPLOY_DIR" 2>/dev/null || true
+          ls -la "$DEPLOY_DIR" 2>/dev/null || true
+          if [[ "$STORAGE" == "nvme" && "$DEVICE" != "jetson-agx-thor" ]]; then
+            [[ -s "$NVME_IMG" ]] || {
+              echo "::error::offline NVMe image $NVME_IMG missing/empty immediately after generation (see df/ls above — suspect /wendy scratch exhaustion)"
+              exit 1
+            }
+          fi
+
       - name: Build Thor flashpack
         # Pack the extracted tegraflash-tar into the single .tar.zst the wendy CLI
         # flashes (see make-thor-flashpack.sh). The NVIDIA flash tools it runs are
@@ -664,7 +689,14 @@ jobs:
           # it doubles as the eMMC image and the Jetson recovery-flash artifact.
           TEGRAFLASH_BUNDLE=""
           if [[ "$MACHINE" != raspberry* ]]; then
-            TEGRAFLASH_BUNDLE="$DEPLOY_DIR/wendyos-image-${MACHINE}.tegraflash-tar"
+            # Resolve by glob, matching the generate step: r38.4.x/JP7 may deploy
+            # a compressed .tegraflash-tar.zst and the unsuffixed "latest"
+            # symlink is not guaranteed. Empty if genuinely absent — handled
+            # with a diagnostic below.
+            TEGRAFLASH_BUNDLE=$(find "$DEPLOY_DIR" -maxdepth 1 \
+              \( -name "wendyos-image-${MACHINE}.tegraflash-tar" \
+                 -o -name "wendyos-image-${MACHINE}.tegraflash-tar.zst" \) \
+              -print -quit)
           fi
 
           BMAP_FILE=""
@@ -675,13 +707,27 @@ jobs:
             IMAGE_FILE="$DEPLOY_DIR/wendyos-image-${MACHINE}-nvme.img"
             if [[ ! -f "$IMAGE_FILE" ]]; then
               echo "::error::NVMe image not produced this run for ${DEVICE} (${MACHINE}): ${IMAGE_FILE} missing. Refusing to upload a possibly-stale image." >&2
+              # AGX Orin: the image exists after the generate step but is gone by
+              # here — dump scratch state to distinguish /wendy exhaustion from
+              # external removal (see the generate step's matching diagnostic).
+              df -h "$DEPLOY_DIR" 2>/dev/null || true
+              ls -la "$DEPLOY_DIR" 2>/dev/null || true
               exit 1
             fi
             bmaptool create "$IMAGE_FILE" > "${IMAGE_FILE}.bmap"
             BMAP_FILE="${IMAGE_FILE}.bmap"
           elif [[ "$MACHINE" != raspberry* && ( "$STORAGE" == "emmc" || "$DEVICE" == "jetson-agx-thor" ) ]]; then
             # No offline disk image for eMMC or Thor NVMe; the tegraflash bundle
-            # is the flash artifact.
+            # is the flash artifact. It existed during the build (the generate
+            # step extracted it), so an empty/missing bundle here is the same
+            # vanish-from-scratch symptom — fail with disk context, not a bare
+            # "file does not exist" from the publisher.
+            if [[ -z "$TEGRAFLASH_BUNDLE" || ! -f "$TEGRAFLASH_BUNDLE" ]]; then
+              echo "::error::tegraflash bundle for ${MACHINE} missing at upload time (it was present during the build). Suspect /wendy scratch exhaustion." >&2
+              df -h "$DEPLOY_DIR" 2>/dev/null || true
+              ls -la "$DEPLOY_DIR" 2>/dev/null || true
+              exit 1
+            fi
             IMAGE_FILE="$TEGRAFLASH_BUNDLE"
           else
             # RPi: Mender emits .sdimg; pre-Mender RPi builds produced


### PR DESCRIPTION
## Summary

Nightly run [28662739751](https://github.com/wendylabsinc/WendyOS-Builder/actions/runs/28662739751) fails on 3 of 4 Jetson matrix jobs. They are **not the same bug** — this PR fixes the two confirmed ones and instruments the third.

| Job | Fails at | Cause | This PR |
|---|---|---|---|
| orin-nano (nvme) | — | passes (control) | — |
| thor (nvme) | Generate | `.tegraflash-tar` bundle named differently on r38.4.x/JP7 (tegra264) | ✅ fixed |
| orin-agx (emmc) | Upload | tegraflash bundle present during Generate, gone by Upload | ⚠️ instrumented + glob |
| orin-agx (nvme) | Upload | offline `.img` written (`Done` printed) then **vanishes** (`du` empty mid-script) | ⚠️ instrumented |

## Confirmed fixes

1. **Thor bundle naming (Generate + Upload).** The step hard-coded `wendyos-image-${MACHINE}.tegraflash-tar` and `tar -xf`'d it directly. On Thor (JP7/L4T r38.4.x) that path doesn't exist even though `do_image_tegraflash_tar` succeeds. Resolve by `find` (glob), accepting the `.tegraflash-tar.zst` variant `tegra-common.inc` defaults to (GNU tar auto-detects zstd on extraction). Applied to both the Generate extraction and the Upload `TEGRAFLASH_BUNDLE`. Orin found it fine at the same path, so this is Thor-specific — **not a flake** (confirmed by re-running the original job on the unfixed commit).

2. **Dead `DEVICE` guard in Generate.** The emmc log prints `No offline NVMe image for **  ** (storage=emmc)` — `$DEVICE` is empty because the Generate step's `env:` never set it, so the `"$DEVICE" != "jetson-agx-thor"` guard always evaluated true. Harmless while Thor failed earlier, but the tar fix lets Thor reach it and it would wrongly run `make-thor-nvme-img.py`. Set `DEVICE: ${{ matrix.device }}`.

## Instrumented (root cause not yet confirmable from logs)

3. **AGX Orin artifacts vanish between Generate and Upload.** On *both* AGX Orin jobs, an artifact that provably exists during Generate is gone by Upload — the nvme `.img` vanishes even *within* `make-thor-nvme-img.py` (its `du -sh` returns empty right after a successful 12 GiB dd), and the emmc `.tegraflash-tar` disappears after `tar -xf` read it. The smaller **orin-nano** build survives. `build/tmp` is a **symlink onto the shared `/wendy` mount**, so this is the signature of **scratch exhaustion**, not a naming issue — but there's no `df` in the logs to prove it. Added `df -h` + `ls -la` at generation and at both upload failure paths, plus a non-empty check on the freshly written `.img`, so the next run shows space-vs-eviction instead of a bare "not produced" / "file does not exist".

Once CI on this branch runs, the `df`/`ls` output will confirm whether the AGX vanish is `/wendy` exhaustion; the real remediation (prune stale scratch / relocate the offline image / drop the redundant APP_b copy) follows from that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)