### PR TITLE
ci: abort wedged bitbake builds instead of idling for hours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,12 @@ jobs:
       # Federation still works on the self-hosted platform.
       id-token: write
     runs-on: [self-hosted, linux, x64, wendyos-builder]
+    # Backstop against a wedged build holding a shared runner for hours. Healthy
+    # CI builds run in ~8-18 min off the warm NVMe caches; a cold-ish build is
+    # well under an hour. The stall watchdog on the build step aborts a hung
+    # bitbake far sooner (see run 29087311971: 82 min wedged on a hung do_fetch
+    # before a manual cancel); this is the last-resort ceiling if that misses.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
@@ -475,9 +481,18 @@ jobs:
           # population glitches — and pass on retry (validated: both Orin and
           # Thor needed one). The retry is cheap: sstate and downloads persist,
           # so the second pass reuses everything the first produced.
-          make build MACHINE="$MACHINE" || {
+          #
+          # Wrap each attempt in the stall watchdog: if bitbake reports no task
+          # events for STALL_ABORT_SECONDS (a hung do_fetch on an unreachable
+          # mirror wedges the scheduler with no effective timeout), it kills the
+          # build tree so the attempt fails fast instead of idling for hours. A
+          # transient network stall then gets the same second chance as any
+          # other cold-attempt glitch above.
+          watchdog=./scripts/run-with-stall-watchdog.sh
+          export STALL_ABORT_SECONDS="${STALL_ABORT_SECONDS:-1800}"
+          "$watchdog" make build MACHINE="$MACHINE" || {
             echo "::warning::make build failed on first attempt; retrying once"
-            make build MACHINE="$MACHINE"
+            "$watchdog" make build MACHINE="$MACHINE"
           }
 
       # The persistent NVMe cache is written in place by the build (sstate,

--- a/scripts/run-with-stall-watchdog.sh
+++ b/scripts/run-with-stall-watchdog.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# run-with-stall-watchdog.sh — run a bitbake build and abort it if the
+# scheduler wedges (as opposed to merely being slow).
+#
+# Why this exists: a network do_fetch can hang on an unreachable/slow upstream
+# mirror with no effective timeout. When a *sibling* fetch then fails hard,
+# bitbake stops launching new tasks and waits for the already-running (hung)
+# fetches to finish — which they never do. The build then sits idle for as long
+# as the job is allowed to run (GitHub's 6h default) until a human cancels it.
+# See run 29087311971 / PR #187: ~5 min of real work, then 82 min wedged on
+# systemd/linux-yocto/systemd-boot do_fetch before a manual cancel.
+#
+# The signal: bitbake's knotty UI prints a heartbeat roughly every 600s while
+# the scheduler makes no progress:
+#
+#   Bitbake still alive (no events for 1800s). Active tasks: ...
+#
+# The number is seconds since the last task state-change. Because the builder
+# runs dozens of tasks concurrently, a long zero-event window means the whole
+# build is wedged, not that one recipe is compiling slowly — under normal load
+# some task starts or finishes every few seconds. So we abort once that window
+# crosses STALL_ABORT_SECONDS, killing the entire bitbake process tree so the
+# caller ("make build") exits promptly instead of idling for hours.
+#
+# Usage:
+#   STALL_ABORT_SECONDS=1800 run-with-stall-watchdog.sh make build MACHINE=...
+#
+# Exit codes: the wrapped command's own code on normal completion; 124 (the
+# GNU-timeout convention) when the build was killed for stalling.
+
+set -uo pipefail
+
+STALL_ABORT_SECONDS="${STALL_ABORT_SECONDS:-1800}"
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: STALL_ABORT_SECONDS=<n> $(basename "$0") <cmd> [args...]" >&2
+  exit 2
+fi
+
+fifo="$(mktemp -u)"
+mkfifo "$fifo"
+trap 'rm -f "$fifo"' EXIT
+
+# Run the build in its own process group so a single signal reaches the whole
+# tree (bitbake forks a memory-resident server plus task workers; killing only
+# the parent would orphan them). Job-control mode (set -m) places a background
+# job in a new process group whose PGID equals the job's PID — portable across
+# Linux CI and macOS, with no dependency on setsid(1).
+set -m
+"$@" >"$fifo" 2>&1 &
+child=$!
+pgid="$child"
+set +m
+
+# Forward external cancellation (GitHub "cancel", the job's timeout-minutes) to
+# the whole group so nothing is left running on the shared self-hosted runner.
+trap 'kill -TERM -"$pgid" 2>/dev/null || true' TERM INT
+
+kill_tree() {
+  kill -TERM -"$pgid" 2>/dev/null || true
+  # bitbake shuts its workers down on SIGTERM; SIGKILL the stragglers if it
+  # hasn't exited within the grace window.
+  ( sleep 30; kill -KILL -"$pgid" 2>/dev/null || true ) &
+}
+
+stalled=0
+
+# Relay every line unchanged (the CI log must stay complete) while watching for
+# the stall heartbeat.
+while IFS= read -r line; do
+  printf '%s\n' "$line"
+  case "$line" in
+    *"no events for"*)
+      secs="$(printf '%s\n' "$line" | sed -n 's/.*no events for \([0-9]\{1,\}\)s.*/\1/p')"
+      if [ -n "$secs" ] && [ "$secs" -ge "$STALL_ABORT_SECONDS" ]; then
+        echo "::error::bitbake stalled: no task events for ${secs}s (>= ${STALL_ABORT_SECONDS}s); aborting the wedged build." >&2
+        stalled=1
+        kill_tree
+        break
+      fi
+      ;;
+  esac
+done < "$fifo"
+
+if [ "$stalled" -eq 1 ]; then
+  wait "$child" 2>/dev/null || true
+  exit 124
+fi
+
+wait "$child"
+exit $?


