### PR TITLE
tegra: arm rootfs A/B redundancy at boot + pin wendyos-update preflight

### DIFF
--- a/meta-tegra-extensions/recipes-bsp/tegra-rootfs-redundancy/files/wendyos-tegra-arm-rootfs-redundancy.sh
+++ b/meta-tegra-extensions/recipes-bsp/tegra-rootfs-redundancy/files/wendyos-tegra-arm-rootfs-redundancy.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Arm rootfs A/B redundancy on Jetson when the firmware left it disabled.
+#
+# A device provisioned by writing the rootfs image straight to disk (e.g. a
+# raw NVMe flash) never gets NVIDIA's RootfsRedundancyLevel UEFI variable set —
+# that is normally done by tegraflash. Without it the firmware runs single-slot:
+# `nvbootctrl -t rootfs set-active-boot-slot` is silently ignored, so every OTA
+# installs to the inactive slot, reboots, comes up on the OLD slot, and rolls
+# back at commit (running slot != target slot).
+#
+# This one-shot arms redundancy (identical to `system-status.sh --dual`) and
+# reboots once so the firmware picks it up on the next boot. It is idempotent
+# and guarded so it can never reboot-loop: once it has attempted the arm, it
+# never tries again, even if the arm did not take (that case needs a reflash).
+set -eu
+
+GUID="781e084c-a330-417c-b678-38e696380cb9"
+EFIVAR_DIR="/sys/firmware/efi/efivars"
+REDUNDANCY_VAR="${EFIVAR_DIR}/RootfsRedundancyLevel-${GUID}"
+STATE_DIR="/data/wendyos-update"
+ATTEMPT_MARKER="${STATE_DIR}/rootfs-redundancy-arm-attempted"
+
+log() { echo "wendyos-tegra-redundancy: $*"; }
+
+# Not a Jetson / no boot control — nothing to do.
+command -v nvbootctrl >/dev/null 2>&1 || exit 0
+
+# Already armed: the variable exists. Firmware honors rootfs slot switches;
+# leave it alone.
+if [ -e "${REDUNDANCY_VAR}" ]; then
+    log "rootfs A/B redundancy already armed"
+    exit 0
+fi
+
+# Only arm when a second rootfs slot actually exists — arming redundancy on a
+# genuinely single-slot device would be wrong. APP is slot A, APP_b is slot B.
+if [ ! -e /dev/disk/by-partlabel/APP_b ]; then
+    log "no APP_b partition; device is single-slot, not arming redundancy"
+    exit 0
+fi
+
+# Guard against a reboot loop: if we already tried once and the variable is
+# still missing, the arm did not take (needs a reflash) — do not try again.
+if [ -e "${ATTEMPT_MARKER}" ]; then
+    log "already attempted to arm redundancy but it is still disabled; a reflash is required (not retrying)"
+    exit 0
+fi
+
+log "rootfs A/B redundancy is not armed; arming RootfsRedundancyLevel and rebooting"
+
+# Record the attempt BEFORE writing, on the persistent data partition, so a
+# crash between the write and the reboot still counts as one attempt.
+mkdir -p "${STATE_DIR}"
+: > "${ATTEMPT_MARKER}"
+sync
+
+# 4-byte attrs (0x07 = NV+BS+RT) + UINT32 level 1 — the exact payload
+# system-status.sh --dual writes. The variable is absent (checked above), so
+# there is no immutable flag to clear; the create succeeds directly.
+tmp="$(mktemp)"
+printf '\x07\x00\x00\x00\x01\x00\x00\x00' > "${tmp}"
+if ! cp "${tmp}" "${REDUNDANCY_VAR}" 2>/dev/null; then
+    rm -f "${tmp}"
+    log "failed to write RootfsRedundancyLevel; leaving the attempt marker so we do not loop"
+    exit 0
+fi
+rm -f "${tmp}"
+sync
+
+log "RootfsRedundancyLevel armed; rebooting to activate rootfs A/B redundancy"
+exec systemctl --no-block reboot

