### PR TITLE
ci: dispatch build matrix longest-pole-first to shorten wall-clock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,15 +110,23 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Ordered longest-pole-first. The self-hosted builder pool cannot run
+          # all matrix jobs at once, so queued jobs are picked up in this
+          # (include) order as runners free up. A run's wall-clock is set by
+          # whichever heavy build lands in the final scheduling wave, so the
+          # slowest builds must be dispatched first: jetson-agx-thor is the long
+          # pole (~14 min warm vs ~5 min for a Pi; heavier still on release
+          # builds, which add tegraflash + flashpack + upload), then the other
+          # Jetsons, then the Raspberry Pis. Do NOT sort this alphabetically.
           ALL_MATRIX='[
-            {"device":"raspberry-pi-3","storage":"sd"},
-            {"device":"raspberry-pi-4","storage":"sd"},
-            {"device":"raspberry-pi-5","storage":"sd"},
-            {"device":"raspberry-pi-5","storage":"nvme"},
+            {"device":"jetson-agx-thor","storage":"nvme"},
             {"device":"jetson-agx-orin","storage":"nvme"},
             {"device":"jetson-agx-orin","storage":"emmc"},
             {"device":"jetson-orin-nano","storage":"nvme"},
-            {"device":"jetson-agx-thor","storage":"nvme"}
+            {"device":"raspberry-pi-5","storage":"nvme"},
+            {"device":"raspberry-pi-5","storage":"sd"},
+            {"device":"raspberry-pi-4","storage":"sd"},
+            {"device":"raspberry-pi-3","storage":"sd"}
           ]'
           # Collapse to one line so it can be written to $GITHUB_OUTPUT, which
           # requires single-line key=value pairs (no implicit multiline support).
@@ -126,7 +134,7 @@ jobs:
 
           emit_all() {
             echo "matrix={\"include\":${ALL_MATRIX}}" >> "$GITHUB_OUTPUT"
-            echo "devices=raspberry-pi-3 raspberry-pi-4 raspberry-pi-5 jetson-agx-orin jetson-orin-nano jetson-agx-thor" >> "$GITHUB_OUTPUT"
+            echo "devices=jetson-agx-thor jetson-agx-orin jetson-orin-nano raspberry-pi-5 raspberry-pi-4 raspberry-pi-3" >> "$GITHUB_OUTPUT"
           }
 
           emit_one() {
@@ -182,7 +190,10 @@ jobs:
 
           INCLUDED=()
           DEVICES=()
-          for dev in raspberry-pi-3 raspberry-pi-4 raspberry-pi-5 jetson-agx-orin jetson-orin-nano jetson-agx-thor; do
+          # Same longest-pole-first order as ALL_MATRIX (see above): a partial
+          # matrix built from a subset of devices should still dispatch its
+          # heaviest members first.
+          for dev in jetson-agx-thor jetson-agx-orin jetson-orin-nano raspberry-pi-5 raspberry-pi-4 raspberry-pi-3; do
             if echo "${CHANGED}" | grep -Eq "${DEV_RE[$dev]}"; then
               while IFS= read -r entry; do
                 INCLUDED+=("$entry")


### PR DESCRIPTION
## Problem

Build runs take 30–82 min wall-clock, but that is **not** because any single build is slow.

Measured on a warm-sstate run ([28686874710](https://github.com/wendylabsinc/WendyOS-Builder/actions/runs/28686874710), 67 min total):

- **Per-job build time is already optimal.** Step timing shows `Build image` (bitbake) is ~100% of every job — Thor 840s, Pi5 330s — and all setup/checkout/cache/upload steps are single-digit seconds. Nothing to squeeze *inside* a job.
- **The cost is scheduling.** The self-hosted pool can't run all 8 `device×storage` jobs at once, so they run in waves. In that run: `+0m` 2 jobs → `+17m` 4 jobs → `+52m` 2 jobs. The **14-min long-pole `jetson-agx-thor` was dispatched in the *last* wave (+52m)** and alone defined the 67-min tail, while the two ~5-min Raspberry Pi jobs grabbed the first free slots.

## Change

Reorder the build matrix **longest-pole-first** — `jetson-agx-thor` → other Jetsons → Raspberry Pis — in all three places that carry the order (`ALL_MATRIX`, the `emit_all` device list, and the partial-matrix device loop). GitHub picks up queued matrix jobs in `include` order as runners free up, so front-loading the heaviest builds keeps the long pole out of the final scheduling wave.

**No functional change:** identical set of jobs and artifacts; only dispatch order changes. Cannot make wall-clock worse; removes the pathological case where the slowest build is scheduled last.

## What this does *not* do (deliberately — flagging for review)

These are larger levers I did **not** take, because each is either unsafe or infra-side:

- **Shrink the push-to-main matrix by changed paths.** Unsafe: every push resolves and bakes in the latest `wendyos-agent` pin at build time, so unaffected devices still need a rebuild to get a fresh nightly. Path-pruning main would ship stale nightlies. (PR builds already prune by path via `detect-changes`.)
- **Collapse storage variants** (orin `nvme`+`emmc`, rpi5 `sd`+`nvme`) into single jobs. Doesn't reduce total bitbake work, and the Jetson image-packaging path is fragile (recent breakage in #170). Not worth the risk.
- **Scale / co-schedule the runner pool.** The dominant remaining cost — including a ~27-min mid-run gap from cross-run pool contention — is infra, not repo-controllable. This is where the biggest wins actually are.

## Verification

build.yml changes force a full 8-device build via `detect-changes`, so CI on this branch exercises every device. Watching for green + confirming Thor now dispatches early. Note: `jetson-agx-orin (nvme)` has a known transient `/wendy` scratch-exhaustion flake (see #170) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)