### PR TITLE
TEST: Orin image with GRUB2 A/B (wendyos-update#12)

### DIFF
--- a/conf/distro/include/tegra-image.inc
+++ b/conf/distro/include/tegra-image.inc
@@ -33,6 +33,23 @@ IMAGE_INSTALL:append = " \
     v4l-utils \
     "
 
+# GRUB2 A/B boot stack (WENDYOS_TEGRA_GRUB_AB = 1, set per NVMe Orin machine;
+# default OFF here). Swaps Orin's boot path from NVIDIA UEFI/L4TLauncher +
+# nvbootctrl A/B (whose RootfsRedundancyLevel is unarmable from the OS on Orin)
+# to a GRUB2 EFI payload on the ESP that selects the A/B rootfs slot from an
+# OS-writable grubenv:
+#   wendyos-grub                  grubaa64.efi + grub.cfg + grubenv (staged to ESP)
+#   wendyos-grub-firstboot        stage to ESP + enroll BootOrder (L4TLauncher kept)
+#   wendyos-update-config-grubenv pin the grubenv connector (not tegrauefi)
+#   efibootmgr                    BootOrder enroll tool the first-boot service uses
+#   grub-editenv                  runtime grubenv editor the grubenv connector uses
+# L4TLauncher stays enrolled as the fallback boot path. tegra-rootfs-redundancy
+# is dropped from the packagegroup on this path (its firmware A/B mechanism is
+# unused and unarmable on Orin).
+IMAGE_INSTALL:append = " \
+    ${@'wendyos-grub wendyos-grub-firstboot wendyos-update-config-grubenv efibootmgr grub-editenv' if (d.getVar('WENDYOS_TEGRA_GRUB_AB') or '0') == '1' else ''} \
+    "
+
 # Enable DeepStream SDK support (optional - adds ~1GB to image)
 # Tegra/NVIDIA hardware only - DeepStream requires NVIDIA GPUs
 # Also enables l4t-deepstream.csv which provides:

--- a/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
@@ -11,6 +11,28 @@ require conf/machine/jetson-orin-nano-devkit-nvme.conf
 UBOOT_EXTLINUX = "1"
 USE_REDUNDANT_FLASH_LAYOUT_DEFAULT = "1"
 
+# --- OS-managed A/B via GRUB2 (grubaa64.efi on the ESP + BootOrder) ---------
+# Orin's NVIDIA firmware rootfs redundancy (RootfsRedundancyLevel) cannot be
+# armed from the OS (efivar writes EINVAL), so nvbootctrl slot switches no-op.
+# On this path a GRUB2 UEFI app enrolled FIRST in BootOrder (L4TLauncher kept as
+# fallback) owns A/B slot selection from an OS-writable grubenv on the ESP FAT,
+# and the wendyos-update `grubenv` connector drives it. Turning this knob on
+# wires the GRUB stack into the image (see tegra-image.inc) and drops the
+# unarmable tegra-rootfs-redundancy service (see packagegroup-wendyos-tegra.bb).
+WENDYOS_TEGRA_GRUB_AB = "1"
+
+# grub-efi (oe-core) build tuning for the A/B grubaa64.efi. GRUB_BUILDIN embeds
+# the modules the A/B grub.cfg needs so the EFI app is self-contained on the FAT
+# ESP (no external module load): filesystem (ext2/fat), GPT + label search,
+# linux loader, GOP console, and the loadenv/configfile/scripting primitives the
+# grubenv trial logic uses. EFIDIR is the grub-mkimage prefix AND the ESP subdir
+# GRUB looks in for grub.cfg + grubenv — pinned to /EFI/wendyos so it matches
+# where the first-boot service stages the files. These are global (config-scope)
+# so the grub-efi recipe itself sees them.
+EFI_PROVIDER = "grub-efi"
+EFIDIR = "/EFI/wendyos"
+GRUB_BUILDIN += "ext2 fat part_gpt search search_label linux efi_gop configfile echo test loadenv normal boot"
+
 MENDER_FEATURES_DISABLE:append = " mender-uboot"
 MENDER_EFI_LOADER = ""
 

--- a/meta-tegra-extensions/recipes-bsp/wendyos-grub-firstboot/files/wendyos-grub-firstboot.service
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-grub-firstboot/files/wendyos-grub-firstboot.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Enroll WendyOS GRUB2 into the UEFI BootOrder on first boot
+DefaultDependencies=no
+# Needs the ESP mounted (to stage grubaa64.efi/grub.cfg/grubenv) and efivarfs
+# (to register the Boot#### / reorder BootOrder). Must run before the OTA boot
+# verifier so the boot path is settled first. Idempotent + guarded by a marker
+# on the persistent data partition; the script itself fails safe (leaves the
+# existing L4TLauncher BootOrder untouched) on any error.
+After=local-fs.target data.mount
+RequiresMountsFor=/boot/efi /data
+Before=wendyos-update-verify.service
+ConditionPathExists=/sys/firmware/efi/efivars
+ConditionPathExists=!/data/wendyos-update/grub-enrolled
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/wendyos-grub-firstboot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-tegra-extensions/recipes-bsp/wendyos-grub-firstboot/files/wendyos-grub-firstboot.sh
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-grub-firstboot/files/wendyos-grub-firstboot.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# WendyOS Jetson GRUB2 first-boot enrollment.
+#
+# Runs once on a freshly flashed Orin to make our GRUB2 the primary boot path
+# WITHOUT ever leaving the device unbootable:
+#   1. copy grubaa64.efi + grub.cfg (+ grubenv if absent) onto the ESP, into the
+#      GRUB prefix dir EFI/wendyos (matches EFIDIR / the grubenv connector path)
+#   2. register a UEFI Boot#### for grubaa64.efi and put it FIRST in BootOrder,
+#      keeping the existing L4TLauncher entry enrolled as a lower-priority
+#      fallback (never deleted).
+#
+# Brick-safety is the whole point: every step that could fail is checked, and if
+# BootOrder cannot be set our entry is simply left off — the device still boots
+# L4TLauncher exactly as before. Idempotent via a marker; safe to re-run.
+set -eu
+
+ESP_MOUNT="/boot/efi"
+ESP_DIR="${ESP_MOUNT}/EFI/wendyos"        # GRUB prefix (matches EFIDIR)
+SRC_DIR="/usr/lib/wendyos-grub"           # image ships grubaa64.efi + grub.cfg + grubenv here
+MARKER="/data/wendyos-update/grub-enrolled"
+LOADER='\EFI\wendyos\grubaa64.efi'        # UEFI path (backslashes, on the ESP)
+LABEL="WendyOS GRUB"
+
+log() { echo "wendyos-grub-firstboot: $*"; }
+
+[ -f "$MARKER" ] && { log "already enrolled; nothing to do"; exit 0; }
+
+# --- 0. Preconditions (fail closed = leave L4TLauncher as-is) --------------
+command -v efibootmgr >/dev/null 2>&1 || { log "efibootmgr missing; aborting (device keeps L4TLauncher)"; exit 0; }
+mountpoint -q "$ESP_MOUNT" || { log "ESP not mounted at ${ESP_MOUNT}; aborting"; exit 0; }
+[ -f "${SRC_DIR}/grubaa64.efi" ] || { log "no ${SRC_DIR}/grubaa64.efi; aborting"; exit 0; }
+
+# Resolve the ESP's disk + partition number from the running system (don't
+# hardcode nvme0n1p11). partlabel "esp" is set by the NVIDIA flash layout.
+ESP_PART="$(readlink -f /dev/disk/by-partlabel/esp 2>/dev/null || true)"
+[ -n "$ESP_PART" ] || { log "cannot resolve /dev/disk/by-partlabel/esp; aborting"; exit 0; }
+# /dev/nvme0n1p11 -> disk=/dev/nvme0n1 partnum=11 ; /dev/sda11 -> /dev/sda + 11
+case "$ESP_PART" in
+    *[0-9]p[0-9]*) ESP_DISK="${ESP_PART%p*}"; ESP_PARTNUM="${ESP_PART##*p}" ;;
+    *)             ESP_PARTNUM="$(echo "$ESP_PART" | sed 's/.*[^0-9]\([0-9]*\)$/\1/')"
+                   ESP_DISK="${ESP_PART%"$ESP_PARTNUM"}" ;;
+esac
+[ -n "${ESP_DISK:-}" ] && [ -n "${ESP_PARTNUM:-}" ] || { log "cannot parse ESP disk/part from ${ESP_PART}; aborting"; exit 0; }
+log "ESP=${ESP_PART} disk=${ESP_DISK} part=${ESP_PARTNUM}"
+
+# --- 1. Stage grubaa64.efi + grub.cfg (+ grubenv if virgin) onto the ESP ----
+mkdir -p "$ESP_DIR"
+cp -f "${SRC_DIR}/grubaa64.efi" "${ESP_DIR}/grubaa64.efi"
+cp -f "${SRC_DIR}/grub.cfg"     "${ESP_DIR}/grub.cfg"
+# Only seed the grubenv if the ESP has none: a re-run (or a re-flash that kept
+# the ESP) must never reset live A/B state. GRUB save_env rewrites this file
+# in place, so it must stay the exact 1024-byte block created at build time.
+[ -f "${ESP_DIR}/grubenv" ] || cp -f "${SRC_DIR}/grubenv" "${ESP_DIR}/grubenv"
+sync
+
+# --- 2. Register Boot#### and make it first (L4TLauncher stays as fallback) -
+# Idempotent: delete any prior entry with our label before creating a fresh one.
+OLD_IDS="$(efibootmgr | sed -n "s/^Boot\([0-9A-Fa-f]\{4\}\)\*\? ${LABEL}\$/\1/p" || true)"
+for id in $OLD_IDS; do efibootmgr -b "$id" -B >/dev/null 2>&1 || true; done
+
+if ! efibootmgr -c -d "$ESP_DISK" -p "$ESP_PARTNUM" -L "$LABEL" -l "$LOADER" >/dev/null 2>&1; then
+    log "efibootmgr create failed; device keeps its existing BootOrder (L4TLauncher). NOT marking enrolled."
+    exit 0
+fi
+
+# Our new entry's id (efibootmgr -c already prepends it to BootOrder). Confirm it
+# is present and that BootOrder is non-empty. If either check fails, we still have
+# not removed anything, so the device stays bootable.
+NEW_ID="$(efibootmgr | sed -n "s/^Boot\([0-9A-Fa-f]\{4\}\)\*\? ${LABEL}\$/\1/p" | head -n1 || true)"
+ORDER="$(efibootmgr | sed -n 's/^BootOrder: //p')"
+if [ -z "$NEW_ID" ] || [ -z "$ORDER" ]; then
+    log "post-create verification failed (id=${NEW_ID:-none} order=${ORDER:-none}); leaving as-is, NOT marking enrolled"
+    exit 0
+fi
+case ",$ORDER," in
+    *",$NEW_ID,"*) : ;;  # already present (efibootmgr -c prepends it)
+    *) efibootmgr -o "${NEW_ID},${ORDER}" >/dev/null 2>&1 || { log "could not reorder BootOrder; leaving as-is"; exit 0; } ;;
+esac
+log "enrolled Boot${NEW_ID} first; BootOrder now: $(efibootmgr | sed -n 's/^BootOrder: //p')"
+
+mkdir -p "$(dirname "$MARKER")"
+: >"$MARKER"
+log "done"