### PR DESCRIPTION
## Problem

`generic-x86-64 (disk)` in [run 29087311971](https://github.com/wendylabsinc/WendyOS-Builder/actions/runs/29087311971/job/86375607383?pr=187) took **1h31m** — not because it was slow, but because it **hung**. It did ~5 min of real work, then sat completely idle for **82 minutes** until a manual cancel.

Timeline from the job log:
- `13:45:24` — `ERROR: nerdctl do_fetch: Unable to fetch URL from any source` (wget exit 4 on `proxy.golang.org/.../go-nft`). Last real event.
- `13:45 → 15:07` — `Bitbake still alive (no events for 600s … 4800s)`. Active tasks frozen the whole time on `systemd` / `linux-yocto` / `systemd-boot` `do_fetch`.
- `15:07` — canceled by hand.

Root cause: a hung network `do_fetch` (unreachable/slow upstream mirror) has no effective timeout. When the sibling `nerdctl` fetch failed hard, bitbake stopped launching new tasks and waited for the already-running hung fetches to finish — which they never did. Nothing killed it (no job `timeout-minutes`, so GitHub's 6h default applied).

## Fix

- **`scripts/run-with-stall-watchdog.sh`** — relays bitbake output unchanged while watching its own `no events for Ns` heartbeat, and kills the whole build process tree once the zero-progress window crosses `STALL_ABORT_SECONDS` (default **1800s**). Because the builder runs dozens of tasks concurrently, a long zero-event window means the scheduler is wedged, not that one recipe is compiling slowly.
- **`build.yml`** — each build attempt now runs under the watchdog, so a network stall fails fast and takes the existing single retry (a transient stall gets the same second chance as any other cold-attempt glitch). Added **`timeout-minutes: 120`** on the build job as a last-resort ceiling (healthy CI builds are ~8–18 min).

## Testing

Exercised the watchdog end-to-end locally: normal success (rc 0, output relayed), non-zero passthrough (rc preserved), simulated stall (emits `::error`, exits 124, kills the tree in ~0s without waiting for a hung child), and below-threshold heartbeat (not aborted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)