### PR TITLE
TEST: Orin image with systemd-boot A/B (wendyos-update#11)

### DIFF
--- a/conf/distro/include/tegra-image.inc
+++ b/conf/distro/include/tegra-image.inc
@@ -33,6 +33,25 @@ IMAGE_INSTALL:append = " \
     v4l-utils \
     "
 
+# systemd-boot A/B boot stack (WENDYOS_TEGRA_SYSTEMDBOOT_AB = 1, set per NVMe Orin
+# machine). Swaps Orin's boot path from NVIDIA UEFI/L4TLauncher + nvbootctrl A/B
+# (whose RootfsRedundancyLevel is unarmable from the OS on Orin) to systemd-boot
+# on the writable ESP, which selects/trials the A/B rootfs slot via its native
+# +tries boot counting (a file-name rename on the FAT ESP — no runtime EFI-var
+# persistence needed):
+#   systemd-boot               the systemd-bootaa64.efi UEFI payload + bootctl
+#   wendyos-systemdboot        stage EFI + loader.conf + slot entries + kernels to
+#                              the ESP on first boot; enroll BootOrder (L4TLauncher
+#                              kept as fallback)
+#   wendyos-update-config-systemdboot  pin the systemdboot connector (not tegrauefi)
+#   efibootmgr                 the BootOrder tool the enroll service shells out to
+# L4TLauncher + the existing extlinux.conf are untouched (kept as the fallback boot
+# path). tegra-rootfs-redundancy is dropped from the packagegroup on this path (the
+# firmware A/B mechanism it arms is unused).
+IMAGE_INSTALL:append = " \
+    ${@'systemd-boot wendyos-systemdboot wendyos-update-config-systemdboot efibootmgr' if (d.getVar('WENDYOS_TEGRA_SYSTEMDBOOT_AB') or '0') == '1' else ''} \
+    "
+
 # Enable DeepStream SDK support (optional - adds ~1GB to image)
 # Tegra/NVIDIA hardware only - DeepStream requires NVIDIA GPUs
 # Also enables l4t-deepstream.csv which provides:

--- a/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
@@ -77,3 +77,14 @@ IMAGE_ROOTFS_SIZE = "16384"
 
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "jetson-orin-nano"
+
+# OS-managed A/B via systemd-boot on the writable ESP (native +tries boot
+# counting), replacing NVIDIA's firmware rootfs A/B whose RootfsRedundancyLevel
+# is unarmable from the OS on Orin (SetVariable EINVAL). Pulls in systemd-boot +
+# wendyos-systemdboot (first-boot ESP staging + BootOrder enroll, L4TLauncher kept
+# as fallback) + the systemdboot connector pin; drops tegra-rootfs-redundancy.
+# See conf/distro/include/tegra-image.inc and
+# meta-tegra-extensions/recipes-bsp/wendyos-systemdboot. NOTE: hardware-unverified
+# spike — the device-tree hand-off is the biggest open risk (see the DTB/UKI block
+# in wendyos-systemdboot.bb).
+WENDYOS_TEGRA_SYSTEMDBOOT_AB = "1"

--- a/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/loader.conf
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/loader.conf
@@ -1,0 +1,12 @@
+# systemd-boot loader configuration for the WendyOS Jetson A/B boot path.
+# Staged onto the ESP at loader/loader.conf by wendyos-systemdboot-firstboot.
+#
+# default: the counter-less slot id systemd-boot selects when no
+#   LoaderEntryOneShot/LoaderEntryDefault EFI variable overrides it. The
+#   wendyos-update systemdboot connector points LoaderEntryDefault at the
+#   committed slot via `bootctl set-default`, which takes precedence; this static
+#   default is the first-boot fallback.
+# timeout: brief menu so a serial console can intervene; 0 would hide the menu.
+default slot-a
+timeout 3
+console-mode keep

--- a/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/slot-a.conf
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/slot-a.conf
@@ -1,0 +1,11 @@
+title    WendyOS (slot A)
+linux    /a/Image
+initrd    /a/initrd
+options    root=PARTLABEL=APP ro rootwait console=ttyTCU0,115200
+# Type #1 loader entry for rootfs slot A. systemd-boot loads the kernel/initrd
+# from the ESP (paths above are ESP-relative), NOT from the ext4 rootfs, so the
+# wendyos-systemdboot-firstboot service copies slot A's kernel to <ESP>/a/ and
+# the wendyos-update connector refreshes it on every OTA install to slot A.
+# console=ttyTCU0 is the Jetson Tegra Combined UART. This file is staged as
+# loader/entries/slot-a+3.conf (the "+3" arms 3 trial boots for the automatic
+# boot assessment); a healthy commit renames the counter away.

--- a/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/slot-b.conf
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/slot-b.conf
@@ -1,0 +1,7 @@
+title    WendyOS (slot B)
+linux    /b/Image
+initrd    /b/initrd
+options    root=PARTLABEL=APP_b ro rootwait console=ttyTCU0,115200
+# Type #1 loader entry for rootfs slot B (see slot-a.conf for the full rationale).
+# root=PARTLABEL=APP_b is the second slot of the NVIDIA redundant-flash layout.
+# Staged as loader/entries/slot-b+3.conf.

--- a/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/wendyos-systemdboot-firstboot.service
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/wendyos-systemdboot-firstboot.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Enroll WendyOS systemd-boot into the UEFI BootOrder on first boot
+DefaultDependencies=no
+# Needs the ESP mounted (to stage systemd-bootaa64.efi + loader entries + the
+# per-slot kernels) and efivarfs (to register the Boot#### / reorder BootOrder).
+# Must run before the OTA boot verifier so the boot path is settled first.
+# Idempotent + guarded by a marker on the persistent data partition; the script
+# itself fails safe (leaves the existing L4TLauncher BootOrder untouched) on any
+# error.
+After=local-fs.target data.mount
+RequiresMountsFor=/boot/efi /data
+Before=wendyos-update-verify.service
+ConditionPathExists=/sys/firmware/efi/efivars
+ConditionPathExists=!/data/wendyos-update/systemdboot-enrolled
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/wendyos-systemdboot-firstboot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/wendyos-systemdboot-firstboot.sh
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/files/wendyos-systemdboot-firstboot.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# WendyOS Jetson systemd-boot first-boot enrollment.
+#
+# Runs once on a freshly flashed Orin to make systemd-boot the primary boot path
+# WITHOUT ever leaving the device unbootable:
+#   1. copy systemd-bootaa64.efi onto the ESP (both the systemd path and the
+#      removable-media fallback \EFI\BOOT\BOOTAA64.efi)
+#   2. stage loader/loader.conf + the two A/B loader entries (slot-a+3.conf,
+#      slot-b+3.conf) onto the ESP
+#   3. copy the kernel + initrd into <ESP>/a/ and <ESP>/b/ (systemd-boot loads
+#      the kernel from the ESP, not the ext4 rootfs). A fresh redundant flash has
+#      the same rootfs in both slots, so both get the running slot's kernel; the
+#      wendyos-update connector refreshes the target slot's kernel on each OTA.
+#   4. register a UEFI Boot#### for systemd-boot and put it FIRST in BootOrder,
+#      keeping the existing L4TLauncher entry enrolled as a lower-priority
+#      fallback (never deleted).
+#
+# Brick-safety is the whole point: every step that could fail is checked, and if
+# BootOrder cannot be set our entry is simply left off — the device still boots
+# L4TLauncher exactly as before. Idempotent via a marker; safe to re-run.
+set -eu
+
+ESP_MOUNT="/boot/efi"
+SRC_DIR="/usr/lib/wendyos-systemdboot"                 # loader.conf + slot-*.conf ship here
+SDBOOT_EFI="/usr/lib/systemd/boot/efi/systemd-bootaa64.efi"  # from the systemd-boot package
+MARKER="/data/wendyos-update/systemdboot-enrolled"
+LOADER='\EFI\systemd\systemd-bootaa64.efi'            # UEFI path (backslashes, on the ESP)
+LABEL="WendyOS systemd-boot"
+
+log() { echo "wendyos-systemdboot-firstboot: $*"; }
+
+[ -f "$MARKER" ] && { log "already enrolled; nothing to do"; exit 0; }
+
+# --- 0. Preconditions (fail closed = leave L4TLauncher as-is) --------------
+command -v efibootmgr >/dev/null 2>&1 || { log "efibootmgr missing; aborting (device keeps L4TLauncher)"; exit 0; }
+mountpoint -q "$ESP_MOUNT" || { log "ESP not mounted at ${ESP_MOUNT}; aborting"; exit 0; }
+[ -f "$SDBOOT_EFI" ] || { log "no ${SDBOOT_EFI}; aborting"; exit 0; }
+[ -f "${SRC_DIR}/loader.conf" ] || { log "no ${SRC_DIR}/loader.conf; aborting"; exit 0; }
+
+# Resolve the ESP's disk + partition number from the running system (don't
+# hardcode nvme0n1p11). partlabel "esp" is set by the NVIDIA flash layout.
+ESP_PART="$(readlink -f /dev/disk/by-partlabel/esp 2>/dev/null || true)"
+[ -n "$ESP_PART" ] || { log "cannot resolve /dev/disk/by-partlabel/esp; aborting"; exit 0; }
+# /dev/nvme0n1p11 -> disk=/dev/nvme0n1 partnum=11 ; /dev/sda11 -> /dev/sda + 11
+case "$ESP_PART" in
+    *[0-9]p[0-9]*) ESP_DISK="${ESP_PART%p*}"; ESP_PARTNUM="${ESP_PART##*p}" ;;
+    *)             ESP_PARTNUM="$(echo "$ESP_PART" | sed 's/.*[^0-9]\([0-9]*\)$/\1/')"
+                   ESP_DISK="${ESP_PART%"$ESP_PARTNUM"}" ;;
+esac
+[ -n "${ESP_DISK:-}" ] && [ -n "${ESP_PARTNUM:-}" ] || { log "cannot parse ESP disk/part from ${ESP_PART}; aborting"; exit 0; }
+log "ESP=${ESP_PART} disk=${ESP_DISK} part=${ESP_PARTNUM}"
+
+# --- 1. Stage systemd-boot onto the ESP ------------------------------------
+mkdir -p "${ESP_MOUNT}/EFI/systemd" "${ESP_MOUNT}/EFI/BOOT" "${ESP_MOUNT}/loader/entries"
+cp -f "$SDBOOT_EFI" "${ESP_MOUNT}/EFI/systemd/systemd-bootaa64.efi"
+# Removable-media fallback path: lets the firmware find systemd-boot even if the
+# Boot#### entry is lost, and keeps a second escape hatch alongside L4TLauncher.
+cp -f "$SDBOOT_EFI" "${ESP_MOUNT}/EFI/BOOT/BOOTAA64.efi"
+
+# --- 2. Stage loader config + the A/B entries (armed with +3 trial counter) -
+cp -f "${SRC_DIR}/loader.conf" "${ESP_MOUNT}/loader/loader.conf"
+cp -f "${SRC_DIR}/slot-a.conf" "${ESP_MOUNT}/loader/entries/slot-a+3.conf"
+cp -f "${SRC_DIR}/slot-b.conf" "${ESP_MOUNT}/loader/entries/slot-b+3.conf"
+
+# --- 3. Copy the kernel + initrd into <ESP>/a/ and <ESP>/b/ ----------------
+# systemd-boot reads the kernel from the ESP. On a fresh redundant flash both
+# rootfs slots are identical, so seed both ESP slot dirs from the running rootfs;
+# the wendyos-update connector refreshes the target slot's copy on each OTA.
+KERNEL="/boot/Image"
+INITRD="/boot/initrd"
+[ -f "$KERNEL" ] || { log "no ${KERNEL} in rootfs; aborting (device keeps L4TLauncher)"; exit 0; }
+for slot in a b; do
+    mkdir -p "${ESP_MOUNT}/${slot}"
+    cp -f "$KERNEL" "${ESP_MOUNT}/${slot}/Image"
+    [ -f "$INITRD" ] && cp -f "$INITRD" "${ESP_MOUNT}/${slot}/initrd" || log "no ${INITRD}; slot ${slot} entry must not reference one"
+done
+sync
+
+# --- 4. Register Boot#### and make it first (L4TLauncher stays as fallback) -
+# Idempotent: delete any prior entry with our label before creating a fresh one.
+OLD_IDS="$(efibootmgr | sed -n "s/^Boot\([0-9A-Fa-f]\{4\}\)\*\? ${LABEL}\$/\1/p" || true)"
+for id in $OLD_IDS; do efibootmgr -b "$id" -B >/dev/null 2>&1 || true; done
+
+if ! efibootmgr -c -d "$ESP_DISK" -p "$ESP_PARTNUM" -L "$LABEL" -l "$LOADER" >/dev/null 2>&1; then
+    log "efibootmgr create failed; device keeps its existing BootOrder (L4TLauncher). NOT marking enrolled."
+    exit 0
+fi
+
+# Our new entry's id (efibootmgr -c already prepends it to BootOrder). Confirm it
+# is present and that BootOrder is non-empty. If either check fails, we still have
+# not removed anything, so the device stays bootable.
+NEW_ID="$(efibootmgr | sed -n "s/^Boot\([0-9A-Fa-f]\{4\}\)\*\? ${LABEL}\$/\1/p" | head -n1 || true)"
+ORDER="$(efibootmgr | sed -n 's/^BootOrder: //p')"
+if [ -z "$NEW_ID" ] || [ -z "$ORDER" ]; then
+    log "post-create verification failed (id=${NEW_ID:-none} order=${ORDER:-none}); leaving as-is, NOT marking enrolled"
+    exit 0
+fi
+case ",$ORDER," in
+    *",$NEW_ID,"*) : ;;  # already present (efibootmgr -c prepends it)
+    *) efibootmgr -o "${NEW_ID},${ORDER}" >/dev/null 2>&1 || { log "could not reorder BootOrder; leaving as-is"; exit 0; } ;;
+esac
+log "enrolled Boot${NEW_ID} first; BootOrder now: $(efibootmgr | sed -n 's/^BootOrder: //p')"
+
+mkdir -p "$(dirname "$MARKER")"
+: >"$MARKER"
+log "done"