--- a/meta-tegra-extensions/recipes-bsp/wendyos-grub-firstboot/wendyos-grub-firstboot.bb
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-grub-firstboot/wendyos-grub-firstboot.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Enroll WendyOS GRUB2 into the UEFI BootOrder on first boot (Jetson)"
+DESCRIPTION = "One-shot boot service that stages grubaa64.efi + grub.cfg + \
+grubenv onto the (upstream-populated) ESP and registers a UEFI Boot#### for \
+grubaa64.efi as the first BootOrder entry — keeping L4TLauncher enrolled as a \
+lower-priority fallback so the device can never be left unbootable. Idempotent \
+(marker on /data) and fails safe: any error leaves the existing BootOrder \
+untouched. Only built into the image on the GRUB A/B boot path \
+(WENDYOS_TEGRA_GRUB_AB = 1)."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = " \
+    file://wendyos-grub-firstboot.sh \
+    file://wendyos-grub-firstboot.service \
+    "
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "wendyos-grub-firstboot.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${UNPACKDIR}/wendyos-grub-firstboot.sh \
+        ${D}${sbindir}/wendyos-grub-firstboot
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/wendyos-grub-firstboot.service \
+        ${D}${systemd_system_unitdir}/
+}
+
+# efibootmgr registers the Boot#### / reorders BootOrder; the staged GRUB payload
+# ships in wendyos-grub. efivarfs is in-kernel.
+RDEPENDS:${PN} = "systemd efibootmgr wendyos-grub"
+
+FILES:${PN} += " \
+    ${sbindir}/wendyos-grub-firstboot \
+    ${systemd_system_unitdir}/wendyos-grub-firstboot.service \
+    "