--- a/meta-tegra-extensions/recipes-bsp/tegra-rootfs-redundancy/files/wendyos-tegra-rootfs-redundancy.service
+++ b/meta-tegra-extensions/recipes-bsp/tegra-rootfs-redundancy/files/wendyos-tegra-rootfs-redundancy.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Arm Jetson rootfs A/B redundancy if firmware left it disabled
+DefaultDependencies=no
+# Needs the persistent data partition for its one-shot attempt marker, and
+# efivarfs for the UEFI variable. Must settle the slot machinery BEFORE the
+# OTA boot verifier reads/commits a pending update, so it is ordered ahead of
+# wendyos-update-verify.service. It may reboot once on first run; that is
+# guarded so it can never loop.
+After=local-fs.target data.mount
+Before=wendyos-update-verify.service
+ConditionPathExists=/sys/firmware/efi/efivars
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/wendyos-tegra-arm-rootfs-redundancy
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-tegra-extensions/recipes-bsp/tegra-rootfs-redundancy/tegra-rootfs-redundancy_1.0.bb
+++ b/meta-tegra-extensions/recipes-bsp/tegra-rootfs-redundancy/tegra-rootfs-redundancy_1.0.bb
@@ -1,0 +1,41 @@
+SUMMARY = "Arm Jetson rootfs A/B redundancy at boot"
+DESCRIPTION = "One-shot boot service that enables NVIDIA rootfs A/B redundancy \
+(the RootfsRedundancyLevel UEFI variable) when it is missing — the state left \
+by flashing a rootfs image directly to disk instead of via tegraflash. Without \
+it the firmware runs single-slot and every WendyOS OTA rolls back because the \
+rootfs slot switch is a no-op. The service arms redundancy once and reboots to \
+activate it; it is idempotent and guarded against reboot loops."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://wendyos-tegra-arm-rootfs-redundancy.sh \
+    file://wendyos-tegra-rootfs-redundancy.service \
+    "
+
+S = "${UNPACKDIR}"
+
+inherit systemd allarch
+
+SYSTEMD_SERVICE:${PN} = "wendyos-tegra-rootfs-redundancy.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${UNPACKDIR}/wendyos-tegra-arm-rootfs-redundancy.sh \
+        ${D}${sbindir}/wendyos-tegra-arm-rootfs-redundancy
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/wendyos-tegra-rootfs-redundancy.service \
+        ${D}${systemd_system_unitdir}/
+}
+
+# nvbootctrl is guaranteed on every tegra image (meta-tegra
+# MACHINE_EXTRA_RDEPENDS -> tegra-redundant-boot); the script also guards on
+# its presence, so no hard RDEPENDS that would couple this to a package name.
+RDEPENDS:${PN} = "systemd"
+
+FILES:${PN} += " \
+    ${sbindir}/wendyos-tegra-arm-rootfs-redundancy \
+    ${systemd_system_unitdir}/wendyos-tegra-rootfs-redundancy.service \
+    "

--- a/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
+++ b/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
@@ -20,6 +20,7 @@ RDEPENDS:${PN} = " \
     ${@'tegra-flash-reboot' if ('tegra234' in d.getVar('MACHINEOVERRIDES').split(':') and (d.getVar('WENDYOS_LAYER_TREE') or '') == 'scarthgap') else ''} \
     tegra-tools-tegrastats \
     tegra-bootcontrol-overlay \
+    tegra-rootfs-redundancy \
     setup-nv-boot-control \
     packagegroup-nvidia-container \
     "

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -24,6 +24,12 @@ GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 GO_SRCURI_DESTSUFFIX ?= "${@os.path.join(os.path.basename(d.getVar('S')), 'src', d.getVar('GO_IMPORT')) + '/'}"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
+# 33da342c (main, wendyos-update#8): install preflight refuses when tegra rootfs
+# A/B redundancy is not armed (RootfsRedundancyLevel UEFI variable missing/zero).
+# A device flashed by writing the rootfs straight to NVMe never gets it set, so
+# `nvbootctrl -t rootfs set-active-boot-slot` is a silent no-op and every OTA
+# rolls back (running slot != target slot). Paired with the boot service in
+# tegra-rootfs-redundancy, which arms it. Builds on:
 # f0357892 (main, wendyos-update#7): decouple the rootfs slot switch from the
 # bootloader capsule on non-Thor SoCs. UEFI capsule-on-disk is only honored on
 # Thor (t264); on Orin (t234) the firmware advertises FILE_CAPSULE_DELIVERY but
@@ -60,7 +66,7 @@ SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_
 # slot — kills the Orin Nano stale-inactive-slot false-positive, validated
 # against the real r39.2 efivar format) + structured per-slot `status` and the
 # `switch` verb.
-SRCREV = "f03578922ea94de7e68116f0b376964676d82056"
+SRCREV = "33da342c3748bf29bc74584ac2ea1bd5880e7ed5"
 
 inherit go-mod systemd
 


### PR DESCRIPTION
## Problem

Both fleet Jetson Orin Nano units roll back **every** OTA. Root cause (confirmed with a live EFI snapshot pulled over gRPC — no SSH): these devices are provisioned by writing the rootfs image straight to NVMe rather than via tegraflash, so NVIDIA's `RootfsRedundancyLevel` UEFI variable is never set. The firmware runs single-slot, `nvbootctrl -t rootfs set-active-boot-slot` is a silent no-op, and every update installs → reboots onto the old slot → rolls back at commit.

## Change

- **New `tegra-rootfs-redundancy` recipe** (`meta-tegra-extensions`): a boot one-shot that arms rootfs A/B redundancy (`RootfsRedundancyLevel=1`, identical to `scripts/system-status.sh --dual`) when it's missing **and** a second slot (`APP_b`) exists, then reboots once to activate it. Idempotent; guarded by a persistent marker so it **can never reboot-loop** (if the arm doesn't take, it logs "needs reflash" and stops). Added to `packagegroup-wendyos-tegra`, so every Jetson image self-heals on first boot — including the already-flashed units on their next reflash.
- **Bump `wendyos-update` SRCREV → `33da342` (wendyos-update#8)**: the install preflight now refuses and diagnoses when redundancy isn't armed, instead of silently rolling back (defense-in-depth).

## Companion PRs
- `wendyos-update#8` (merged) — the preflight + `rootfs_redundancy` diagnostic.
- `wendyos#1352` — verbose engine diagnostics over gRPC (the tool that found this).

## Validation
Shell script syntax-checked; recipe follows existing `meta-tegra-extensions` patterns. Full validation is the image build on merge + a reflash-and-OTA test on an Orin Nano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHUU2AnJNQSCPWfTvHpHhy