### PR TITLE
boot screen: build tag/ID under the logo + commit hash on PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,6 +345,33 @@ jobs:
           ln -sfn "$scratch" "$GITHUB_WORKSPACE/build/tmp"
           echo "TMPDIR pinned to $scratch; build/tmp aliased to it"
 
+      - name: Stamp build provenance (version + commit)
+        # Bake the build's tag/ID and the exact builder commit into the image so
+        # they surface on the boot screen (/etc/issue) and in /etc/wendyos/commit.
+        # VERSION is the same string the publish step uploads under
+        # (pr-<N> | nightly-<ts> | X.Y.Z); COMMIT is the full builder SHA — the PR
+        # head on pull_request (the reviewed commit, not the ephemeral merge SHA),
+        # otherwise github.sha. Runs on every build. See WENDYOS_BUILD_* in
+        # conf/template/include/local/common.inc.
+        env:
+          BUILD_VERSION: ${{ needs.detect-changes.outputs.version }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+            BUILD_COMMIT="$PR_HEAD_SHA"
+          else
+            BUILD_COMMIT="$PUSH_SHA"
+          fi
+          {
+            echo ''
+            echo '# CI: build provenance stamped into the image'
+            echo "WENDYOS_BUILD_VERSION = \"${BUILD_VERSION}\""
+            echo "WENDYOS_BUILD_COMMIT = \"${BUILD_COMMIT}\""
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+          echo "Stamped version=${BUILD_VERSION} commit=${BUILD_COMMIT}"
+
       - name: Enable debug for nightly builds
         # Release images are production builds — no debug tools by default.
         # Nightly and workflow_dispatch builds get debug tooling so CI-flashed

--- a/conf/template/include/local/common.inc
+++ b/conf/template/include/local/common.inc
@@ -57,3 +57,10 @@ WENDYOS_DEBUG_UART ??= "0"
 # non-fortress (PR) builds. NEVER set on release or nightly. See wendyos-image.bb.
 WENDYOS_DEV_LOGIN ??= "0"
 WENDYOS_SSHD ??= "0"
+
+# Build provenance stamped into the image (boot screen /etc/issue + /etc/wendyos/commit).
+# CI overrides these in auto.conf per build: VERSION is the release/nightly/PR tag
+# (pr-<N> | nightly-<ts> | X.Y.Z), COMMIT is the full builder git SHA. Local builds
+# fall back to DISTRO_VERSION and an empty commit.
+WENDYOS_BUILD_VERSION ??= "${DISTRO_VERSION}"
+WENDYOS_BUILD_COMMIT ??= ""

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -87,6 +87,22 @@ disable_local_login() {
 # (WENDYOS_DEV_LOGIN="1") keep getty/serial-getty so the PR is debuggable.
 ROOTFS_POSTPROCESS_COMMAND += "${@'' if d.getVar('WENDYOS_DEV_LOGIN') == '1' else 'disable_local_login;'}"
 
+# Stamp build provenance onto the console boot screen (base-files' /etc/issue,
+# shown under the WendyOS logo before the login prompt). The build tag/ID is
+# shown on every build; the builder commit is added only on PR/dev builds, gated
+# on WENDYOS_DEV_LOGIN (CI sets it only for pull_request). WENDYOS_BUILD_* come
+# from auto.conf on CI and fall back to DISTRO_VERSION / "" locally (common.inc).
+# Runs after base-files installs /etc/issue, so the file is present to append to.
+stamp_boot_screen() {
+    issue="${IMAGE_ROOTFS}${sysconfdir}/issue"
+    [ -f "$issue" ] || return 0
+    printf 'Build: %s\n' "${WENDYOS_BUILD_VERSION}" >> "$issue"
+    if [ "${WENDYOS_DEV_LOGIN}" = "1" ] && [ -n "${WENDYOS_BUILD_COMMIT}" ]; then
+        printf 'Commit: %s\n' "${WENDYOS_BUILD_COMMIT}" >> "$issue"
+    fi
+}
+ROOTFS_POSTPROCESS_COMMAND += "stamp_boot_screen;"
+
 # Optional runtime package management (rpm/dnf in the rootfs).
 # Disabled by default — image is updated atomically via Mender A/B.
 # Set WENDYOS_ENABLE_PACKAGE_MANAGEMENT = "1" in local.conf or distro to enable.
@@ -175,6 +191,8 @@ BUILDCFG_VARS += " \
     WENDYOS_PERSIST_JOURNAL_LOGS \
     WENDYOS_UPDATE_BOOTLOADER \
     WENDYOS_DEEPSTREAM \
+    WENDYOS_BUILD_VERSION \
+    WENDYOS_BUILD_COMMIT \
     "
 
 # Include hardware-specific image configuration

--- a/recipes-core/wendyos-etc-binds/files/setup-etc-binds.sh
+++ b/recipes-core/wendyos-etc-binds/files/setup-etc-binds.sh
@@ -78,6 +78,13 @@ then
     cp -p /usr/lib/wendyos/version.txt /etc/wendyos/version.txt
 fi
 
+# Same OTA-freshness refresh for the builder commit stamp (see version.txt above).
+if mountpoint -q /etc/wendyos && [ -f /usr/lib/wendyos/commit ]
+then
+    log_info "Refreshing /etc/wendyos/commit from /usr/lib/wendyos/"
+    cp -p /usr/lib/wendyos/commit /etc/wendyos/commit
+fi
+
 # [Note]
 # /etc/hostname is NOT bind-mounted because file-level bind mounts prevent atomic
 # writes. hostnamectl uses rename() for atomic updates, which fails with EBUSY on

--- a/recipes-core/wendyos-identity/wendyos-identity_1.0.bb
+++ b/recipes-core/wendyos-identity/wendyos-identity_1.0.bb
@@ -60,6 +60,14 @@ do_install() {
     # (via the /data bind mount) on every boot to stay OTA-fresh.
     ln -sf ../../usr/lib/wendyos/version.txt ${D}${sysconfdir}/wendyos/version.txt
 
+    # Builder git commit this image was built from (empty on plain local builds).
+    # Same read-only-rootfs + symlink pattern as version.txt so it survives the
+    # /etc/wendyos bind mount on Tegra; setup-etc-binds.sh keeps the bound copy
+    # OTA-fresh. WENDYOS_BUILD_COMMIT is set by CI in auto.conf (see common.inc).
+    echo "${WENDYOS_BUILD_COMMIT}" > ${WORKDIR}/commit
+    install -m 0644 ${WORKDIR}/commit ${D}${nonarch_libdir}/wendyos/commit
+    ln -sf ../../usr/lib/wendyos/commit ${D}${sysconfdir}/wendyos/commit
+
     # Create build ID file (actual date will be set at first boot if needed)
     echo "WendyOS-${DISTRO_VERSION}" > ${WORKDIR}/wendyos-build-id
     install -m 0644 ${WORKDIR}/wendyos-build-id ${D}${sysconfdir}/wendyos-build-id
@@ -95,6 +103,8 @@ FILES:${PN} += "${sysconfdir}/wendyos"
 FILES:${PN} += "${sysconfdir}/wendyos/device-type"
 FILES:${PN} += "${sysconfdir}/wendyos/version.txt"
 FILES:${PN} += "${nonarch_libdir}/wendyos/version.txt"
+FILES:${PN} += "${sysconfdir}/wendyos/commit"
+FILES:${PN} += "${nonarch_libdir}/wendyos/commit"
 FILES:${PN} += "${sysconfdir}/wendyos-build-id"
 
 CONFFILES:${PN} += "${sysconfdir}/wendyos/device-type"


### PR DESCRIPTION
## What

Stamps **build provenance** into every WendyOS image and shows it on the **console boot screen** — `/etc/issue`, directly under the WendyOS logo, before the login prompt:

- **`Build: <tag/ID>`** — on **every** build (`pr-<N>` | `nightly-<ts>` | `X.Y.Z`)
- **`Commit: <sha>`** — **PR builds only**, full builder git SHA

Also writes the builder commit to **`/etc/wendyos/commit`**, alongside `version.txt` / `device-type` / `wendyos-build-id`.

Example on a PR image:

```
WendyOS - AI-Powered Edge Computing Platform
<hostname> <tty>

Build: pr-182
Commit: 0123456789abcdef0123456789abcdef01234567
```

A nightly/release image shows only the `Build:` line.

## Why

Makes a flashed device self-identifying: you can tell at a glance from the attached monitor / serial console exactly which build (and, on a PR image, which commit) is running — no SSH or `wendy device` round-trip. Pairs with `wendy os install --pr` (#180): a PR image now names its own PR and commit on screen.

## How

| Piece | Change |
|---|---|
| `common.inc` | Weak defaults `WENDYOS_BUILD_VERSION ??= "${DISTRO_VERSION}"`, `WENDYOS_BUILD_COMMIT ??= ""` |
| `build.yml` | New step writes both to `auto.conf` on every build. `COMMIT` = PR head SHA on `pull_request` (the reviewed commit, not the merge SHA), else `github.sha` |
| `wendyos-image.bb` | `stamp_boot_screen` `ROOTFS_POSTPROCESS_COMMAND` appends to `/etc/issue`; commit line gated on `WENDYOS_DEV_LOGIN` |
| `wendyos-identity` | Authoritative `/usr/lib/wendyos/commit` + `/etc/wendyos/commit` symlink (same pattern as `version.txt`) |
| `setup-etc-binds.sh` | Refreshes the bound `/etc/wendyos/commit` each boot for OTA freshness on Tegra |

**PR-build gate:** reuses `WENDYOS_DEV_LOGIN` (CI already sets it to `"1"` only on `pull_request`) as the is-PR signal — no new variable.

**Tegra bind mount:** `/etc/wendyos/commit` mirrors the `version.txt` authoritative-rootfs + symlink + boot-time refresh pattern, so it survives the `/etc/wendyos` → `/data` bind mount and stays fresh across OTA.

## Testing

- `build.yml` validated (YAML parse); new step uses the `env:`-var-quoted pattern (no workflow injection).
- `setup-etc-binds.sh` passes `bash -n`.
- `/etc/issue` rendering dry-run against the real `recipes-core/base-files/files/issue` confirms: PR build → `Build:` + `Commit:`; nightly → `Build:` only.
- Full on-device validation happens when CI builds this PR's image (`wendy os install --pr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)