--- a/meta-tegra-extensions/recipes-bsp/wendyos-grub/files/grub.cfg
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-grub/files/grub.cfg
@@ -1,0 +1,86 @@
+# WendyOS A/B grub.cfg — GRUB2 rootfs A/B for Jetson Orin under UEFI.
+#
+# GRUB (grubaa64.efi) is enrolled FIRST in the UEFI BootOrder by
+# wendyos-grub-firstboot, ahead of NVIDIA L4TLauncher (kept as the fallback).
+# This config selects the A/B rootfs slot from the grubenv (beside grubaa64.efi
+# on the ESP, at the GRUB prefix /EFI/wendyos) using the RAUC contrib/grub.conf
+# model, and loads that slot's kernel directly.
+#
+# Env-var contract (identical to the wendyos-update `grubenv` connector):
+#   ORDER   "A B" | "B A"   slot preference order; the head is the intended slot
+#   A_OK / B_OK   0|1        slot is a known-good boot target
+#   A_TRY / B_TRY 0|1        a one-shot trial of the slot is in flight
+#
+# Trial/rollback mechanism: for the first slot in ORDER that is OK and not yet
+# tried, set its TRY=1 and save_env BEFORE booting. A boot that dies before
+# userspace confirms (wendyos-update MarkGood clears TRY) leaves TRY=1, so the
+# next boot skips that slot and falls to the other OK slot. If no slot is
+# eligible (both trials burned), clear the stale TRY flags and boot the ORDER
+# head anyway — brick avoidance.
+#
+# ===========================================================================
+# KNOWN HARDWARE RISK — NVIDIA DEVICE-TREE OVERLAYS ARE NOT APPLIED HERE.
+# ---------------------------------------------------------------------------
+# There is deliberately NO `devicetree` line below: GRUB inherits the DTB that
+# edk2/UEFI installed in the EFI configuration table (Canonical's Jetson model),
+# which preserves edk2's runtime DTB fixups. BUT NVIDIA camera / peripheral
+# `.dtbo` overlays that L4TLauncher+extlinux would normally apply are NOT merged
+# by GRUB. Any board needing those overlays must have them PRE-MERGED into the
+# base DTB at build time (fdtoverlay / a merged .dtb shipped in edk2). This is
+# an unsolved follow-up on this path — see the GRUB A/B design notes. Do not
+# assume camera/CSI or other overlay-dependent peripherals work until the merged
+# DTB is in place.
+#
+# SECONDARY RISK — the full NVIDIA `extlinux.conf` APPEND (cbootargs, console,
+# etc.) is NOT inherited either; only the minimal cmdline below is passed. Tune
+# it to match the board's required kernel arguments.
+# ===========================================================================
+
+set timeout=1
+set default=""
+
+# --- Load persisted A/B state (falls back to compiled defaults if virgin) ---
+load_env
+if [ "${ORDER}" = "" ] ; then set ORDER="A B" ; fi
+if [ "${A_OK}"  = "" ] ; then set A_OK=1 ; fi
+if [ "${A_TRY}" = "" ] ; then set A_TRY=0 ; fi
+if [ "${B_OK}"  = "" ] ; then set B_OK=0 ; fi
+if [ "${B_TRY}" = "" ] ; then set B_TRY=0 ; fi
+
+# --- Pick the first ORDER slot that is OK and not already tried -------------
+# The "${default}" = "" guards make the FIRST eligible slot in ORDER win
+# (no dependence on `break`, which is not relied upon in GRUB script).
+for SLOT in ${ORDER} ; do
+    if [ "${default}" = "" -a "${SLOT}" = "A" -a "${A_OK}" = "1" -a "${A_TRY}" = "0" ] ; then
+        set default="slotA" ; set A_TRY=1 ; save_env A_TRY
+    fi
+    if [ "${default}" = "" -a "${SLOT}" = "B" -a "${B_OK}" = "1" -a "${B_TRY}" = "0" ] ; then
+        set default="slotB" ; set B_TRY=1 ; save_env B_TRY
+    fi
+done
+
+# --- No eligible slot: clear stale trials and boot the ORDER head -----------
+if [ "${default}" = "" ] ; then
+    echo "wendyos: no eligible A/B slot; clearing stale trial flags and booting the ORDER head"
+    set A_TRY=0 ; set B_TRY=0 ; save_env A_TRY B_TRY
+    for SLOT in ${ORDER} ; do
+        if [ "${default}" = "" -a "${SLOT}" = "A" ] ; then set default="slotA" ; fi
+        if [ "${default}" = "" -a "${SLOT}" = "B" ] ; then set default="slotB" ; fi
+    done
+fi
+
+# --- Slot menuentries -------------------------------------------------------
+# `search --label` matches the ext4 FILESYSTEM label; the rootfs slots must be
+# labelled APP / APP_b for this to resolve (flag: verify the flash layout sets
+# the fs label, not only the GPT partlabel). The kernel root= uses the GPT
+# PARTLABEL, which udev resolves via /dev/disk/by-partlabel regardless.
+menuentry "WendyOS slot A (APP)" --id slotA {
+    search --no-floppy --label APP --set=root
+    linux /boot/Image root=PARTLABEL=APP rootwait rw console=ttyTCU0,115200 console=tty0
+    initrd /boot/initrd
+}
+menuentry "WendyOS slot B (APP_b)" --id slotB {
+    search --no-floppy --label APP_b --set=root
+    linux /boot/Image root=PARTLABEL=APP_b rootwait rw console=ttyTCU0,115200 console=tty0
+    initrd /boot/initrd
+}

