### PR TITLE
image: only generate SPDX SBOM on release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,6 +389,22 @@ jobs:
             echo 'WENDYOS_DEBUG = "1"'
           } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
 
+      - name: Enable SBOM generation for release builds
+        # SPDX SBOM generation (create-spdx) is expensive — a do_create_spdx
+        # task per recipe plus rootfs-time image/runtime SPDX. It is only ever
+        # consumed on release builds (attached to the GitHub release by the
+        # publish job). promote.yml rebuilds from scratch at the release tag
+        # rather than reusing nightly artifacts, so a nightly's SBOM can never
+        # feed a release — nightly and PR builds skip it entirely. The distro
+        # gates `INHERIT += "create-spdx"` on WENDYOS_SBOM, set here.
+        if: needs.detect-changes.outputs.is-release == 'true'
+        run: |
+          {
+            echo ''
+            echo '# Release build: generate SPDX SBOM (attached to the GitHub release)'
+            echo 'WENDYOS_SBOM = "1"'
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+
       - name: Enable SSH when explicitly requested
         # SSH is disabled by default (WENDYOS_SSHD ??= "0" in common.inc).
         # Pass inputs.sshd = true on workflow_dispatch or promote.yml to opt in.

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -228,8 +228,13 @@ USE_REDUNDANT_FLASH_LAYOUT_DEFAULT ?= "1"
 BB_SIGNATURE_HANDLER ?= "OEEquivHash"
 BB_HASHSERVE ??= "auto"
 
-# Enable creation of SPDX manifests by default
-INHERIT += "create-spdx"
+# SBOM generation adds a do_create_spdx task per recipe plus rootfs-time
+# image/runtime SPDX — expensive, and it runs on every build. Only inherit it
+# for release builds, which are the only builds whose SBOM is consumed:
+# promote.yml rebuilds from scratch at the release tag (it does not reuse
+# nightly artifacts), so a nightly's SBOM can never feed a release. CI sets
+# WENDYOS_SBOM=1 on tag/release builds; nightly and PR builds skip it.
+INHERIT += "${@'create-spdx' if (d.getVar('WENDYOS_SBOM') or '0') == '1' else ''}"
 
 INHERIT += " \
     uninative \


### PR DESCRIPTION
## What

`create-spdx` (SPDX SBOM generation) was inherited unconditionally in `conf/distro/wendyos.conf`, so it ran on **every** build — PR, nightly, and release. It adds a `do_create_spdx` task to every recipe plus rootfs-time image/runtime SPDX generation, which is one of the more expensive things Yocto can do.

But the SBOM is only ever *consumed* on release builds (the publish job attaches it to the GitHub release). And `promote.yml` rebuilds from scratch at the release tag rather than reusing nightly artifacts — so a nightly's SBOM can **never** feed a release. That makes SBOM generation on nightly and PR builds pure waste.

## Change

- `conf/distro/wendyos.conf`: gate `INHERIT += "create-spdx"` on a new `WENDYOS_SBOM` flag.
- `.github/workflows/build.yml`: set `WENDYOS_SBOM = "1"` in `build/conf/auto.conf` only when `is-release == 'true'`.

## Effect

- **PR / nightly builds:** skip `create-spdx` entirely. The existing `Stage`/`Upload SBOM` steps already no-op when no SBOM is found (`found=false`).
- **Release / promoted builds:** `is-release=true` → SBOM generated and attached exactly as before. Safe with promotion because promotion rebuilds at the tag.

## Trade-off

This is a config-time `INHERIT` change, so the first post-merge nightly re-runs the affected image tasks once (sstate miss on `do_rootfs` and friends). One-time cost; steady state is faster. Savings land on nightly/PR builds, not on release builds (which still pay for the SBOM by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)