--- a/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/wendyos-systemdboot.bb
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-systemdboot/wendyos-systemdboot.bb
@@ -1,0 +1,87 @@
+SUMMARY = "WendyOS systemd-boot A/B boot stack for Jetson (Orin)"
+DESCRIPTION = "Stages systemd-boot (systemd-bootaa64.efi) + loader.conf + the two \
+A/B loader entries (slot-a/slot-b) and the per-slot kernels onto the writable ESP \
+on first boot, and enrolls a UEFI Boot#### for systemd-boot as the first \
+BootOrder entry — keeping L4TLauncher as a lower-priority fallback so the device \
+can never be left unbootable. This replaces NVIDIA's OS-unarmable firmware rootfs \
+A/B (RootfsRedundancyLevel EINVAL on Orin) with systemd-boot's native +tries boot \
+counting, whose state is a file-name rename on the FAT ESP (no runtime EFI-var \
+persistence required). The wendyos-update systemdboot connector drives the slot \
+selection at runtime. Only built into the image on the systemd-boot A/B boot path \
+(WENDYOS_TEGRA_SYSTEMDBOOT_AB = 1)."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = " \
+    file://loader.conf \
+    file://slot-a.conf \
+    file://slot-b.conf \
+    file://wendyos-systemdboot-firstboot.sh \
+    file://wendyos-systemdboot-firstboot.service \
+    "
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "wendyos-systemdboot-firstboot.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    # loader.conf + the two A/B entry templates: the first-boot service copies
+    # these onto the ESP (renaming the entries to slot-<x>+3.conf).
+    install -d ${D}${libdir}/wendyos-systemdboot
+    install -m 0644 ${UNPACKDIR}/loader.conf ${D}${libdir}/wendyos-systemdboot/loader.conf
+    install -m 0644 ${UNPACKDIR}/slot-a.conf ${D}${libdir}/wendyos-systemdboot/slot-a.conf
+    install -m 0644 ${UNPACKDIR}/slot-b.conf ${D}${libdir}/wendyos-systemdboot/slot-b.conf
+
+    install -d ${D}${sbindir}
+    install -m 0755 ${UNPACKDIR}/wendyos-systemdboot-firstboot.sh \
+        ${D}${sbindir}/wendyos-systemdboot-firstboot
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/wendyos-systemdboot-firstboot.service \
+        ${D}${systemd_system_unitdir}/
+}
+
+# systemd-boot provides systemd-bootaa64.efi (staged to the ESP) + bootctl /
+# systemd-bless-boot (used by the wendyos-update connector); efibootmgr registers
+# the Boot####. efivarfs is in-kernel.
+RDEPENDS:${PN} = "systemd systemd-boot efibootmgr"
+
+FILES:${PN} += " \
+    ${libdir}/wendyos-systemdboot \
+    ${sbindir}/wendyos-systemdboot-firstboot \
+    ${systemd_system_unitdir}/wendyos-systemdboot-firstboot.service \
+    "
+
+# ============================================================================
+# BIGGEST RISK — DEVICE TREE. READ BEFORE TAKING THIS PAST THE SPIKE.
+# ============================================================================
+# This recipe ships the SIMPLE Type #1 layout (loader/entries/slot-<x>.conf with
+# `linux`/`initrd`/`options`). Type #1 entries have NO `devicetree` line here on
+# purpose: systemd-boot's `devicetree` key hands the DTB to the kernel via the
+# EFI_DT_FIXUP_PROTOCOL, which NVIDIA's edk2 (L4T UEFI) does NOT implement — so a
+# `devicetree` line would be silently ignored and the kernel would come up with
+# the WRONG (or no) device tree. On Jetson today L4TLauncher/extlinux passes the
+# DTB (and NVIDIA's runtime-generated overlays) through a Tegra-specific path that
+# systemd-boot does not reproduce. This is UNVERIFIED on hardware and is the most
+# likely reason a first boot via systemd-boot fails.
+#
+# RECOMMENDED FOLLOW-UP (do NOT attempt in this spike): build a UKI (Unified
+# Kernel Image) per slot with the merged DTB embedded, using systemd-stub. That
+# requires the kernel built with CONFIG_EFI_ZBOOT=y and the base DTB (plus any
+# required overlays, merged AT BUILD TIME) bundled into the .efi via the stub's
+# `.dtb` PE section. The `+tries` boot counter then lives on the UKI file name in
+# EFI/Linux/ (e.g. EFI/Linux/slot-a+3.efi) instead of on the .conf, and the
+# wendyos-update systemdboot connector's entry-rename logic works unchanged
+# (same slot-<x>[+tries] naming, different directory/extension).
+#
+# The hard, DEFERRED sub-problem is NVIDIA's runtime DTB OVERLAYS (kernel-dtb
+# overlays / pinmux / plugin-manager applied by cboot/UEFI at boot). A build-time
+# UKI freezes one merged DTB and does NOT reproduce that runtime overlay merge.
+# Solving overlay-merge is explicitly OUT OF SCOPE here and must be designed
+# separately before this ships to hardware.
+# ============================================================================