--- a/meta-tegra-extensions/recipes-bsp/wendyos-grub/wendyos-grub.bb
+++ b/meta-tegra-extensions/recipes-bsp/wendyos-grub/wendyos-grub.bb
@@ -1,0 +1,63 @@
+SUMMARY = "WendyOS A/B GRUB2 payload (grubaa64.efi + grub.cfg + grubenv) for Jetson"
+DESCRIPTION = "Stages the GRUB2 A/B boot stack into the image for the first-boot \
+enroll service: the self-contained grubaa64.efi built by oe-core grub-efi (with \
+the A/B modules embedded via GRUB_BUILDIN), the A/B grub.cfg (RAUC grub.conf \
+model — pick the first ORDER slot with <S>_OK=1 && <S>_TRY=0, one-shot TRY \
+trial, fall back otherwise), and a pre-created grubenv seeded to boot slot A. \
+These are shipped under ${libdir}/wendyos-grub (a staging area, NOT the ESP); \
+wendyos-grub-firstboot copies them onto the mounted ESP and enrolls BootOrder. \
+Only built into the image on the GRUB A/B boot path (WENDYOS_TEGRA_GRUB_AB = 1)."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = "file://grub.cfg"
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+# grub-efi builds the aarch64 EFI application (grubaa64.efi) with GRUB_BUILDIN
+# modules embedded (set in the machine conf); grub-native provides grub-editenv
+# to pre-create the grubenv block at build time.
+DEPENDS = "grub-efi grub-native"
+
+# Pull the freshly built EFI app out of grub-efi's deploy step.
+do_install[depends] += "grub-efi:do_deploy"
+
+# Pre-create + seed the grubenv (a fixed 1024-byte GRUB environment block).
+# Initial state: slot A is the factory-good slot, B is empty. grub.cfg boots A,
+# and the wendyos-update grubenv connector arms B on the first OTA.
+do_compile() {
+    grub-editenv ${B}/grubenv create
+    grub-editenv ${B}/grubenv set ORDER="A B" A_OK=1 A_TRY=0 B_OK=0 B_TRY=0
+}
+
+do_install() {
+    install -d ${D}${libdir}/wendyos-grub
+
+    # grub-efi deploys the built aarch64 EFI application into DEPLOY_DIR_IMAGE.
+    # Its exact filename is set by grub-efi.bbclass (${GRUB_IMAGE}); glob to be
+    # resilient to prefix/name differences across oe-core versions, then install
+    # it under the canonical grubaa64.efi the first-boot service expects.
+    src="$(ls -1 ${DEPLOY_DIR_IMAGE}/grub-efi-bootaa64.efi \
+                 ${DEPLOY_DIR_IMAGE}/grubaa64.efi \
+                 ${DEPLOY_DIR_IMAGE}/*aa64.efi 2>/dev/null | head -n1)"
+    if [ -z "${src}" ] || [ ! -f "${src}" ]; then
+        bbfatal "grub-efi did not deploy an aarch64 EFI image to ${DEPLOY_DIR_IMAGE}"
+    fi
+    install -m 0644 "${src}" ${D}${libdir}/wendyos-grub/grubaa64.efi
+
+    install -m 0644 ${UNPACKDIR}/grub.cfg ${D}${libdir}/wendyos-grub/grub.cfg
+    install -m 0644 ${B}/grubenv          ${D}${libdir}/wendyos-grub/grubenv
+}
+
+FILES:${PN} = " \
+    ${libdir}/wendyos-grub/grubaa64.efi \
+    ${libdir}/wendyos-grub/grub.cfg \
+    ${libdir}/wendyos-grub/grubenv \
+    "
+
+# The staged EFI app is a prebuilt binary from grub-efi; nothing to strip/scan.
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+EXCLUDE_FROM_SHLIBS = "1"

