### PR TITLE
PR builds: publish installable debug images to pr/<N>/ (wendy os install --pr)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,9 @@ jobs:
   # ---------------------------------------------------------------------------
   # detect-changes: compute the build matrix.
   # On main / workflow_dispatch we always build every device (nightly).
-  # On pull_request we prune to only the devices whose paths actually changed.
-  # Any change touching a "global" path (distro conf, shared recipes, the
-  # workflow itself, etc.) falls back to building every device.
+  # On pull_request we also always build every device: PR images back
+  # `wendy os install --pr`, which needs an image for the user's target
+  # regardless of which paths changed in the PR.
   # ---------------------------------------------------------------------------
   detect-changes:
     name: Detect affected devices
@@ -78,6 +78,8 @@ jobs:
         env:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           if [[ "$REF_TYPE" == "tag" ]]; then
@@ -94,6 +96,9 @@ jobs:
               exit 1
             fi
             echo "is-release=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+            VERSION="pr-${PR_NUMBER}"
+            echo "is-release=false" >> "$GITHUB_OUTPUT"
           else
             VERSION="nightly-$(date -u +%Y%m%dT%H%M%S)"
             echo "is-release=false" >> "$GITHUB_OUTPUT"
@@ -104,8 +109,6 @@ jobs:
       - id: set
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           INPUT_DEVICE: ${{ inputs.device }}
         run: |
           set -euo pipefail
@@ -163,56 +166,11 @@ jobs:
             exit 0
           fi
 
