### PR TITLE
publisher: ship Jetson OS image as seekable .zst, drop gzip .img.gz

### DIFF
--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -561,13 +560,18 @@ func compressFile(ctx context.Context, inputPath string, fileType string) (strin
 		} else if fileType == "recovery" {
 			compressionMethod = "xz-fast" // Fast compression for recovery (frequently accessed)
 		} else {
-			// gzip for OS images: it is only ever the fallback download. The
-			// wendy CLI's primary flash path is the seekable .zst + bmap (which
-			// the publisher always generates for these images), and it streams
-			// this fallback via content-sniffed gzip decompression — the same
-			// path Raspberry Pi .sdimg.gz images already use. gzip is done
-			// in-process below, so the publisher host needs no `zip` binary.
-			compressionMethod = "gzip"
+			// Seekable-zstd for OS images. This single artifact IS the image the
+			// wendy CLI flashes: the fast path streams it as .zst + bmap, and the
+			// full-image fallback (--no-bmap, `wendy os download`) reads the same
+			// object by content-sniffing the zstd magic. It doubles as the
+			// manifest .zst artifact, so it is produced once here rather than a
+			// gzip .img.gz plus a separate seekable pass over the same 60+ GB
+			// image. Done in-process, so the publisher host needs no `zip` binary.
+			//
+			// Only raw images reach this branch: Raspberry Pi .sdimg is gzipped
+			// by the build workflow before upload (isAlreadyCompressed short-
+			// circuits it), and eMMC/Thor ship a recovery bundle, not an .img.
+			compressionMethod = "seekable-zstd"
 		}
 	default:
 		// Other file types - don't compress
@@ -596,8 +600,8 @@ func compressFile(ctx context.Context, inputPath string, fileType string) (strin
 	switch compressionMethod {
 	case "xz-max", "xz-fast":
 		outputPath = inputPath + ".xz"
-	case "gzip":
-		outputPath = inputPath + ".gz"
+	case "seekable-zstd":
+		outputPath = inputPath + ".zst"
 	default:
 		return "", fmt.Errorf("unknown compression method: %s", compressionMethod)
 	}
@@ -690,12 +694,13 @@ func compressFile(ctx context.Context, inputPath string, fileType string) (strin
 			cmd.Stderr = os.Stderr
 		}
 
-	case "gzip":
-		// Compress OS images with the standard library in-process — no external
-		// `zip`/`gzip` binary required. This is the fallback download only; the
-		// CLI prefers the seekable .zst + bmap. Handle everything here and
-		// return, since the process-based machinery below is xz-only.
-		if err := gzipFile(ctx, inputPath, outputPath); err != nil {
+	case "seekable-zstd":
+		// Produce the seekable-zstd image in-process — no external binary
+		// required. Frames are independently decompressible, so the CLI can
+		// random-access via bmap; the whole file also decodes as a normal zstd
+		// stream for the full-image fallback. Handle everything here and return,
+		// since the process-based machinery below is xz-only.
+		if err := compressSeekableZstd(inputPath, outputPath); err != nil {
 			if rmErr := os.Remove(outputPath); rmErr != nil && !os.IsNotExist(rmErr) {
 				log.WithError(rmErr).Warn("Failed to clean up partial compressed file")
 			}
@@ -801,57 +806,6 @@ func compressFile(ctx context.Context, inputPath string, fileType string) (strin
 	}).Info("Compression complete")
 
 	return outputPath, nil
-}
-
-// ctxReader wraps an io.Reader so a long copy aborts promptly when ctx is
-// cancelled: ctx.Err() is checked before each underlying Read.
-type ctxReader struct {
-	ctx context.Context
-	r   io.Reader
-}
-
-func (c *ctxReader) Read(p []byte) (int, error) {
-	if err := c.ctx.Err(); err != nil {
-		return 0, err
-	}
-	return c.r.Read(p)
-}
-
-// gzipFile compresses src into dst (a .gz file) using the standard library,
-// honoring ctx cancellation. It shells out to no external binary, so the
-// publisher host needs neither `zip` nor `gzip` installed. The compression
-// level matches the previous `zip -6`: balanced size versus speed.
-func gzipFile(ctx context.Context, src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("failed to open input file: %w", err)
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return fmt.Errorf("failed to create output file: %w", err)
-	}
-
-	gz, err := gzip.NewWriterLevel(out, gzip.DefaultCompression)
-	if err != nil {
-		out.Close()
-		return fmt.Errorf("failed to create gzip writer: %w", err)
-	}
-
-	if _, err := io.Copy(gz, &ctxReader{ctx: ctx, r: in}); err != nil {
-		gz.Close()
-		out.Close()
-		return fmt.Errorf("gzip compression failed: %w", err)
-	}
-	if err := gz.Close(); err != nil {
-		out.Close()
-		return fmt.Errorf("failed to finalize gzip stream: %w", err)
-	}
-	if err := out.Close(); err != nil {
-		return fmt.Errorf("failed to close output file: %w", err)
-	}
-	return nil
 }
 
 // sendDiscordNotification sends a notification to Discord about the update