--- a/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
+++ b/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-wendyos-tegra.bb
@@ -16,11 +16,16 @@ SUMMARY:${PN} = "Tegra hardware support packages"
 # (blacksail's tegra-flash-init does not RDEPEND on it), so gate on BOTH the
 # SoC and the scarthgap layer tree — a bare tegra234 check would wrongly pull
 # it on blacksail Orin ("Nothing PROVIDES tegra-flash-reboot").
+# tegra-rootfs-redundancy arms NVIDIA's firmware A/B (RootfsRedundancyLevel) and
+# reboots. On the GRUB2 A/B boot path (WENDYOS_TEGRA_GRUB_AB = 1) that firmware
+# mechanism is unused — slot selection lives in the grubenv — and the var is
+# unarmable from the OS on Orin anyway, so drop the arming service there (it
+# would only burn a boot trying).
 RDEPENDS:${PN} = " \
     ${@'tegra-flash-reboot' if ('tegra234' in d.getVar('MACHINEOVERRIDES').split(':') and (d.getVar('WENDYOS_LAYER_TREE') or '') == 'scarthgap') else ''} \
+    ${@'' if (d.getVar('WENDYOS_TEGRA_GRUB_AB') or '0') == '1' else 'tegra-rootfs-redundancy'} \
     tegra-tools-tegrastats \
     tegra-bootcontrol-overlay \
-    tegra-rootfs-redundancy \
     setup-nv-boot-control \
     packagegroup-nvidia-container \
     "