--- a/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
+++ b/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
@@ -16,11 +16,16 @@ SUMMARY:${PN} = "Tegra hardware support packages"
 # (blacksail's tegra-flash-init does not RDEPEND on it), so gate on BOTH the
 # SoC and the scarthgap layer tree — a bare tegra234 check would wrongly pull
 # it on blacksail Orin ("Nothing PROVIDES tegra-flash-reboot").
+# tegra-rootfs-redundancy arms NVIDIA's firmware A/B (RootfsRedundancyLevel) and
+# reboots. On the systemd-boot A/B boot path (WENDYOS_TEGRA_SYSTEMDBOOT_AB = 1)
+# that firmware mechanism is unused — slot selection lives in systemd-boot's own
+# +tries boot counting on the ESP — and the var is unarmable from the OS on Orin
+# anyway, so drop the arming service there (it would only burn a boot trying).
 RDEPENDS:${PN} = " \
     ${@'tegra-flash-reboot' if ('tegra234' in d.getVar('MACHINEOVERRIDES').split(':') and (d.getVar('WENDYOS_LAYER_TREE') or '') == 'scarthgap') else ''} \
+    ${@'' if (d.getVar('WENDYOS_TEGRA_SYSTEMDBOOT_AB') or '0') == '1' else 'tegra-rootfs-redundancy'} \
     tegra-tools-tegrastats \
     tegra-bootcontrol-overlay \
-    tegra-rootfs-redundancy \
     setup-nv-boot-control \
     packagegroup-nvidia-container \
     "