@@ -1557,29 +1511,10 @@ func main() {
 			bmapUploadChan = uploadFileAsync(ctx, bucket, *bmapFile, *deviceType, *version)
 		}
 
-		// Generate and upload a seekable-zstd image for OS images (the
-		// .img/.wic/.sdimg → zip case). OTA and recovery files use their own
-		// compression formats and are not wrapped in .zst.
-		var zstUploadChan <-chan uploadResult
-		if *localFile != "" && mainResult.compressedPath != "" {
-			rawPath, symErr := filepath.EvalSymlinks(*localFile)
-			if symErr != nil {
-				rawPath = *localFile
-			}
-			rawExt := strings.ToLower(filepath.Ext(rawPath))
-			if rawExt == ".img" || rawExt == ".wic" || rawExt == ".sdimg" {
-				zstPath := rawPath + ".zst"
-				log.WithFields(logrus.Fields{
-					"src": rawPath,
-					"dst": zstPath,
-				}).Info("Generating seekable-zstd image...")
-				if zstErr := compressSeekableZstd(rawPath, zstPath); zstErr != nil {
-					log.WithError(zstErr).Fatal("Failed to generate seekable-zstd image")
-				}
-				log.Info("Seekable-zstd image generated, uploading...")
-				zstUploadChan = uploadFileAsync(ctx, bucket, zstPath, *deviceType, *version)
-			}
-		}
+		// The seekable-zstd OS image now IS the main file (compressFile produced
+		// it in place of a gzip .img.gz), so there is no separate .zst artifact
+		// to generate or upload here — the manifest .zst fields reuse the main
+		// upload. See the zst-derivation block after the upload waits.
 
 		// Wait for uploads to complete
 		var mainUpload uploadResult
@@ -1636,28 +1571,16 @@ func main() {
 			log.Info("SBOM file uploaded successfully")
 		}
 
