### PR TITLE
wendyos-update: bump to boot-chain A/B on Orin (wendyos-update#10)

### DIFF
--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -24,6 +24,16 @@ GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 GO_SRCURI_DESTSUFFIX ?= "${@os.path.join(os.path.basename(d.getVar('S')), 'src', d.getVar('GO_IMPORT')) + '/'}"
 
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
+# 20ec14e (main, wendyos-update#10): drive rootfs A/B on Orin (t234) by switching
+# the BOOT CHAIN (nvbootctrl WITHOUT `-t rootfs`) instead of the rootfs-redundancy
+# slot, and skip the redundancy preflight on Orin. RootfsRedundancyLevel is
+# unarmable from the OS on Orin (flash-time device-tree setting; efivarfs writes
+# EINVAL), so the rootfs-redundancy slot switch is a silent no-op there — verified
+# on wendyos-test-adrian: the arm boot service exited SUCCESS yet the var stayed
+# level 0. The boot chain is coupled to the rootfs slot and needs no such
+# variable, so Orin drives it directly. Thor (t264) and unknown SoCs keep the
+# rootfs-redundancy + capsule path. Supersedes the f086a3c firmware-capability
+# gating (whose armed-redundancy preflight would refuse every Orin OTA). Builds on:
 # 33da342c (main, wendyos-update#8): install preflight refuses when tegra rootfs
 # A/B redundancy is not armed (RootfsRedundancyLevel UEFI variable missing/zero).
 # A device flashed by writing the rootfs straight to NVMe never gets it set, so
@@ -66,7 +76,7 @@ SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_
 # slot — kills the Orin Nano stale-inactive-slot false-positive, validated
 # against the real r39.2 efivar format) + structured per-slot `status` and the
 # `switch` verb.
-SRCREV = "33da342c3748bf29bc74584ac2ea1bd5880e7ed5"
+SRCREV = "20ec14eaef589967ca0279fdff98d431ade315ab"
 
 inherit go-mod systemd
 


### PR DESCRIPTION
Bumps the `wendyos-update` recipe `SRCREV` to `20ec14e` (wendyos-update `main`), shipping **wendyos-update#10**: rootfs A/B on Orin (t234) driven via the **boot chain** (`nvbootctrl` without `-t rootfs`) instead of the rootfs-redundancy slot, with the redundancy preflight skipped on Orin.

### Why
`RootfsRedundancyLevel` is **unarmable from the OS on Orin** (flash-time device-tree setting; `efivarfs` writes `EINVAL`), so the rootfs-redundancy slot switch is a silent no-op and every OTA rolled back. Verified on `wendyos-test-adrian`: the arm boot service exited SUCCESS yet the variable stayed level 0, and the firmware-capability approach (`f086a3c`, now superseded on wendyos-update main) **refused the install at preflight** on the unarmed device. The boot chain is coupled to the rootfs slot and needs no such variable, so Orin drives it directly. Thor (t264) and unknown SoCs are unchanged.

Started as a TEST PIN to validate #10's Orin image on hardware (this PR built it green); now a plain merged-main bump.

> ⚠️ #10's positive path (boot-chain switch actually moves the running rootfs slot and survives commit on Orin) is inferred, not yet confirmed by a full OTA round-trip on device — see #10's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmX1dRPhZTjb2RsBHrXAv1