### PR TITLE
wendyos-identity: write STORAGE= to /etc/wendyos/device-type

### DIFF
--- a/conf/template/boards/jetson-agx-orin-emmc/local.conf
+++ b/conf/template/boards/jetson-agx-orin-emmc/local.conf
@@ -8,6 +8,12 @@ require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/tegra-t234
 # upstream declares blacksail. Inert on non-blacksail trees.
 require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/blacksail-compat.inc
 
+# DEVICE is the OTA manifest key (shared with the NVMe variant, which is
+# published under the same key with --storage nvme). STORAGE selects the
+# eMMC artifact and is written to /etc/wendyos/device-type so the OTA client
+# does not have to infer the medium from the machine name.
+DEVICE  = "jetson-agx-orin"
+STORAGE = "emmc"
 MACHINE = "jetson-agx-orin-devkit-emmc-wendyos"
 
 # Flash image size - sets MENDER_STORAGE_TOTAL_SIZE_MB via flash-image-sizes.inc

--- a/recipes-core/wendyos-identity/wendyos-identity_1.0.bb
+++ b/recipes-core/wendyos-identity/wendyos-identity_1.0.bb
@@ -5,6 +5,12 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 inherit systemd
 
+# Storage medium ("nvme"/"emmc"/"sd") for /etc/wendyos/device-type; set per
+# board in the template local.conf. Weak default keeps ${STORAGE} well-defined
+# (empty) for boards that declare no medium (e.g. qemu), so the do_install
+# guard below reliably skips the STORAGE line instead of risking a literal.
+STORAGE ??= ""
+
 SRC_URI = " \
     file://generate-uuid.sh \
     file://generate-device-name.sh \
@@ -61,10 +67,19 @@ do_install() {
 
 do_install:append() {
     # Stable board identity for the wendy agent. Sourced as shell.
-    # BOARD is set in conf/machine/<machine>.conf; MACHINE is the yocto machine name.
+    # BOARD is set in conf/machine/<machine>.conf; MACHINE is the yocto machine
+    # name; STORAGE ("nvme"/"emmc"/"sd") is set in the board template local.conf.
     install -d ${D}${sysconfdir}/wendyos
     printf 'BOARD=%s\n'   "${WENDYOS_BOARD_ID}" >  ${D}${sysconfdir}/wendyos/device-type
     printf 'MACHINE=%s\n' "${MACHINE}"          >> ${D}${sysconfdir}/wendyos/device-type
+    # STORAGE lets the OTA client pick the storage-specific artifact directly
+    # (e.g. jetson-agx-orin publishes both an NVMe and an eMMC image under one
+    # manifest key). Without it the agent must infer the medium from the MACHINE
+    # name, which fails for legacy/plain-string identities and can serve the
+    # wrong image. Only emitted when the board declares a medium.
+    if [ -n "${STORAGE}" ]; then
+        printf 'STORAGE=%s\n' "${STORAGE}"      >> ${D}${sysconfdir}/wendyos/device-type
+    fi
     chmod 0644 ${D}${sysconfdir}/wendyos/device-type
 }
 


### PR DESCRIPTION
## Problem

`jetson-agx-orin` publishes **two** OS images (NVMe + eMMC) under **one** OTA manifest key: the NVMe OTA as `nvme_ota_update_path`, the eMMC OTA as the top-level `ota_update_path` (the default fallback). The CLI picks NVMe only when the device reports `storage_medium == "nvme"`; otherwise it falls back to the eMMC default, which `wendyos-update` then rejects:

```
artifact rejected: artifact targets [jetson-agx-orin-emmc], this device is "jetson-agx-orin"
```

The agent derives `storage_medium` from `/etc/wendyos/device-type`, but this recipe wrote only `BOARD` and `MACHINE` — never `STORAGE`. So the agent had to *infer* the medium from the `MACHINE` name, and that inference is skipped entirely for legacy plain-string device-type files, leaving the medium empty → wrong (eMMC) image served to NVMe devices.

## Change

- **`wendyos-identity_1.0.bb`**: write an explicit `STORAGE=` line to `/etc/wendyos/device-type`, sourced from the board template's existing `STORAGE` var (`nvme`/`emmc`/`sd`). Guarded so boards with no declared medium (qemu) emit no line; a weak `STORAGE ??= ""` default keeps `${STORAGE}` well-defined so the guard is reliable.
- **`jetson-agx-orin-emmc/local.conf`**: fill the gap — this board template was missing the `DEVICE` and `STORAGE` declarations its NVMe sibling already has.

The `STORAGE` value reaches the recipe because `bootstrap.sh` copies the selected board template's `local.conf` straight into `build/conf/local.conf`, making `STORAGE` a global datastore var during the recipe build (same path as the already-working `WENDYOS_BOARD_ID`/`MACHINE`).

## Relationship to the CLI fix

This is the **image-side / defense-in-depth** half. The CLI-side fix (hardware-derive the medium from the device's root block device, with an NVMe fallback for AGX Orin, plus an install summary) is separate and already fixes devices *already in the field* running old images. This PR makes **newly built images** self-report their medium so no inference/fallback is needed.

## Testing

Not yet built. Requires a Yocto image build + boot to confirm `/etc/wendyos/device-type` contains the `STORAGE=` line; the recipe change is standard bitbake (`printf` + shell guard) mirroring the existing `BOARD`/`MACHINE` writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)