-		var zstUpload uploadResult
-		if zstUploadChan != nil {
-			zstUpload = <-zstUploadChan
-			if zstUpload.err != nil {
-				log.WithError(zstUpload.err).Fatal("Failed to upload seekable-zstd file")
-			}
-			log.Info("Seekable-zstd file uploaded successfully")
-		}
-
-		// The checksum of the uploaded .zst (calculated from the local file).
-		var zstChecksum string
-		if zstUpload.path != "" {
-			rawPath, symErr := filepath.EvalSymlinks(*localFile)
-			if symErr != nil {
-				rawPath = *localFile
-			}
-			zstLocalPath := rawPath + ".zst"
-			if cs, csErr := calculateChecksum(zstLocalPath); csErr == nil {
-				zstChecksum = cs
-			} else {
-				log.WithError(csErr).Warn("Failed to calculate zst checksum; zst_checksum will be empty")
-			}
+		// Seekable-zstd manifest fields. When the main OS image is itself a
+		// seekable .zst (Jetson raw .img), it doubles as the .zst artifact, so
+		// reuse the single upload rather than a second identical object.
+		// Non-.zst main images (RPi .sdimg.gz, eMMC/Thor bundles) have none.
+		var zstPath, zstChecksum string
+		var zstSize int64
+		if strings.HasSuffix(strings.ToLower(mainResult.compressedPath), ".zst") {
+			zstPath = mainUpload.path
+			zstChecksum = mainResult.checksum
+			zstSize = mainUpload.size
 		}
 
 		// In upload-only mode the manifests are deliberately untouched: write
@@ -1673,9 +1596,9 @@ func main() {
 				FileSize:          mainUpload.size,
 				FileChecksum:      mainResult.checksum,
 				BmapPath:          bmapUpload.path,
-				ZstPath:           zstUpload.path,
+				ZstPath:           zstPath,
 				ZstChecksum:       zstChecksum,
-				ZstSize:           zstUpload.size,
+				ZstSize:           zstSize,
 				OTAUpdatePath:     otaUpdateUpload.path,
 				OTAUpdateSize:     otaUpdateUpload.size,
 				OTAUpdateChecksum: otaUpdateResult.checksum,
@@ -1701,7 +1624,7 @@ func main() {
 			ctx, bucket, *deviceType, *version,
 			mainUpload.path, mainUpload.size, mainResult.checksum,
 			bmapUpload.path,
-			zstUpload.path, zstChecksum, zstUpload.size,
+			zstPath, zstChecksum, zstSize,
 			otaUpdateUpload.path, otaUpdateUpload.size, otaUpdateResult.checksum,
 			recoveryUpload.path, recoveryUpload.size, recoveryResult.checksum,
 			flashpackUpload.path, flashpackUpload.size, flashpackResult.checksum,


### PR DESCRIPTION
## What

The publish step compressed the **61 GB Jetson NVMe image twice** — a single-threaded stdlib **gzip `.img.gz`** (**~6m42s** in [this CI run](https://github.com/wendylabsinc/WendyOS-Builder/actions/runs/28709232868/job/85139891998)) *plus* a separate seekable `.zst` pass — then uploaded both ~7.7 GB artifacts. The `.img.gz` was only ever a fallback download; the wendy CLI flashes the seekable `.zst` + bmap.

This makes the seekable `.zst` the **single OS-image artifact**:
- `compressFile` emits `.img.zst` for raw images instead of `.gz`.
- The manifest's `.zst` fields **reuse that one upload** (`file_path == zst_path`) instead of generating + uploading a second identical object.

## Impact (per Jetson build)
- Removes the **6m42s** single-threaded gzip pass.
- **Halves** the image-artifact upload volume (one `.zst` instead of `.gz` + `.zst`).

## Scope is naturally Jetson-only
- **Raspberry Pi** `.sdimg` is gzipped by the build workflow *before* upload, so `isAlreadyCompressed` short-circuits — unchanged.
- **eMMC / Thor** ship a recovery bundle, not a raw `.img`, so neither reaches the changed branch.

Also removes the now-dead `gzipFile`/`ctxReader` helpers and the `compress/gzip` import.

## ⚠️ Requires a paired CLI change (accepted gap)
The wendy CLI's full-image path (`openOSImageStream`) currently recognizes only `.zip`/gzip/raw. A follow-up CLI PR adds zstd content-sniffing so `wendy os install --no-bmap`, `wendy os download`, and pre-seekable CLIs can read a `.zst` main image. **Mainstream `wendy os install` (seekable `.zst` + bmap fast path) is unaffected** — it never reads the main `path`.

## Test
`go build` / `go vet` / `gofmt` / `go test ./...` all clean. Correctness of the seekable encoder itself is covered further by the parallel-zstd PR's round-trip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)