--- a/meta-tegra-extensions/recipes-core/wendyos-update-config-grubenv/files/config.json
+++ b/meta-tegra-extensions/recipes-core/wendyos-update-config-grubenv/files/config.json
@@ -1,0 +1,3 @@
+{
+  "connector": "grubenv"
+}

--- a/meta-tegra-extensions/recipes-core/wendyos-update-config-grubenv/wendyos-update-config-grubenv.bb
+++ b/meta-tegra-extensions/recipes-core/wendyos-update-config-grubenv/wendyos-update-config-grubenv.bb
@@ -1,0 +1,25 @@
+SUMMARY = "wendyos-update connector config for Jetson GRUB2 A/B (grubenv)"
+DESCRIPTION = "Installs /etc/wendyos-update/config.json pinning the wendyos-update \
+OTA client to the grubenv connector on the Jetson GRUB2 A/B boot path. On this \
+path the board is driven by a GRUB environment block (grubenv on the ESP) — NOT \
+NVIDIA nvbootctrl/RootfsRedundancyLevel — so the connector MUST be pinned: \
+auto-detect would pick tegrauefi (nvbootctrl is present) and use the firmware \
+A/B mechanism that is unarmable from the OS on Orin. Jetson analogue of the RPi \
+wendyos-update-config. Only built into the image when WENDYOS_TEGRA_GRUB_AB = 1."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = "file://config.json"
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+do_install() {
+    install -d ${D}${sysconfdir}/wendyos-update
+    install -m 0644 ${UNPACKDIR}/config.json ${D}${sysconfdir}/wendyos-update/config.json
+}
+
+# The config dir is also created by the wendyos-update recipe (the <phase>.d
+# hook dirs); allow both to ship it.
+FILES:${PN} = "${sysconfdir}/wendyos-update/config.json"