--- a/meta-tegra-extensions/recipes-core/wendyos-update-config-systemdboot/files/config.json
+++ b/meta-tegra-extensions/recipes-core/wendyos-update-config-systemdboot/files/config.json
@@ -1,0 +1,3 @@
+{
+  "connector": "systemdboot"
+}

--- a/meta-tegra-extensions/recipes-core/wendyos-update-config-systemdboot/wendyos-update-config-systemdboot.bb
+++ b/meta-tegra-extensions/recipes-core/wendyos-update-config-systemdboot/wendyos-update-config-systemdboot.bb
@@ -1,0 +1,25 @@
+SUMMARY = "wendyos-update connector config for Jetson systemd-boot A/B (systemdboot)"
+DESCRIPTION = "Installs /etc/wendyos-update/config.json pinning the wendyos-update \
+OTA client to the systemdboot connector on the Jetson systemd-boot A/B boot path. \
+The connector MUST be pinned: auto-detect would otherwise pick tegrauefi \
+(nvbootctrl is present) and drive NVIDIA's firmware A/B mechanism, whose \
+RootfsRedundancyLevel is unarmable from the OS on Orin. Jetson analogue of the \
+RPi wendyos-update-config. Only built into the image when \
+WENDYOS_TEGRA_SYSTEMDBOOT_AB = 1."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = "file://config.json"
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+do_install() {
+    install -d ${D}${sysconfdir}/wendyos-update
+    install -m 0644 ${UNPACKDIR}/config.json ${D}${sysconfdir}/wendyos-update/config.json
+}
+
+# The config dir is also created by the wendyos-update recipe (the <phase>.d
+# hook dirs); allow both to ship it.
+FILES:${PN} = "${sysconfdir}/wendyos-update/config.json"

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -23,7 +23,10 @@ GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 # to go.bbclass where it already sets this.
 GO_SRCURI_DESTSUFFIX ?= "${@os.path.join(os.path.basename(d.getVar('S')), 'src', d.getVar('GO_IMPORT')) + '/'}"
 
-SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
+# TEMPORARY TEST PIN (jo/systemdboot-ab): points at the systemdboot connector
+# branch so the image binary actually contains the connector this image pins via
+# config.json. REVERT branch=main + a merged-main SRCREV before merge.
+SRC_URI = "git://${GO_IMPORT};protocol=https;branch=jo/systemdboot-connector;destsuffix=${GO_SRCURI_DESTSUFFIX}"
 # 33da342c (main, wendyos-update#8): install preflight refuses when tegra rootfs
 # A/B redundancy is not armed (RootfsRedundancyLevel UEFI variable missing/zero).
 # A device flashed by writing the rootfs straight to NVMe never gets it set, so
@@ -66,7 +69,8 @@ SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_
 # slot — kills the Orin Nano stale-inactive-slot false-positive, validated
 # against the real r39.2 efivar format) + structured per-slot `status` and the
 # `switch` verb.
-SRCREV = "33da342c3748bf29bc74584ac2ea1bd5880e7ed5"
+# TEMPORARY: systemdboot A/B connector (jo/systemdboot-connector).
+SRCREV = "625c28e96d98b7dfad6ea3ce7c7e4551f42f4020"
 
 inherit go-mod systemd
 


### PR DESCRIPTION
## What

Builds an **installable Orin image** using **systemd-boot** for A/B (native `+tries` boot counting), to validate on hardware. Pins the `wendyos-update` recipe to `jo/systemdboot-connector` (wendyos-update#11) so the image binary contains the `systemdboot` connector, and adds the builder stack under `meta-tegra-extensions/`:

- `wendyos-systemdboot` — `EFI_PROVIDER=systemd-boot`; a brick-safe idempotent first-boot oneshot that stages `systemd-bootaa64.efi` + `loader.conf` + two `slot-<a|b>+3.conf` entries + each slot's kernel/initrd onto the ESP, then `efibootmgr -c` first in BootOrder **keeping L4TLauncher as fallback**.
- `wendyos-update-config-systemdboot` — pins `connector=systemdboot`.
- `tegra-image.inc` — install gated on `WENDYOS_TEGRA_SYSTEMDBOOT_AB` (set `=1` on Orin Nano NVMe); `tegra-rootfs-redundancy` dropped on this path.

One of three parallel A/B approaches (see wendyos-update#10 boot-chain fix / Builder#181, and the GRUB2 PRs).

## How to validate

Flash → `wendy device update` → reboot; confirm the running slot moved (systemd-boot booted the trial entry) and commit blesses it; force a bad slot → confirm auto-rollback via the `+tries` counter.

## ⚠️ Biggest risk & before-merge

- **DTB:** kernel boots on edk2's DTB; NVIDIA camera overlays are NOT applied (UKI+`EFI_ZBOOT` route documented as follow-up). This is the most likely first-boot issue.
- Not locally buildable; recipes mirror proven models by eye. **Revert the wendyos-update test pin to main before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)