### PR TITLE
wendyos-update: pin to tegra capsule-decouple fix for image testing

### DIFF
--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -23,17 +23,15 @@ GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 # to go.bbclass where it already sets this.
 GO_SRCURI_DESTSUFFIX ?= "${@os.path.join(os.path.basename(d.getVar('S')), 'src', d.getVar('GO_IMPORT')) + '/'}"
 
-SRC_URI = "git://${GO_IMPORT};protocol=https;branch=fix/tegra-decouple-capsule-slot-switch;destsuffix=${GO_SRCURI_DESTSUFFIX}"
-# c863805f (wendyos-update#7, branch fix/tegra-decouple-capsule-slot-switch):
-# decouple the rootfs slot switch from the bootloader capsule on non-Thor SoCs.
-# UEFI capsule-on-disk is only honored on Thor (t264); on Orin (t234) the
-# firmware advertises FILE_CAPSULE_DELIVERY but silently never processes a
-# staged capsule, so a bootloader-carrying OTA no-op'd (slot never switched,
-# reboot into the same OS, ESRT 0). SwapSlot now allowlists tegra264 for the
-# capsule path and falls back to the nvbootctrl slot switch on Orin/unknown
-# SoCs. TEMPORARY PIN to the PR branch so the fix can be image-tested before
-# #7 merges; re-point branch=main + SRCREV to the merged main SHA after merge.
-# Builds on:
+SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
+# f0357892 (main, wendyos-update#7): decouple the rootfs slot switch from the
+# bootloader capsule on non-Thor SoCs. UEFI capsule-on-disk is only honored on
+# Thor (t264); on Orin (t234) the firmware advertises FILE_CAPSULE_DELIVERY but
+# silently never processes a staged capsule, so a bootloader-carrying OTA
+# no-op'd (slot never switched, reboot into the same OS, ESRT 0, no
+# diagnostics). SwapSlot now allowlists tegra264 for the capsule path and falls
+# back to the nvbootctrl slot switch on Orin/unknown SoCs (the new rootfs boots
+# on the existing bootloader). Builds on:
 # b1f3315a (main): install rejects an OTA payload larger than the target A/B
 # slot up front (blockdev.DeviceCapacity seek-to-end pre-flight, exit 3, nothing
 # written) — the connector-side last line of defense behind the meta-edgeos
@@ -62,7 +60,7 @@ SRC_URI = "git://${GO_IMPORT};protocol=https;branch=fix/tegra-decouple-capsule-s
 # slot — kills the Orin Nano stale-inactive-slot false-positive, validated
 # against the real r39.2 efivar format) + structured per-slot `status` and the
 # `switch` verb.
-SRCREV = "c863805feb1905277deda3e705a79bf982287e12"
+SRCREV = "f03578922ea94de7e68116f0b376964676d82056"
 
 inherit go-mod systemd
 

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -23,7 +23,17 @@ GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 # to go.bbclass where it already sets this.
 GO_SRCURI_DESTSUFFIX ?= "${@os.path.join(os.path.basename(d.getVar('S')), 'src', d.getVar('GO_IMPORT')) + '/'}"
 
-SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
+SRC_URI = "git://${GO_IMPORT};protocol=https;branch=fix/tegra-decouple-capsule-slot-switch;destsuffix=${GO_SRCURI_DESTSUFFIX}"
+# c863805f (wendyos-update#7, branch fix/tegra-decouple-capsule-slot-switch):
+# decouple the rootfs slot switch from the bootloader capsule on non-Thor SoCs.
+# UEFI capsule-on-disk is only honored on Thor (t264); on Orin (t234) the
+# firmware advertises FILE_CAPSULE_DELIVERY but silently never processes a
+# staged capsule, so a bootloader-carrying OTA no-op'd (slot never switched,
+# reboot into the same OS, ESRT 0). SwapSlot now allowlists tegra264 for the
+# capsule path and falls back to the nvbootctrl slot switch on Orin/unknown
+# SoCs. TEMPORARY PIN to the PR branch so the fix can be image-tested before
+# #7 merges; re-point branch=main + SRCREV to the merged main SHA after merge.
+# Builds on:
 # b1f3315a (main): install rejects an OTA payload larger than the target A/B
 # slot up front (blockdev.DeviceCapacity seek-to-end pre-flight, exit 3, nothing
 # written) — the connector-side last line of defense behind the meta-edgeos
@@ -52,7 +62,7 @@ SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_
 # slot — kills the Orin Nano stale-inactive-slot false-positive, validated
 # against the real r39.2 efivar format) + structured per-slot `status` and the
 # `switch` verb.
-SRCREV = "b1f3315a4d1392f7aca5171672d8a998fa6e9614"
+SRCREV = "c863805feb1905277deda3e705a79bf982287e12"
 
 inherit go-mod systemd
 


### PR DESCRIPTION
Bumps the `wendyos-update` recipe to **wendylabsinc/wendyos-update#7** (`fix/tegra-decouple-capsule-slot-switch`) so a full image can be built and flash-tested with the fix.

## Why

On the **Jetson Orin fleet** (AGX Orin + Orin Nano, r39.2), a bootloader-carrying OTA silently no-op'd: the image ships `/var/lib/wendyos/update-bootloader`, so `SwapSlot` took the capsule path — which delegates the *entire* slot switch to UEFI processing a capsule-on-disk — and issued no `nvbootctrl` call. Orin firmware advertises `FILE_CAPSULE_DELIVERY` but **never processes the capsule** (`ESRT 0`), so the slot never switched and the device rebooted into the same OS with no diagnostics. The fix allowlists Thor (`tegra264`) for the capsule path and falls back to the reliable `nvbootctrl` slot switch on Orin/unknown SoCs.

## ⚠ Temporary pin

`SRC_URI` is pointed at the PR **branch** and `SRCREV` at commit `c863805` so we can image-test before the fix merges. **Once wendyos-update#7 lands, re-point `branch=main` and bump `SRCREV` to the merged main SHA** (recipe comment says the same). I can push that follow-up as soon as #7 merges.

## Testing

- wendyos-update#7: unit tests (SoC detection + swap routing) pass in `golang:1.26`.
- Not yet: a full bitbake image build + on-device OTA round-trip — that's the point of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnDjyn5AM3p6oTcyqHbe3K