--- a/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
+++ b/recipes-core/wendyos-update/wendyos-update_0.1.0.bb
@@ -23,7 +23,10 @@ GO_IMPORT = "github.com/wendylabsinc/wendyos-update"
 # to go.bbclass where it already sets this.
 GO_SRCURI_DESTSUFFIX ?= "${@os.path.join(os.path.basename(d.getVar('S')), 'src', d.getVar('GO_IMPORT')) + '/'}"
 
-SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_DESTSUFFIX}"
+# TEMPORARY TEST PIN (jo/grub-ab): points at the grubenv connector branch so the
+# image binary contains the connector this image pins via config.json. REVERT
+# branch=main + a merged-main SRCREV before merge.
+SRC_URI = "git://${GO_IMPORT};protocol=https;branch=jo/grubenv-connector;destsuffix=${GO_SRCURI_DESTSUFFIX}"
 # 33da342c (main, wendyos-update#8): install preflight refuses when tegra rootfs
 # A/B redundancy is not armed (RootfsRedundancyLevel UEFI variable missing/zero).
 # A device flashed by writing the rootfs straight to NVMe never gets it set, so
@@ -66,7 +69,8 @@ SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main;destsuffix=${GO_SRCURI_
 # slot — kills the Orin Nano stale-inactive-slot false-positive, validated
 # against the real r39.2 efivar format) + structured per-slot `status` and the
 # `switch` verb.
-SRCREV = "33da342c3748bf29bc74584ac2ea1bd5880e7ed5"
+# TEMPORARY: grubenv A/B connector (jo/grubenv-connector).
+SRCREV = "a2e0e8e251a9340d23c386d2d31a8ad1efc9fdc8"
 
 inherit go-mod systemd
 


### PR DESCRIPTION
## What

Builds an **installable Orin image** using **GRUB2** for A/B (grubenv trial/rollback), to validate on hardware. Pins the `wendyos-update` recipe to `jo/grubenv-connector` so the image binary contains the `grubenv` connector, and adds the builder stack under `meta-tegra-extensions/`:

- `wendyos-grub` — `grubaa64.efi` (oe-core `grub-efi`) + a RAUC-pattern `grub.cfg` (no `devicetree` line — inherits edk2's DTB, Canonical's model) + a pre-seeded `grubenv`.
- `wendyos-grub-firstboot` — brick-safe idempotent oneshot: stage onto the ESP, `efibootmgr -c` first in BootOrder **keeping L4TLauncher as fallback**.
- `wendyos-update-config-grubenv` — pins `connector=grubenv`.
- `tegra-image.inc` — install gated on `WENDYOS_TEGRA_GRUB_AB` (set `=1` on Orin Nano NVMe); `tegra-rootfs-redundancy` dropped on this path.

One of three parallel A/B approaches (see wendyos-update#10 / Builder#181, and systemd-boot #11 / Builder#182).

## How to validate

Flash → `wendy device update` → reboot; confirm GRUB booted the trial slot and commit confirms it; force a bad slot → confirm grubenv fallback to the good slot.

## ⚠️ Biggest risk & before-merge

- **DTB:** camera `.dtbo` overlays not applied (pre-merge-at-build is the follow-up).
- `grub-efi` deployed filename / `grub-editenv` packaging need a build to confirm (hedged with a glob).
- Not locally buildable; recipes mirror proven models. **Revert the wendyos-update test pin to main before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)