-          CHANGED=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
-          echo "Changed files:"
-          printf '  %s\n' ${CHANGED:-<none>}
-
-          # Paths whose change can affect any device. Conservative: anything
-          # that isn't clearly board/machine-scoped is treated as global.
-          GLOBAL_RE='^(conf/distro/|conf/template/include/|conf/layer\.conf$|classes/|recipes-|wic/|scripts/|Makefile$|bootstrap\.sh$|\.github/workflows/build\.yml$)'
-
-          if echo "${CHANGED}" | grep -Eq "${GLOBAL_RE}"; then
-            echo "Global path changed -> building all devices."
-            emit_all
-            exit 0
-          fi
-
-          # Per-device path patterns. meta-rpi-extensions affects every Pi;
-          # meta-tegra-extensions affects Jetson only.
-          declare -A DEV_RE=(
-            [raspberry-pi-3]='(^conf/template/boards/rpi3-sd/|^conf/machine/raspberrypi3-64-wendyos\.conf$|^meta-rpi-extensions/)'
-            [raspberry-pi-4]='(^conf/template/boards/rpi4-sd/|^conf/machine/raspberrypi4-64-wendyos\.conf$|^meta-rpi-extensions/)'
-            [raspberry-pi-5]='(^conf/template/boards/rpi5-(sd|nvme)/|^conf/machine/raspberrypi5(-nvme)?-wendyos\.conf$|^meta-rpi-extensions/)'
-            [jetson-agx-orin]='(^conf/template/boards/jetson-agx-orin(-emmc)?/|^conf/machine/jetson-agx-orin-devkit-(nvme|emmc)-wendyos\.conf$|^meta-tegra-extensions/)'
-            [jetson-orin-nano]='(^conf/template/boards/jetson-orin-nano-(nvme|sd)/|^conf/machine/jetson-orin-nano-devkit(-nvme)?-wendyos\.conf$|^meta-tegra-extensions/)'
-            [jetson-agx-thor]='(^conf/template/boards/jetson-agx-thor/|^conf/machine/jetson-agx-thor-devkit-nvme-wendyos\.conf$|^meta-tegra-extensions-jp7/)'
-          )
-
-          INCLUDED=()
-          DEVICES=()
-          # Same longest-pole-first order as ALL_MATRIX (see above): a partial
-          # matrix built from a subset of devices should still dispatch its
-          # heaviest members first.
-          for dev in jetson-agx-thor jetson-agx-orin jetson-orin-nano raspberry-pi-5 raspberry-pi-4 raspberry-pi-3; do
-            if echo "${CHANGED}" | grep -Eq "${DEV_RE[$dev]}"; then
-              while IFS= read -r entry; do
-                INCLUDED+=("$entry")
-              done < <(echo "${ALL_MATRIX}" | jq -c ".[] | select(.device == \"${dev}\")")
-              DEVICES+=("${dev}")
-            fi
-          done
-
-          if [[ ${#INCLUDED[@]} -eq 0 ]]; then
-            echo "No device-affecting paths changed -> empty matrix (build job will be skipped)."
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            echo 'devices='              >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Building devices: ${DEVICES[*]}"
-          MATRIX="{\"include\":[$(IFS=,; echo "${INCLUDED[*]}")]}"
-          echo "matrix=${MATRIX}"      >> "$GITHUB_OUTPUT"
-          echo "devices=${DEVICES[*]}" >> "$GITHUB_OUTPUT"
+          # PR builds force-build every device so `wendy os install --pr` always
+          # has an image for the user's target, regardless of which paths changed.
+          echo "Trigger=pull_request: force-building all devices for --pr installs."
+          emit_all
+          exit 0
 
   # ---------------------------------------------------------------------------
   # build: per-device Yocto image build.
@@ -400,6 +358,22 @@ jobs:
             echo 'WENDYOS_DEBUG = "1"'
           } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
 
+      - name: Enable developer profile (PR builds)
+        # PR images are open-book debug builds: full debug tooling, SSH, UART
+        # console, and a local passwordless login so the PR is debuggable on
+        # real hardware. Never applied to nightly (in-between) or release
+        # (fortress) builds. See WENDYOS_DEV_LOGIN in wendyos-image.bb.
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            echo ''
+            echo '# PR CI: open-book developer profile'
+            echo 'WENDYOS_DEBUG = "1"'
+            echo 'WENDYOS_SSHD = "1"'
+            echo 'WENDYOS_DEBUG_UART = "1"'
+            echo 'WENDYOS_DEV_LOGIN = "1"'
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+
       - name: Enable SBOM generation for release builds
         # SPDX SBOM generation (create-spdx) is expensive — a do_create_spdx
         # task per recipe plus rootfs-time image/runtime SPDX. It is only ever
@@ -569,18 +543,15 @@ jobs:
           overwrite: true
 
       - name: Authenticate to Google Cloud
-        if: github.event_name != 'pull_request'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        if: github.event_name != 'pull_request'
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Set up Go
-        if: github.event_name != 'pull_request'
         uses: actions/setup-go@v5
         with:
           go-version-file: wendyos/tools/publisher/go.mod
@@ -592,7 +563,7 @@ jobs:
       # passwordless sudo, so there is no apt-get step here.
 
       - name: Generate flashable image (Jetson)
-        if: github.event_name != 'pull_request' && startsWith(matrix.device, 'jetson-')
+        if: startsWith(matrix.device, 'jetson-')
         env:
           DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
           MACHINE: ${{ steps.vars.outputs.machine }}
@@ -684,7 +655,7 @@ jobs:
         # Pack the extracted tegraflash-tar into the single .tar.zst the wendy CLI
         # flashes (see make-thor-flashpack.sh). The NVIDIA flash tools it runs are
         # i386, so this x86_64 runner needs i386 runtime libs.
-        if: github.event_name != 'pull_request' && matrix.device == 'jetson-agx-thor'
+        if: matrix.device == 'jetson-agx-thor'
         env:
           UPLOAD_VERSION: ${{ needs.detect-changes.outputs.version }}
           MACHINE: ${{ steps.vars.outputs.machine }}
@@ -700,7 +671,6 @@ jobs:
           echo "FLASHPACK_FILE=$GITHUB_WORKSPACE/thor-flashpack/wendyos-${UPLOAD_VERSION}-jetson-agx-thor.flashpack.tar.zst" >> "$GITHUB_ENV"
 
       - name: Upload image and emit manifest entry
-        if: github.event_name != 'pull_request'
         env:
           DEPLOY_DIR: ${{ github.workspace }}/build/tmp/deploy/images/${{ steps.vars.outputs.machine }}
           MACHINE: ${{ steps.vars.outputs.machine }}
@@ -709,6 +679,8 @@ jobs:
           IS_RELEASE: ${{ needs.detect-changes.outputs.is-release }}
           UPLOAD_VERSION: ${{ needs.detect-changes.outputs.version }}
           SBOM_FILE: ${{ steps.sbom.outputs.bundle }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           TOKEN=$(gcloud auth print-access-token)
 
@@ -794,6 +766,12 @@ jobs:
             ARGS+=(--nightly)
           fi
 
+          # PR builds upload to the pr/<N>/ subtree instead of the shared
+          # nightly/release tree (see wendy os install --pr).
+          if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+            ARGS+=(--pr "${PR_NUMBER}")
+          fi
+
           # For all Jetson targets, include the tegraflash bundle as the recovery file
           # (used for USB recovery-mode flashing via tegraflash.py / initrd-flash).
           # wendy/blacksail builds use .tegraflash-tar (JP7/r38.4.x renamed the
@@ -846,7 +824,8 @@ jobs:
           go run . "${ARGS[@]}"
 
       - name: Upload manifest entry artifact
-        if: github.event_name != 'pull_request'
+        # Runs on PRs too: publish-pr (a separate job) consumes these
+        # PR-stamped manifest-entry artifacts to write pr/<N>/ manifests.
         uses: actions/upload-artifact@v4
         with:
           name: manifest-entry-${{ matrix.device }}-${{ matrix.storage }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1052,3 +1052,89 @@ jobs:
               -H "Content-Type: application/json" \
               -d @- \
               "$DISCORD_WEBHOOK_URL"
+
+  # ---------------------------------------------------------------------------
+  # publish-pr: PR-only counterpart to `publish`. Writes into the pr/<N>/
+  # manifest namespace instead of the top-level one, so `wendy os install --pr`
+  # can resolve a PR's images without touching the real device manifests.
+  # No release tagging / Discord announcement here - that stays exclusive to
+  # the `publish` job's nightly/release path.
+  # ---------------------------------------------------------------------------
+  publish-pr:
+    name: Publish PR manifests
+    needs: [detect-changes, build]
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+    concurrency:
+      group: pr-publish-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: [runs-on, family=c7i-flex.xlarge, spot=false, "run-id=${{ github.run_id }}-publish-pr"]
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: wendyos
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: wendyos/tools/publisher/go.mod
+          cache-dependency-path: wendyos/tools/publisher/go.sum
+
+      - name: Download manifest entries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: manifest-entry-*
+          path: manifest-entries
+          merge-multiple: true
+
+      - name: Write PR device manifests
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          entries=("$GITHUB_WORKSPACE"/manifest-entries/*.json)
+          if [[ ${#entries[@]} -eq 0 ]]; then
+            echo "::warning::No manifest entries found (did every build fail?); nothing to publish."
+            exit 0
+          fi
+          TOKEN=$(gcloud auth print-access-token)
+          cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
+          go build -o "$RUNNER_TEMP/publisher" .
+          for entry in "${entries[@]}"; do
+            echo "::group::apply $(basename "$entry")"
+            cat "$entry"
+            "$RUNNER_TEMP/publisher" --apply-metadata "$entry" --access-token "$TOKEN"
+            echo "::endgroup::"
+          done
+
+      - name: Update PR master manifest
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          entries=("$GITHUB_WORKSPACE"/manifest-entries/*.json)
+          if [[ ${#entries[@]} -eq 0 ]]; then
+            echo "No manifest entries; skipping PR master manifest update."
+            exit 0
+          fi
+          TOKEN=$(gcloud auth print-access-token)
+          cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
+          [[ -x "$RUNNER_TEMP/publisher" ]] || go build -o "$RUNNER_TEMP/publisher" .
+          readarray -t rows < <(jq -sc '[.[] | {device, version}] | unique_by(.device) | .[]' "${entries[@]}")
+          for row in "${rows[@]}"; do
+            DEVICE=$(jq -r .device <<<"$row")
+            VERSION=$(jq -r .version <<<"$row")
+            "$RUNNER_TEMP/publisher" --device "$DEVICE" --version "$VERSION" --pr "$PR_NUMBER" --master-manifest-only --nightly --access-token "$TOKEN" </dev/null
+          done

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -80,11 +80,30 @@ jobs:
             exit 1
           fi
 
-          # List existing pr/<N>/ prefixes in the bucket. A non-zero exit here
-          # just means the pr/ prefix doesn't exist yet (nothing to sweep) -
-          # treat that as an empty listing rather than an error.
-          pr_dirs=$(gsutil ls "gs://wendyos-images-public/pr/" 2>/dev/null | \
-            sed -nE 's#.*/pr/([0-9]+)/#\1#p' | sort -u || true)
+          # Fail closed on an empty-but-successful result. gh can exit 0 with no
+          # output (e.g. a --jq/--json schema mismatch after a gh version bump,
+          # or a transient empty-but-successful API response). An empty open-PR
+          # set would make every pr/<N>/ below look orphaned and get deleted -
+          # including live PRs. This repo always has open PRs at sweep time, so
+          # zero-open is treated as a signal error, not a real state.
+          if [[ -z "$open_prs" ]]; then
+            echo "::error::gh pr list returned zero open PRs; refusing to sweep — cannot distinguish a PR-less repo from an API glitch." >&2
+            exit 1
+          fi
+
+          # List existing pr/<N>/ prefixes in the bucket. gsutil ls exits 1 both
+          # when the prefix legitimately doesn't exist yet (nothing to sweep)
+          # and on a genuine failure (network/auth/permissions), so distinguish
+          # them: the "no matches" case is benign, anything else gets a warning
+          # and we still fail toward under-deletion (empty pr_dirs -> no-op).
+          if ls_out=$(gsutil ls "gs://wendyos-images-public/pr/" 2>&1); then
+            pr_dirs=$(sed -nE 's#.*/pr/([0-9]+)/#\1#p' <<<"$ls_out" | sort -u)
+          elif grep -qiE 'matched no objects|bucketnotfound|no urls matched' <<<"$ls_out"; then
+            pr_dirs=""
+          else
+            echo "::warning::gsutil ls of the pr/ prefix failed (not an empty-listing case); treating as nothing to sweep. Output: ${ls_out}" >&2
+            pr_dirs=""
+          fi
 
           if [[ -z "$pr_dirs" ]]; then
             echo "No pr/<N>/ directories found in the bucket; nothing to sweep."

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,103 @@
+name: Cleanup PR Images
+on:
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: "17 4 * * 1"   # Mondays 04:17 UTC — weekly orphan sweep
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  # ---------------------------------------------------------------------------
+  # cleanup-closed: fires on every PR close (merged or not) and deletes that
+  # PR's self-contained pr/<N>/ subtree from the public images bucket.
+  # ---------------------------------------------------------------------------
+  cleanup-closed:
+    name: Delete images for closed PR
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Remove pr/<N>/ subtree
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # -m parallel, and tolerate an already-empty prefix (PR that never built).
+          gsutil -m rm -r "gs://wendyos-images-public/pr/${PR_NUMBER}/**" || \
+            echo "Nothing to delete for PR ${PR_NUMBER}."
+
+  # ---------------------------------------------------------------------------
+  # sweep-orphans: weekly safety net for missed close events (e.g. workflow
+  # outage, force-deleted PR). Deletes any pr/<N>/ subtree whose PR number is
+  # no longer open. Fails safe: if the open-PR list can't be fetched, the job
+  # aborts before touching the bucket rather than risk treating every PR as
+  # orphaned and mass-deleting.
+  # ---------------------------------------------------------------------------
+  sweep-orphans:
+    name: Weekly orphan sweep
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Delete pr/<N>/ trees with no open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Fetch the open-PR set first. If this fails for any reason (API
+          # outage, auth hiccup, gh CLI error), abort immediately rather than
+          # falling through to a sweep that would see zero "open" PRs and
+          # delete every pr/<N>/ tree in the bucket.
+          if ! open_prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 1000 --json number --jq '.[].number' | sort -u); then
+            echo "::error::Failed to list open PRs via gh; aborting sweep without deleting anything." >&2
+            exit 1
+          fi
+
+          # List existing pr/<N>/ prefixes in the bucket. A non-zero exit here
+          # just means the pr/ prefix doesn't exist yet (nothing to sweep) -
+          # treat that as an empty listing rather than an error.
+          pr_dirs=$(gsutil ls "gs://wendyos-images-public/pr/" 2>/dev/null | \
+            sed -nE 's#.*/pr/([0-9]+)/#\1#p' | sort -u || true)
+
+          if [[ -z "$pr_dirs" ]]; then
+            echo "No pr/<N>/ directories found in the bucket; nothing to sweep."
+            exit 0
+          fi
+
+          while IFS= read -r n; do
+            [[ -z "$n" ]] && continue
+            if grep -qx -- "$n" <<<"$open_prs"; then
+              echo "PR $n is open -> keeping."
+            else
+              echo "PR $n not open -> deleting."
+              gsutil -m rm -r "gs://wendyos-images-public/pr/${n}/**" || \
+                echo "::warning::Failed to delete gs://wendyos-images-public/pr/${n}/ (may already be empty)."
+            fi
+          done <<<"$pr_dirs"

--- a/conf/template/include/local/common.inc
+++ b/conf/template/include/local/common.inc
@@ -52,4 +52,8 @@ CONF_VERSION = "2"
 # auto.conf (parsed before local.conf per bitbake.conf) is not clobbered.
 WENDYOS_DEBUG ??= "0"
 WENDYOS_DEBUG_UART ??= "0"
+
+# Dev-only: re-enable local console/serial login + passwordless root on
+# non-fortress (PR) builds. NEVER set on release or nightly. See wendyos-image.bb.
+WENDYOS_DEV_LOGIN ??= "0"
 WENDYOS_SSHD ??= "0"

--- a/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rpi-extensions/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -23,7 +23,17 @@ inherit partuuid-rpi
 #
 # A hypothetical future RPi without a dwc2 peripheral controller would
 # need its own :append:<machine> override.
-WENDYOS_RPI_CMDLINE_EXTRAS = " console=serial0,115200${@' modules-load=dwc2' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
+#
+# `console=serial0,115200` (the kernel bootarg that puts boot + printk output
+# on UART) is gated on WENDYOS_DEBUG_UART, mirroring WENDYOS_DEV_LOGIN's gate
+# on the serial *login* prompt (see wendyos-image.bb's disable_local_login).
+# Fortress default (WENDYOS_DEBUG_UART="0"): no serial console registered, so
+# neither boot logs nor a login prompt reach UART. Dev/PR builds
+# (WENDYOS_DEBUG_UART="1", set by CI) restore the console= arg so field
+# bring-up can watch the boot again. "serial0" is the RPi firmware alias that
+# resolves to the correct UART per board (ttyAMA0 on RPi5, ttyS0 on RPi3/4 —
+# see SERIAL_CONSOLES above), so no per-machine override is needed here.
+WENDYOS_RPI_CMDLINE_EXTRAS = "${@' console=serial0,115200' if d.getVar('WENDYOS_DEBUG_UART') == '1' else ''}${@' modules-load=dwc2' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
 CMDLINE_ROOTFS:append:rpi = "${WENDYOS_RPI_CMDLINE_EXTRAS}"
 
 do_deploy[depends] += "${PN}:do_generate_partuuids"

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -39,6 +39,18 @@ WENDYOS_DEBUG_FEATURES ?= " \
     "
 IMAGE_FEATURES += "${@oe.utils.ifelse(d.getVar('WENDYOS_DEBUG') == '1', d.getVar('WENDYOS_DEBUG_FEATURES'), '')}"
 
+# The classic debug-tweaks credential set (empty/passwordless root + autologin)
+# that #172 removed from WENDYOS_DEBUG_FEATURES. Reintroduced ONLY for dev/PR
+# builds, gated strictly on WENDYOS_DEV_LOGIN (never WENDYOS_DEBUG). Without a
+# working credential the restored getty would be unusable (root is otherwise
+# locked to root:*: by zap_empty_root_password).
+WENDYOS_DEV_LOGIN_FEATURES ?= " \
+    empty-root-password \
+    allow-empty-password \
+    allow-root-login \
+    "
+IMAGE_FEATURES += "${@oe.utils.ifelse(d.getVar('WENDYOS_DEV_LOGIN') == '1', d.getVar('WENDYOS_DEV_LOGIN_FEATURES'), '')}"
+
 # No local interactive login on ANY image (debug included). A physically
 # attached monitor+keyboard (VT: getty@tty1 plus logind's autovt@ VT-switch
 # spawns) and the serial console login (serial-getty@, driven by
@@ -65,7 +77,9 @@ disable_local_login() {
     printf '[Login]\nNAutoVTs=0\nReserveVT=0\n' \
         > ${IMAGE_ROOTFS}${systemd_unitdir}/logind.conf.d/10-wendyos-no-autovt.conf
 }
-ROOTFS_POSTPROCESS_COMMAND += "disable_local_login;"
+# Fortress (release + nightly): strip every local login path. Dev/PR builds
+# (WENDYOS_DEV_LOGIN="1") keep getty/serial-getty so the PR is debuggable.
+ROOTFS_POSTPROCESS_COMMAND += "${@'' if d.getVar('WENDYOS_DEV_LOGIN') == '1' else 'disable_local_login;'}"
 
 # Optional runtime package management (rpm/dnf in the rootfs).
 # Disabled by default — image is updated atomically via Mender A/B.
@@ -147,6 +161,7 @@ BUILDCFG_VARS += " \
     WENDYOS_DATA_PART \
     WENDYOS_DEBUG \
     WENDYOS_DEBUG_UART \
+    WENDYOS_DEV_LOGIN \
     WENDYOS_SSHD \
     WENDYOS_USB_GADGET \
     WENDYOS_USB_NET_MODE \

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -55,10 +55,14 @@ IMAGE_FEATURES += "${@oe.utils.ifelse(d.getVar('WENDYOS_DEV_LOGIN') == '1', d.ge
 # attached monitor+keyboard (VT: getty@tty1 plus logind's autovt@ VT-switch
 # spawns) and the serial console login (serial-getty@, driven by
 # SERIAL_CONSOLES) are both an attack surface on a product device and are
-# removed. Kernel boot messages still reach the serial console — that is the
-# `console=` bootarg, not a getty — so field bring-up can still watch the boot;
-# there is simply no login prompt. Device access is exclusively via the
-# wendy-agent (gRPC); there is no interactive login path (SSH stays off).
+# removed. The kernel `console=` bootarg (boot + printk output on UART, not a
+# getty/login prompt) is a separate knob, gated on WENDYOS_DEBUG_UART in the
+# per-machine bootarg wiring (e.g. meta-rpi-extensions' rpi-cmdline.bbappend):
+# fortress builds (the "0" default) get neither boot-log visibility nor a
+# login prompt on UART; dev/PR builds (WENDYOS_DEBUG_UART="1") restore boot
+# logs for field bring-up, independent of WENDYOS_DEV_LOGIN's login-prompt
+# gate below. Device access is exclusively via the wendy-agent (gRPC); there
+# is no interactive login path (SSH stays off).
 #
 # Masking these units in the rootfs is fatal: systemd's 90-systemd.preset
 # enables getty@/serial-getty@ and the rootfs preset-all pass rejects "enable a

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -56,13 +56,15 @@ IMAGE_FEATURES += "${@oe.utils.ifelse(d.getVar('WENDYOS_DEV_LOGIN') == '1', d.ge
 # spawns) and the serial console login (serial-getty@, driven by
 # SERIAL_CONSOLES) are both an attack surface on a product device and are
 # removed. The kernel `console=` bootarg (boot + printk output on UART, not a
-# getty/login prompt) is a separate knob, gated on WENDYOS_DEBUG_UART in the
-# per-machine bootarg wiring (e.g. meta-rpi-extensions' rpi-cmdline.bbappend):
-# fortress builds (the "0" default) get neither boot-log visibility nor a
-# login prompt on UART; dev/PR builds (WENDYOS_DEBUG_UART="1") restore boot
-# logs for field bring-up, independent of WENDYOS_DEV_LOGIN's login-prompt
-# gate below. Device access is exclusively via the wendy-agent (gRPC); there
-# is no interactive login path (SSH stays off).
+# getty/login prompt) is a separate knob lit per-machine in the bootarg wiring,
+# not here: on Raspberry Pi it is gated on WENDYOS_DEBUG_UART (see
+# meta-rpi-extensions' rpi-cmdline.bbappend), so RPi fortress builds (the "0"
+# default) get no serial boot output and dev/PR builds (WENDYOS_DEBUG_UART="1")
+# restore it. Tegra console gating on the same knob is still pending (task A2),
+# so Jetson builds currently emit serial boot output regardless of this flag.
+# Either way that is independent of WENDYOS_DEV_LOGIN's login-prompt gate below.
+# Device access is exclusively via the wendy-agent (gRPC); there is no
+# interactive login path (SSH stays off).
 #
 # Masking these units in the rootfs is fatal: systemd's 90-systemd.preset
 # enables getty@/serial-getty@ and the rootfs preset-all pass rejects "enable a

--- a/tools/publisher/manifest_entry.go
+++ b/tools/publisher/manifest_entry.go
@@ -17,6 +17,10 @@ type ManifestEntry struct {
 	Storage   string `json:"storage,omitempty"`
 	Nightly   bool   `json:"nightly"`
 	Stability string `json:"stability,omitempty"`
+	// PR, when > 0, marks this entry as a per-PR debug build. It routes all
+	// uploads and manifest writes into the self-contained pr/<N>/ subtree
+	// instead of the shared release manifests. Zero for release/nightly.
+	PR int `json:"pr,omitempty"`
 
 	FilePath     string `json:"file_path,omitempty"`
 	FileSize     int64  `json:"file_size,omitempty"`
@@ -96,4 +100,13 @@ func readManifestEntry(path string) (ManifestEntry, error) {
 		return entry, fmt.Errorf("validating %s: %w", path, err)
 	}
 	return entry, nil
+}
+
+// prPrefix returns the GCS object-path prefix for a per-PR build ("pr/<N>/"),
+// or "" for a normal release/nightly build (pr <= 0).
+func prPrefix(pr int) string {
+	if pr <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("pr/%d/", pr)
 }

--- a/tools/publisher/manifest_entry_test.go
+++ b/tools/publisher/manifest_entry_test.go
@@ -101,3 +101,31 @@ func TestReadManifestEntryRejectsGarbage(t *testing.T) {
 		t.Error("readManifestEntry accepted a missing file")
 	}
 }
+
+func TestPRPrefix(t *testing.T) {
+	if got := prPrefix(0); got != "" {
+		t.Fatalf("prPrefix(0) = %q, want empty", got)
+	}
+	if got := prPrefix(-1); got != "" {
+		t.Fatalf("prPrefix(-1) = %q, want empty", got)
+	}
+	if got := prPrefix(123); got != "pr/123/" {
+		t.Fatalf("prPrefix(123) = %q, want pr/123/", got)
+	}
+}
+
+func TestManifestEntryPRRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "entry.json")
+	in := ManifestEntry{Device: "raspberry-pi-5", Version: "pr-123", PR: 123, FilePath: "pr/123/images/raspberry-pi-5/pr-123/x.img.gz"}
+	if err := writeManifestEntry(p, in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := readManifestEntry(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.PR != 123 {
+		t.Fatalf("PR = %d, want 123", out.PR)
+	}
+}

--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -33,6 +33,28 @@ import (
 
 var log = logrus.New()
 
+// imageObjectPath, deviceManifestPath, and masterManifestPath build the GCS
+// object paths for OS images and manifests. Every path is routed through one
+// of these so that a single active "prefix" (prPrefix(pr), "" for
+// release/nightly builds) consistently isolates a per-PR debug build into its
+// own pr/<N>/ subtree without touching the shared release paths.
+func imageObjectPath(prefix, deviceType, version, filename string) string {
+	return fmt.Sprintf("%simages/%s/%s/%s", prefix, deviceType, version, filename)
+}
+func deviceManifestPath(prefix, deviceType string) string {
+	return fmt.Sprintf("%smanifests/%s.json", prefix, deviceType)
+}
+func masterManifestPath(prefix string) string {
+	return prefix + "manifests/master.json"
+}
+
+// imageDirPrefix builds the GCS prefix used to list/delete all objects under
+// a device's image directory (images/<device>/), respecting the active
+// pr/<N>/ prefix the same way imageObjectPath does.
+func imageDirPrefix(prefix, deviceType string) string {
+	return fmt.Sprintf("%simages/%s/", prefix, deviceType)
+}
+
 // gcloudTokenSource implements oauth2.TokenSource. It seeds with the caller's
 // initial access token and refreshes by running "gcloud auth print-access-token"
 // once the token is within 10 seconds of expiry (the oauth2 package's Valid()
@@ -430,7 +452,7 @@ type uploadResult struct {
 }
 
 // uploadFileAsync uploads a file asynchronously
-func uploadFileAsync(ctx context.Context, bucket *storage.BucketHandle, localPath, deviceType, version string) <-chan uploadResult {
+func uploadFileAsync(ctx context.Context, bucket *storage.BucketHandle, prefix, localPath, deviceType, version string) <-chan uploadResult {
 	resultChan := make(chan uploadResult, 1)
 
 	go func() {
@@ -444,7 +466,7 @@ func uploadFileAsync(ctx context.Context, bucket *storage.BucketHandle, localPat
 		}
 		expectedSize := localInfo.Size()
 
-		path, err := uploadFile(ctx, bucket, localPath, deviceType, version)
+		path, err := uploadFile(ctx, bucket, prefix, localPath, deviceType, version)
 		if err != nil {
 			resultChan <- uploadResult{err: err}
 			return
@@ -1090,11 +1112,18 @@ func main() {
 	removeDevice := flag.Bool("remove-device", false, "Remove a device (or firmware chip with --firmware) and all its images/versions")
 	removeKeepFiles := flag.Bool("remove-keep-files", false, "When removing a device, keep uploaded files in the bucket (only remove from manifests)")
 	renameTo := flag.String("rename-to", "", "Rename a device (--device old --rename-to new) by moving all files and updating manifests")
+	pr := flag.Int("pr", 0, "Per-PR debug build: route uploads and manifests into pr/<N>/ instead of the shared release manifests")
 	flag.Parse()
 
 	if *debug {
 		log.SetLevel(logrus.DebugLevel)
 	}
+
+	// The active path prefix for this invocation: "" for release/nightly
+	// builds, "pr/<N>/" for a per-PR debug build. The --apply-metadata branch
+	// overrides this below from the entry's own PR field, since that job runs
+	// without --pr and must route purely from what --upload-only recorded.
+	prefix := prPrefix(*pr)
 
 	// Validate args
 	if *listImages {
@@ -1282,7 +1311,7 @@ func main() {
 
 	// Send notification for an already-published release
 	if *notifyOnly {
-		manifestPath := fmt.Sprintf("manifests/%s.json", *deviceType)
+		manifestPath := deviceManifestPath(prefix, *deviceType)
 		r, err := bucket.Object(manifestPath).NewReader(ctx)
 		if err != nil {
 			log.WithError(err).Fatal("Failed to read device manifest")
@@ -1315,7 +1344,7 @@ func main() {
 			"is_nightly":  *nightly,
 			"stability":   *stability,
 		})
-		if err := updateMasterManifest(ctx, logger, bucket, *deviceType, *version, *nightly, *stability, true); err != nil {
+		if err := updateMasterManifest(ctx, logger, bucket, prefix, *deviceType, *version, *nightly, *stability, true); err != nil {
 			log.WithError(err).Fatal("Failed to update master manifest")
 		}
 		return
@@ -1330,14 +1359,18 @@ func main() {
 		if err != nil {
 			log.WithError(err).Fatal("Failed to read manifest entry")
 		}
+		// This job runs without --pr; route purely from what --upload-only
+		// stamped onto the entry so the publish-pr job needs only the entry.
+		prefix = prPrefix(entry.PR)
 		log.WithFields(logrus.Fields{
 			"entry":   *applyMetadata,
 			"device":  entry.Device,
 			"version": entry.Version,
 			"storage": entry.Storage,
+			"pr":      entry.PR,
 		}).Info("Applying manifest entry")
 		updateManifests(
-			ctx, bucket, entry.Device, entry.Version,
+			ctx, bucket, prefix, entry.Device, entry.Version,
 			entry.FilePath, entry.FileSize, entry.FileChecksum,
 			entry.BmapPath,
 			entry.ZstPath, entry.ZstChecksum, entry.ZstSize,
@@ -1352,7 +1385,7 @@ func main() {
 
 	// Rename device if requested
 	if *renameTo != "" {
-		if err := renameDeviceType(ctx, bucket, *deviceType, *renameTo); err != nil {
+		if err := renameDeviceType(ctx, bucket, prefix, *deviceType, *renameTo); err != nil {
 			log.WithError(err).Fatal("Failed to rename device")
 		}
 		return
@@ -1368,7 +1401,7 @@ func main() {
 
 	// Remove device if requested
 	if *removeDevice {
-		if err := removeDeviceType(ctx, bucket, *deviceType, !*removeKeepFiles); err != nil {
+		if err := removeDeviceType(ctx, bucket, prefix, *deviceType, !*removeKeepFiles); err != nil {
 			log.WithError(err).Fatal("Failed to remove device")
 		}
 		return
@@ -1384,7 +1417,7 @@ func main() {
 
 	// Create device if requested
 	if *createDevice {
-		if err := createNewDevice(ctx, bucket, *deviceType, *stability); err != nil {
+		if err := createNewDevice(ctx, bucket, prefix, *deviceType, *stability); err != nil {
 			log.WithError(err).Fatal("Failed to create device")
 		}
 		return
@@ -1392,13 +1425,13 @@ func main() {
 
 	// Promote nightly to stable if requested
 	if *promote {
-		promoteNightlyToStable(ctx, bucket, *deviceType, *version, *notifyDiscord)
+		promoteNightlyToStable(ctx, bucket, prefix, *deviceType, *version, *notifyDiscord)
 		return
 	}
 
 	// Swap image file if requested
 	if *swap {
-		swapImageFile(ctx, bucket, *deviceType, *version, *localFile, *recoveryFile, *nightly)
+		swapImageFile(ctx, bucket, prefix, *deviceType, *version, *localFile, *recoveryFile, *nightly)
 		return
 	}
 
@@ -1528,33 +1561,33 @@ func main() {
 
 		var mainUploadChan <-chan uploadResult
 		if mainResult.compressedPath != "" {
-			mainUploadChan = uploadFileAsync(ctx, bucket, mainResult.compressedPath, *deviceType, *version)
+			mainUploadChan = uploadFileAsync(ctx, bucket, prefix, mainResult.compressedPath, *deviceType, *version)
 		}
 
 		var otaUpdateUploadChan <-chan uploadResult
 		if otaUpdateResult.compressedPath != "" {
-			otaUpdateUploadChan = uploadFileAsync(ctx, bucket, otaUpdateResult.compressedPath, *deviceType, *version)
+			otaUpdateUploadChan = uploadFileAsync(ctx, bucket, prefix, otaUpdateResult.compressedPath, *deviceType, *version)
 		}
 
 		var recoveryUploadChan <-chan uploadResult
 		if recoveryResult.compressedPath != "" {
-			recoveryUploadChan = uploadFileAsync(ctx, bucket, recoveryResult.compressedPath, *deviceType, *version)
+			recoveryUploadChan = uploadFileAsync(ctx, bucket, prefix, recoveryResult.compressedPath, *deviceType, *version)
 		}
 
 		var flashpackUploadChan <-chan uploadResult
 		if flashpackResult.compressedPath != "" {
-			flashpackUploadChan = uploadFileAsync(ctx, bucket, flashpackResult.compressedPath, *deviceType, *version)
+			flashpackUploadChan = uploadFileAsync(ctx, bucket, prefix, flashpackResult.compressedPath, *deviceType, *version)
 		}
 
 		var sbomUploadChan <-chan uploadResult
 		if sbomResult.compressedPath != "" {
-			sbomUploadChan = uploadFileAsync(ctx, bucket, sbomResult.compressedPath, *deviceType, *version)
+			sbomUploadChan = uploadFileAsync(ctx, bucket, prefix, sbomResult.compressedPath, *deviceType, *version)
 		}
 
 		// bmap is a small XML file; upload it in parallel with the others.
 		var bmapUploadChan <-chan uploadResult
 		if *bmapFile != "" {
-			bmapUploadChan = uploadFileAsync(ctx, bucket, *bmapFile, *deviceType, *version)
+			bmapUploadChan = uploadFileAsync(ctx, bucket, prefix, *bmapFile, *deviceType, *version)
 		}
 
 		// Generate and upload a seekable-zstd image for OS images (the
@@ -1577,7 +1610,7 @@ func main() {
 					log.WithError(zstErr).Fatal("Failed to generate seekable-zstd image")
 				}
 				log.Info("Seekable-zstd image generated, uploading...")
-				zstUploadChan = uploadFileAsync(ctx, bucket, zstPath, *deviceType, *version)
+				zstUploadChan = uploadFileAsync(ctx, bucket, prefix, zstPath, *deviceType, *version)
 			}
 		}
 
@@ -1669,6 +1702,7 @@ func main() {
 				Storage:           *storage,
 				Nightly:           *nightly,
 				Stability:         *stability,
+				PR:                *pr,
 				FilePath:          mainUpload.path,
 				FileSize:          mainUpload.size,
 				FileChecksum:      mainResult.checksum,
@@ -1698,7 +1732,7 @@ func main() {
 
 		// Update manifests with results
 		updateManifests(
-			ctx, bucket, *deviceType, *version,
+			ctx, bucket, prefix, *deviceType, *version,
 			mainUpload.path, mainUpload.size, mainResult.checksum,
 			bmapUpload.path,
 			zstUpload.path, zstChecksum, zstUpload.size,
@@ -1710,7 +1744,7 @@ func main() {
 		)
 	} else {
 		// Just update manifests for existing file
-		imagePath := fmt.Sprintf("images/%s/%s/%s", *deviceType, *version, filepath.Base(*localFile))
+		imagePath := imageObjectPath(prefix, *deviceType, *version, filepath.Base(*localFile))
 
 		obj := bucket.Object(imagePath)
 		attrs, err := obj.Attrs(ctx)
@@ -1725,7 +1759,7 @@ func main() {
 		var otaUpdateChecksum string
 		var recoveryChecksum string
 
-		manifestPath := fmt.Sprintf("manifests/%s.json", *deviceType)
+		manifestPath := deviceManifestPath(prefix, *deviceType)
 		manifestObj := bucket.Object(manifestPath)
 		r, err := manifestObj.NewReader(ctx)
 		if err == nil {
@@ -1756,7 +1790,7 @@ func main() {
 		var otaUpdatePath string
 		var otaUpdateSize int64
 		if *otaUpdateFile != "" {
-			otaUpdatePath = fmt.Sprintf("images/%s/%s/%s", *deviceType, *version, filepath.Base(*otaUpdateFile))
+			otaUpdatePath = imageObjectPath(prefix, *deviceType, *version, filepath.Base(*otaUpdateFile))
 			menderObj := bucket.Object(otaUpdatePath)
 			menderAttrs, err := menderObj.Attrs(ctx)
 			if err != nil {
@@ -1770,7 +1804,7 @@ func main() {
 		var recoveryPath string
 		var recoverySize int64
 		if *recoveryFile != "" {
-			recoveryPath = fmt.Sprintf("images/%s/%s/%s", *deviceType, *version, filepath.Base(*recoveryFile))
+			recoveryPath = imageObjectPath(prefix, *deviceType, *version, filepath.Base(*recoveryFile))
 			recoveryObj := bucket.Object(recoveryPath)
 			recoveryAttrs, err := recoveryObj.Attrs(ctx)
 			if err != nil {
@@ -1780,7 +1814,7 @@ func main() {
 			recoverySize = recoveryAttrs.Size
 		}
 
-		updateManifests(ctx, bucket, *deviceType, *version, imagePath, attrs.Size, mainChecksum, "", "", "", 0, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, "", 0, "", "", 0, "", *storage, *nightly, *stability, *notifyDiscord, *skipMasterManifest)
+		updateManifests(ctx, bucket, prefix, *deviceType, *version, imagePath, attrs.Size, mainChecksum, "", "", "", 0, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, "", 0, "", "", 0, "", *storage, *nightly, *stability, *notifyDiscord, *skipMasterManifest)
 	}
 }
 
@@ -1889,9 +1923,9 @@ func listImagesInBucket(ctx context.Context, bucket *storage.BucketHandle) {
 	}
 }
 
-func uploadFile(ctx context.Context, bucket *storage.BucketHandle, localPath, deviceType, version string) (string, error) {
+func uploadFile(ctx context.Context, bucket *storage.BucketHandle, prefix, localPath, deviceType, version string) (string, error) {
 	filename := filepath.Base(localPath)
-	destinationPath := fmt.Sprintf("images/%s/%s/%s", deviceType, version, filename)
+	destinationPath := imageObjectPath(prefix, deviceType, version, filename)
 
 	// Skip re-upload if the object already exists in GCS with the same size.
 	// This makes outer-retry loops (used to survive 412 manifest races when
@@ -1955,7 +1989,7 @@ func uploadFile(ctx context.Context, bucket *storage.BucketHandle, localPath, de
 	return destinationPath, nil
 }
 
-func updateManifests(ctx context.Context, bucket *storage.BucketHandle, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, flashpackPath string, flashpackSize int64, flashpackChecksum string, sbomPath string, sbomSize int64, sbomChecksum string, storage string, isNightly bool, stability string, notifyDiscord bool, skipMasterManifest bool) {
+func updateManifests(ctx context.Context, bucket *storage.BucketHandle, prefix, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, flashpackPath string, flashpackSize int64, flashpackChecksum string, sbomPath string, sbomSize int64, sbomChecksum string, storage string, isNightly bool, stability string, notifyDiscord bool, skipMasterManifest bool) {
 	logger := log.WithFields(logrus.Fields{
 		"device_type":     deviceType,
 		"version":         version,
@@ -1981,7 +2015,7 @@ func updateManifests(ctx context.Context, bucket *storage.BucketHandle, deviceTy
 
 	if skipMasterManifest {
 		logger.Info("Updating device manifest (master manifest will be updated by a separate publish job)")
-		if err := updateDeviceManifest(ctx, deviceLogger, bucket, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, flashpackPath, flashpackSize, flashpackChecksum, sbomPath, sbomSize, sbomChecksum, storage, isNightly); err != nil {
+		if err := updateDeviceManifest(ctx, deviceLogger, bucket, prefix, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, flashpackPath, flashpackSize, flashpackChecksum, sbomPath, sbomSize, sbomChecksum, storage, isNightly); err != nil {
 			logger.WithError(err).Fatal("Failed to update device manifest")
 		}
 	} else {
@@ -2003,12 +2037,12 @@ func updateManifests(ctx context.Context, bucket *storage.BucketHandle, deviceTy
 
 		go func() {
 			defer wg.Done()
-			deviceErrChan <- updateDeviceManifest(ctx, deviceLogger, bucket, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, flashpackPath, flashpackSize, flashpackChecksum, sbomPath, sbomSize, sbomChecksum, storage, isNightly)
+			deviceErrChan <- updateDeviceManifest(ctx, deviceLogger, bucket, prefix, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, flashpackPath, flashpackSize, flashpackChecksum, sbomPath, sbomSize, sbomChecksum, storage, isNightly)
 		}()
 
 		go func() {
 			defer wg.Done()
-			masterErrChan <- updateMasterManifest(ctx, masterLogger, bucket, deviceType, version, isNightly, stability, false)
+			masterErrChan <- updateMasterManifest(ctx, masterLogger, bucket, prefix, deviceType, version, isNightly, stability, false)
 		}()
 
 		wg.Wait()
@@ -2184,7 +2218,7 @@ func compressSeekableZstd(srcPath, dstPath string) error {
 // into the stable version's image directory and returns the new path. It
 // returns "" when srcPath is empty, malformed, or the copy fails — the caller
 // treats a missing artifact as non-fatal, matching the image-copy behavior.
-func copyManifestArtifact(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, srcPath, deviceType, stableVersion, label string) string {
+func copyManifestArtifact(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, prefix, srcPath, deviceType, stableVersion, label string) string {
 	if srcPath == "" {
 		return ""
 	}
@@ -2192,7 +2226,7 @@ func copyManifestArtifact(ctx context.Context, logger *logrus.Entry, bucket *sto
 	if len(parts) < 4 {
 		return ""
 	}
-	destPath := fmt.Sprintf("images/%s/%s/%s", deviceType, stableVersion, parts[len(parts)-1])
+	destPath := imageObjectPath(prefix, deviceType, stableVersion, parts[len(parts)-1])
 	if _, err := bucket.Object(destPath).CopierFrom(bucket.Object(srcPath)).Run(ctx); err != nil {
 		logger.WithError(err).Warnf("Failed to copy %s, continuing without it", label)
 		return ""
@@ -2201,8 +2235,8 @@ func copyManifestArtifact(ctx context.Context, logger *logrus.Entry, bucket *sto
 	return destPath
 }
 
-func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, flashpackPath string, flashpackSize int64, flashpackChecksum string, sbomPath string, sbomSize int64, sbomChecksum string, storageType string, isNightly bool) error {
-	manifestPath := fmt.Sprintf("manifests/%s.json", deviceType)
+func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, prefix, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, flashpackPath string, flashpackSize int64, flashpackChecksum string, sbomPath string, sbomSize int64, sbomChecksum string, storageType string, isNightly bool) error {
+	manifestPath := deviceManifestPath(prefix, deviceType)
 	logger = logger.WithField("manifest_path", manifestPath)
 	logger.Info("Processing device manifest")
 
@@ -2465,8 +2499,8 @@ func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 	return fmt.Errorf("failed to write device manifest after %d attempts: concurrent writers", maxRetries)
 }
 
-func updateMasterManifest(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, deviceType, version string, isNightly bool, stability string, forceWrite bool) error {
-	masterManifestPath := "manifests/master.json"
+func updateMasterManifest(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, prefix, deviceType, version string, isNightly bool, stability string, forceWrite bool) error {
+	masterManifestPath := masterManifestPath(prefix)
 	logger = logger.WithField("manifest_path", masterManifestPath)
 	logger.Info("Processing master manifest")
 
@@ -2511,7 +2545,7 @@ func updateMasterManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 					}
 					correctVersion := (isNightly && existingInfo.LatestNightly == version) ||
 						(!isNightly && existingInfo.Latest == version)
-					expectedPath := fmt.Sprintf("manifests/%s.json", deviceType)
+					expectedPath := deviceManifestPath(prefix, deviceType)
 					if correctVersion && existingInfo.ManifestPath == expectedPath && existingInfo.Stability == expectedStability {
 						logger.Info("Master manifest already up-to-date, skipping write")
 						return nil
@@ -2543,7 +2577,7 @@ func updateMasterManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 		}
 
 		// Always set ManifestPath to ensure consistency
-		deviceInfo.ManifestPath = fmt.Sprintf("manifests/%s.json", deviceType)
+		deviceInfo.ManifestPath = deviceManifestPath(prefix, deviceType)
 
 		// Set stability (defaults to "stable" if empty)
 		if stability == "" {
@@ -2617,7 +2651,7 @@ func updateMasterManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 }
 
 // createNewDevice creates a new device type in both manifests
-func createNewDevice(ctx context.Context, bucket *storage.BucketHandle, deviceType string, stability string) error {
+func createNewDevice(ctx context.Context, bucket *storage.BucketHandle, prefix, deviceType string, stability string) error {
 	logger := log.WithFields(logrus.Fields{
 		"device_type": deviceType,
 		"stability":   stability,
@@ -2625,7 +2659,7 @@ func createNewDevice(ctx context.Context, bucket *storage.BucketHandle, deviceTy
 	logger.Info("Creating new device type")
 
 	// Create empty device manifest
-	manifestPath := fmt.Sprintf("manifests/%s.json", deviceType)
+	manifestPath := deviceManifestPath(prefix, deviceType)
 	manifest := DeviceManifest{
 		DeviceID: deviceType,
 		Versions: make(map[string]VersionMetadata),
@@ -2657,7 +2691,7 @@ func createNewDevice(ctx context.Context, bucket *storage.BucketHandle, deviceTy
 	logger.Info("Successfully created device manifest")
 
 	// Update master manifest to include the new device
-	masterManifestPath := "manifests/master.json"
+	masterManifestPath := masterManifestPath(prefix)
 	masterObj := bucket.Object(masterManifestPath)
 
 	var masterManifest MasterManifest
@@ -2721,7 +2755,7 @@ func createNewDevice(ctx context.Context, bucket *storage.BucketHandle, deviceTy
 }
 
 // promoteNightlyToStable promotes a nightly build to stable release by removing "nightly" from version name
-func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, deviceType, nightlyVersion string, notifyDiscord bool) {
+func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, prefix, deviceType, nightlyVersion string, notifyDiscord bool) {
 	logger := log.WithFields(logrus.Fields{
 		"device_type":     deviceType,
 		"nightly_version": nightlyVersion,
@@ -2752,7 +2786,7 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 	logger.WithField("stable_version", stableVersion).Info("Derived stable version name")
 
 	// Read device manifest
-	manifestPath := fmt.Sprintf("manifests/%s.json", deviceType)
+	manifestPath := deviceManifestPath(prefix, deviceType)
 	obj := bucket.Object(manifestPath)
 
 	var manifest DeviceManifest
@@ -2793,7 +2827,7 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 		logger.WithField("path", sourcePath).Fatal("Invalid source file path format")
 	}
 	filename := parts[len(parts)-1]
-	destinationPath := fmt.Sprintf("images/%s/%s/%s", deviceType, stableVersion, filename)
+	destinationPath := imageObjectPath(prefix, deviceType, stableVersion, filename)
 
 	logger.WithFields(logrus.Fields{
 		"source_path":      sourcePath,
@@ -2818,7 +2852,7 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 		otaParts := strings.Split(sourceVersionMeta.OTAUpdatePath, "/")
 		if len(otaParts) >= 4 {
 			otaFilename := otaParts[len(otaParts)-1]
-			otaDestPath = fmt.Sprintf("images/%s/%s/%s", deviceType, stableVersion, otaFilename)
+			otaDestPath = imageObjectPath(prefix, deviceType, stableVersion, otaFilename)
 
 			otaSrcObj := bucket.Object(sourceVersionMeta.OTAUpdatePath)
 			otaDstObj := bucket.Object(otaDestPath)
@@ -2839,7 +2873,7 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 		recoveryParts := strings.Split(sourceVersionMeta.RecoveryPath, "/")
 		if len(recoveryParts) >= 4 {
 			recoveryFilename := recoveryParts[len(recoveryParts)-1]
-			recoveryDestPath = fmt.Sprintf("images/%s/%s/%s", deviceType, stableVersion, recoveryFilename)
+			recoveryDestPath = imageObjectPath(prefix, deviceType, stableVersion, recoveryFilename)
 
 			recoverySrcObj := bucket.Object(sourceVersionMeta.RecoveryPath)
 			recoveryDstObj := bucket.Object(recoveryDestPath)
@@ -2859,7 +2893,7 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 	if sourceVersionMeta.NVMEPath != "" {
 		nvmeParts := strings.Split(sourceVersionMeta.NVMEPath, "/")
 		if len(nvmeParts) >= 4 {
-			nvmeDestPath = fmt.Sprintf("images/%s/%s/%s", deviceType, stableVersion, nvmeParts[len(nvmeParts)-1])
+			nvmeDestPath = imageObjectPath(prefix, deviceType, stableVersion, nvmeParts[len(nvmeParts)-1])
 			if _, err := bucket.Object(nvmeDestPath).CopierFrom(bucket.Object(sourceVersionMeta.NVMEPath)).Run(ctx); err != nil {
 				logger.WithError(err).Warn("Failed to copy NVME image, continuing without it")
 				nvmeDestPath = ""
@@ -2875,7 +2909,7 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 	if sourceVersionMeta.SDCardPath != "" {
 		sdParts := strings.Split(sourceVersionMeta.SDCardPath, "/")
 		if len(sdParts) >= 4 {
-			sdDestPath = fmt.Sprintf("images/%s/%s/%s", deviceType, stableVersion, sdParts[len(sdParts)-1])
+			sdDestPath = imageObjectPath(prefix, deviceType, stableVersion, sdParts[len(sdParts)-1])
 			if _, err := bucket.Object(sdDestPath).CopierFrom(bucket.Object(sourceVersionMeta.SDCardPath)).Run(ctx); err != nil {
 				logger.WithError(err).Warn("Failed to copy SD card image, continuing without it")
 				sdDestPath = ""
@@ -2890,8 +2924,8 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 	// bmap describes one image, so each follows its image to the stable path.
 	// Top-level BmapPath mirrors top-level Path (NVMe) for older CLIs. A pre-fix
 	// nightly that only carries the legacy top-level BmapPath is still promoted.
-	nvmeBmapDest := copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.NVMEBmapPath, deviceType, stableVersion, "NVMe block map")
-	sdBmapDest := copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.SDCardBmapPath, deviceType, stableVersion, "SD card block map")
+	nvmeBmapDest := copyManifestArtifact(ctx, logger, bucket, prefix, sourceVersionMeta.NVMEBmapPath, deviceType, stableVersion, "NVMe block map")
+	sdBmapDest := copyManifestArtifact(ctx, logger, bucket, prefix, sourceVersionMeta.SDCardBmapPath, deviceType, stableVersion, "SD card block map")
 	var topBmapDest string
 	switch {
 	case nvmeBmapDest != "":
@@ -2899,13 +2933,13 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 	case sdBmapDest != "":
 		topBmapDest = sdBmapDest
 	case sourceVersionMeta.BmapPath != "":
-		topBmapDest = copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.BmapPath, deviceType, stableVersion, "block map")
+		topBmapDest = copyManifestArtifact(ctx, logger, bucket, prefix, sourceVersionMeta.BmapPath, deviceType, stableVersion, "block map")
 	}
 
 	// Copy seekable-zstd images, mirroring bmap promotion. Each zst follows
 	// its image to the stable path and retains its checksum/size metadata.
-	nvmeZstDest := copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.NVMEZstPath, deviceType, stableVersion, "NVMe seekable-zstd")
-	sdZstDest := copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.SDCardZstPath, deviceType, stableVersion, "SD card seekable-zstd")
+	nvmeZstDest := copyManifestArtifact(ctx, logger, bucket, prefix, sourceVersionMeta.NVMEZstPath, deviceType, stableVersion, "NVMe seekable-zstd")
+	sdZstDest := copyManifestArtifact(ctx, logger, bucket, prefix, sourceVersionMeta.SDCardZstPath, deviceType, stableVersion, "SD card seekable-zstd")
 	var topZstDest string
 	switch {
 	case nvmeZstDest != "":
@@ -2913,7 +2947,7 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 	case sdZstDest != "":
 		topZstDest = sdZstDest
 	case sourceVersionMeta.ZstPath != "":
-		topZstDest = copyManifestArtifact(ctx, logger, bucket, sourceVersionMeta.ZstPath, deviceType, stableVersion, "seekable-zstd")
+		topZstDest = copyManifestArtifact(ctx, logger, bucket, prefix, sourceVersionMeta.ZstPath, deviceType, stableVersion, "seekable-zstd")
 	}
 
 	// Create new stable version entry with promotion metadata
@@ -3032,7 +3066,7 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 	logger.Info("Successfully updated device manifest")
 
 	// Update master manifest
-	if err := updateMasterManifestForPromotion(ctx, logger, bucket, deviceType, stableVersion); err != nil {
+	if err := updateMasterManifestForPromotion(ctx, logger, bucket, prefix, deviceType, stableVersion); err != nil {
 		logger.WithError(err).Fatal("Failed to update master manifest after promotion")
 	}
 
@@ -3046,8 +3080,8 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, d
 }
 
 // updateMasterManifestForPromotion updates master manifest after promotion
-func updateMasterManifestForPromotion(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, deviceType, stableVersion string) error {
-	masterManifestPath := "manifests/master.json"
+func updateMasterManifestForPromotion(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, prefix, deviceType, stableVersion string) error {
+	masterManifestPath := masterManifestPath(prefix)
 	obj := bucket.Object(masterManifestPath)
 
 	const maxRetries = 10
@@ -3116,7 +3150,7 @@ func updateMasterManifestForPromotion(ctx context.Context, logger *logrus.Entry,
 }
 
 // swapImageFile replaces an existing version's image file while preserving metadata
-func swapImageFile(ctx context.Context, bucket *storage.BucketHandle, deviceType, version, localFile, recoveryFile string, isNightly bool) {
+func swapImageFile(ctx context.Context, bucket *storage.BucketHandle, prefix, deviceType, version, localFile, recoveryFile string, isNightly bool) {
 	logger := log.WithFields(logrus.Fields{
 		"device_type":   deviceType,
 		"version":       version,
@@ -3128,7 +3162,7 @@ func swapImageFile(ctx context.Context, bucket *storage.BucketHandle, deviceType
 	logger.Info("Starting image file swap")
 
 	// Read device manifest to validate version exists
-	manifestPath := fmt.Sprintf("manifests/%s.json", deviceType)
+	manifestPath := deviceManifestPath(prefix, deviceType)
 	obj := bucket.Object(manifestPath)
 
 	var manifest DeviceManifest
@@ -3165,7 +3199,7 @@ func swapImageFile(ctx context.Context, bucket *storage.BucketHandle, deviceType
 	}
 
 	// Upload new file
-	newPath, err := uploadFile(ctx, bucket, localFile, deviceType, version)
+	newPath, err := uploadFile(ctx, bucket, prefix, localFile, deviceType, version)
 	if err != nil {
 		logger.WithError(err).Fatal("Failed to upload new file")
 	}
@@ -3198,7 +3232,7 @@ func swapImageFile(ctx context.Context, bucket *storage.BucketHandle, deviceType
 	var newRecoveryPath, newRecoveryChecksum string
 	var newRecoverySize int64
 	if recoveryFile != "" {
-		recoveryPath, err := uploadFile(ctx, bucket, recoveryFile, deviceType, version)
+		recoveryPath, err := uploadFile(ctx, bucket, prefix, recoveryFile, deviceType, version)
 		if err != nil {
 			logger.WithError(err).Fatal("Failed to upload recovery file")
 		}
@@ -3279,7 +3313,7 @@ func swapImageFile(ctx context.Context, bucket *storage.BucketHandle, deviceType
 	}
 
 	// Update master manifest timestamp only
-	updateMasterManifestTimestamp(ctx, logger, bucket)
+	updateMasterManifestTimestamp(ctx, logger, bucket, prefix)
 
 	logger.WithFields(logrus.Fields{
 		"version":      version,
@@ -3307,8 +3341,8 @@ func calculateGCSChecksum(ctx context.Context, bucket *storage.BucketHandle, fil
 }
 
 // updateMasterManifestTimestamp updates only the timestamp in master manifest
-func updateMasterManifestTimestamp(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle) {
-	masterManifestPath := "manifests/master.json"
+func updateMasterManifestTimestamp(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, prefix string) {
+	masterManifestPath := masterManifestPath(prefix)
 	obj := bucket.Object(masterManifestPath)
 
 	var masterManifest MasterManifest
@@ -3926,7 +3960,7 @@ func deleteObjectsByPrefix(ctx context.Context, bucket *storage.BucketHandle, pr
 }
 
 // removeDeviceType removes a device type from the manifests and optionally deletes its files
-func removeDeviceType(ctx context.Context, bucket *storage.BucketHandle, deviceType string, deleteFiles bool) error {
+func removeDeviceType(ctx context.Context, bucket *storage.BucketHandle, prefix, deviceType string, deleteFiles bool) error {
 	logger := log.WithFields(logrus.Fields{
 		"device_type":  deviceType,
 		"delete_files": deleteFiles,
@@ -3934,7 +3968,7 @@ func removeDeviceType(ctx context.Context, bucket *storage.BucketHandle, deviceT
 	logger.Info("Removing device type")
 
 	// Read the master manifest
-	masterManifestPath := "manifests/master.json"
+	masterManifestPath := masterManifestPath(prefix)
 	masterObj := bucket.Object(masterManifestPath)
 
 	var masterManifest MasterManifest
@@ -3964,9 +3998,9 @@ func removeDeviceType(ctx context.Context, bucket *storage.BucketHandle, deviceT
 
 	// Delete uploaded files if requested
 	if deleteFiles {
-		prefix := fmt.Sprintf("images/%s/", deviceType)
-		logger.WithField("prefix", prefix).Info("Deleting uploaded images")
-		deleted, err := deleteObjectsByPrefix(ctx, bucket, prefix)
+		imgPrefix := imageDirPrefix(prefix, deviceType)
+		logger.WithField("prefix", imgPrefix).Info("Deleting uploaded images")
+		deleted, err := deleteObjectsByPrefix(ctx, bucket, imgPrefix)
 		if err != nil {
 			logger.WithError(err).Error("Failed to delete images")
 			return fmt.Errorf("failed to delete images: %w", err)
@@ -3975,7 +4009,7 @@ func removeDeviceType(ctx context.Context, bucket *storage.BucketHandle, deviceT
 	}
 
 	// Delete the device manifest
-	manifestPath := fmt.Sprintf("manifests/%s.json", deviceType)
+	manifestPath := deviceManifestPath(prefix, deviceType)
 	logger.WithField("manifest_path", manifestPath).Info("Deleting device manifest")
 	if err := bucket.Object(manifestPath).Delete(ctx); err != nil {
 		logger.WithError(err).Warn("Failed to delete device manifest (may not exist)")
@@ -4021,7 +4055,7 @@ func copyObject(ctx context.Context, bucket *storage.BucketHandle, src, dst stri
 }
 
 // renameDeviceType moves all files and manifest data from one device type to another
-func renameDeviceType(ctx context.Context, bucket *storage.BucketHandle, oldDevice, newDevice string) error {
+func renameDeviceType(ctx context.Context, bucket *storage.BucketHandle, prefix, oldDevice, newDevice string) error {
 	logger := log.WithFields(logrus.Fields{
 		"old_device": oldDevice,
 		"new_device": newDevice,
@@ -4029,7 +4063,7 @@ func renameDeviceType(ctx context.Context, bucket *storage.BucketHandle, oldDevi
 	logger.Info("Renaming device type")
 
 	// Read the master manifest
-	masterManifestPath := "manifests/master.json"
+	masterManifestPath := masterManifestPath(prefix)
 	masterObj := bucket.Object(masterManifestPath)
 
 	var masterManifest MasterManifest
@@ -4055,7 +4089,7 @@ func renameDeviceType(ctx context.Context, bucket *storage.BucketHandle, oldDevi
 	}
 
 	// Read the source device manifest
-	oldManifestPath := fmt.Sprintf("manifests/%s.json", oldDevice)
+	oldManifestPath := deviceManifestPath(prefix, oldDevice)
 	oldManifestObj := bucket.Object(oldManifestPath)
 
 	var deviceManifest DeviceManifest
@@ -4074,7 +4108,7 @@ func renameDeviceType(ctx context.Context, bucket *storage.BucketHandle, oldDevi
 
 	// If target device already exists, read its manifest to merge into
 	var targetManifest DeviceManifest
-	newManifestPath := fmt.Sprintf("manifests/%s.json", newDevice)
+	newManifestPath := deviceManifestPath(prefix, newDevice)
 	newManifestObj := bucket.Object(newManifestPath)
 
 	tmr, err := newManifestObj.NewReader(ctx)
@@ -4096,8 +4130,8 @@ func renameDeviceType(ctx context.Context, bucket *storage.BucketHandle, oldDevi
 	}
 
 	// Copy all image files from old device to new device
-	oldPrefix := fmt.Sprintf("images/%s/", oldDevice)
-	newPrefix := fmt.Sprintf("images/%s/", newDevice)
+	oldPrefix := imageDirPrefix(prefix, oldDevice)
+	newPrefix := imageDirPrefix(prefix, newDevice)
 	logger.WithFields(logrus.Fields{
 		"old_prefix": oldPrefix,
 		"new_prefix": newPrefix,

--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -1119,6 +1119,14 @@ func main() {
 		log.SetLevel(logrus.DebugLevel)
 	}
 
+	// --pr isolates OS-image uploads/manifests into pr/<N>/. The firmware
+	// pipeline is deliberately un-prefixed, so combining the two would silently
+	// write firmware into the SHARED manifests/master.json + firmware/<chip>/
+	// tree — the exact corruption --pr exists to prevent. Reject it loudly.
+	if *pr > 0 && *firmware {
+		log.Fatal("--pr is not supported with --firmware (PR builds publish OS images only)")
+	}
+
 	// The active path prefix for this invocation: "" for release/nightly
 	// builds, "pr/<N>/" for a per-PR debug build. The --apply-metadata branch
 	// overrides this below from the entry's own PR field, since that job runs

--- a/tools/publisher/upload_and_manifest_test.go
+++ b/tools/publisher/upload_and_manifest_test.go
@@ -14,6 +14,34 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
+// Test PR path-prefix builders
+func TestImageObjectPath(t *testing.T) {
+	if got := imageObjectPath("", "raspberry-pi-5", "1.2.3", "os.img.gz"); got != "images/raspberry-pi-5/1.2.3/os.img.gz" {
+		t.Fatalf("release path = %q", got)
+	}
+	if got := imageObjectPath("pr/123/", "raspberry-pi-5", "pr-123", "os.img.gz"); got != "pr/123/images/raspberry-pi-5/pr-123/os.img.gz" {
+		t.Fatalf("pr path = %q", got)
+	}
+}
+
+func TestDeviceManifestPath(t *testing.T) {
+	if got := deviceManifestPath("", "raspberry-pi-5"); got != "manifests/raspberry-pi-5.json" {
+		t.Fatalf("release manifest = %q", got)
+	}
+	if got := deviceManifestPath("pr/123/", "raspberry-pi-5"); got != "pr/123/manifests/raspberry-pi-5.json" {
+		t.Fatalf("pr manifest = %q", got)
+	}
+}
+
+func TestMasterManifestPath(t *testing.T) {
+	if got := masterManifestPath(""); got != "manifests/master.json" {
+		t.Fatalf("release master = %q", got)
+	}
+	if got := masterManifestPath("pr/123/"); got != "pr/123/manifests/master.json" {
+		t.Fatalf("pr master = %q", got)
+	}
+}
+
 // Test validation functions
 func TestValidateDeviceType(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What

Make PR builds installable via `wendy os install --pr N` (CLI side is a separate PR in `wendyos`). This is the **builder** half: PR builds become open-book debug images, force-build every device, upload full-parity-minus-SBOM artifacts to a self-contained `pr/<N>/` subtree in the public bucket with a per-PR manifest, and get cleaned up when the PR closes.

## Security tiers

| Tier | Trigger | Posture |
|------|---------|---------|
| Release | tag | Fortress (#172), unchanged |
| Nightly | main | In-between, unchanged |
| **PR** | `pull_request` | **Open book**: `WENDYOS_DEBUG` + `WENDYOS_SSHD` + `WENDYOS_DEBUG_UART` + `WENDYOS_DEV_LOGIN` (passwordless root) |

- New `WENDYOS_DEV_LOGIN` knob (default `0`) gates re-enabling local login + debug-tweaks; only the PR CI step sets it. Never on nightly/release.
- RPi serial console is now gated on `WENDYOS_DEBUG_UART` (endorsed hardening beyond #172 for fortress/nightly RPi). **Tegra console gating is deferred** (lives in the external `meta-tegra` layer).

## How it works

`detect-changes` force-builds all 8 targets on PRs → a PR-only step writes the dev profile to `auto.conf` → build → `publisher --pr N` routes uploads to `pr/<N>/images/...` and stamps the manifest entry → new `publish-pr` job writes `pr/<N>/manifests/{master,<device>}.json` → `pr-cleanup.yml` deletes the subtree on close, with a fail-closed weekly orphan sweep.

**Isolation invariant** (verified in review): a PR run can never write to the shared release manifests/images — every path is prefixed, `--pr`+`--firmware` is rejected, and the release `publish` job stays PR-excluded.

## Verification

- Publisher changes: Go unit tests green (path routing, PR entry round-trip, guards).
- Workflows: YAML-valid + actionlint; **real verification is the CI run this PR triggers.**
- Recipe knobs (`WENDYOS_DEV_LOGIN`, `WENDYOS_DEBUG_UART`): verified by inspection; `bitbake -e` confirmation runs in the PR build.

## Follow-ups (non-blocking)

- `pr/`-scoped GCP service account (isolation is currently code-enforced, not IAM-scoped; fork PRs fail closed).
- Tegra UART console gating; confirm Thor serial device name.

## Depends on / pairs with

CLI PR in `wendylabsinc/wendyos` (adds `wendy os install/update --pr`). **Merge this first** — the CLI can't resolve `--pr` until PR manifests exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
