### PR TITLE
security: kernel hardening + module signing on RPi (M3, phase 1)

### DIFF
--- a/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/hardening-arm64.cfg
+++ b/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/hardening-arm64.cfg
@@ -1,0 +1,9 @@
+# arm64 kernel hardening (finding M3). PTR_AUTH and BTI instructions sit in the
+# hint/NOP encoding space on CPUs older than ARMv8.3/8.5 (e.g. RPi4 Cortex-A72),
+# so enabling them is safe across all WendyOS arm64 boards (no-op where unsupported).
+CONFIG_RANDOMIZE_BASE=y
+CONFIG_UNMAP_KERNEL_AT_EL0=y
+CONFIG_ARM64_SW_TTBR0_PAN=y
+CONFIG_ARM64_PTR_AUTH=y
+CONFIG_ARM64_PTR_AUTH_KERNEL=y
+CONFIG_ARM64_BTI_KERNEL=y

--- a/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/hardening-common.cfg
+++ b/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/hardening-common.cfg
@@ -1,0 +1,26 @@
+# Kernel hardening (finding M3), KSPP-informed. Safe baseline for all WendyOS
+# kernels. Attack-surface-trim options that can have userspace dependencies
+# (LEGACY_PTYS, BINFMT_MISC) are intentionally omitted until verified.
+
+# Memory / allocator hardening
+CONFIG_SLAB_FREELIST_RANDOM=y
+CONFIG_SLAB_FREELIST_HARDENED=y
+CONFIG_SHUFFLE_PAGE_ALLOCATOR=y
+CONFIG_RANDOM_KMALLOC_CACHES=y
+CONFIG_HARDENED_USERCOPY=y
+CONFIG_FORTIFY_SOURCE=y
+CONFIG_BUG_ON_DATA_CORRUPTION=y
+
+# W^X / RO protections
+CONFIG_STRICT_KERNEL_RWX=y
+CONFIG_DEBUG_WX=y
+
+# Stack protection
+CONFIG_STACKPROTECTOR=y
+CONFIG_STACKPROTECTOR_STRONG=y
+CONFIG_VMAP_STACK=y
+
+# Info-leak reduction
+CONFIG_SECURITY_DMESG_RESTRICT=y
+CONFIG_STRICT_DEVMEM=y
+CONFIG_IO_STRICT_DEVMEM=y

--- a/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/module-sig.cfg
+++ b/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/module-sig.cfg
@@ -1,0 +1,18 @@
+# Kernel module signing (finding M3).
+# Enforce that the kernel loads only modules signed by a key in its trusted
+# keyring. RPi ships only in-tree modules, so MODULE_SIG_ALL auto-signs them at
+# build time with a per-build EPHEMERAL key (CONFIG_MODULE_SIG_KEY left empty):
+# kbuild generates the keypair, signs the in-tree .ko set, embeds the public half
+# in the kernel keyring, and discards the private half — so the module set is
+# frozen at build time and nobody can sign a new module for a shipped device.
+#
+# NOTE: Tegra is deliberately NOT wired to this fragment. Its out-of-tree
+# nvgpu/camera/display modules are built by separate recipes and would fail to
+# load under SIG_FORCE (functional brick). Tegra needs build-time vendor-module
+# signing with a persistent key first — see docs/security/specs/M3-*.
+CONFIG_MODULE_SIG=y
+CONFIG_MODULE_SIG_FORCE=y
+CONFIG_MODULE_SIG_ALL=y
+CONFIG_MODULE_SIG_SHA256=y
+CONFIG_MODULE_SIG_HASH="sha256"
+CONFIG_SYSTEM_TRUSTED_KEYS=""

--- a/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -7,6 +7,12 @@ SRC_URI:append:rpi = "${@' file://container.cfg' if d.getVar('WENDYOS_CONTAINER_
 SRC_URI:append:rpi = "${@' file://usb-gadget.cfg' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
 SRC_URI += "file://0001-dwc2-force-g_dma-false-for-BCM2712-in-peripheral-mod.patch"
 
+# Kernel hardening + module signing (finding M3). RPi ships only in-tree modules,
+# so MODULE_SIG_ALL auto-signs them with a per-build ephemeral key. Tegra is
+# deliberately NOT wired to module-sig here (its out-of-tree vendor modules would
+# fail to load under SIG_FORCE) — see docs/security/specs/M3-*.
+SRC_URI:append:rpi = " file://hardening-common.cfg file://hardening-arm64.cfg file://module-sig.cfg"
+
 # CVE backports below are 6.6.y stable backports — they apply to (and are only
 # needed on) the 6.6 kernel that the scarthgap meta-raspberrypi ships. Newer
 # kernels already carry these fixes upstream and the 6.6-context patches do NOT


### PR DESCRIPTION
## What (finding M3, phase 1)
Adds kernel hardening + module signing, scoped to **Raspberry Pi** first (in-tree modules → safe to force-sign). Draft: **CI is the build validation**; a device boot test is still required before merge.

Three fragments wired into `linux-raspberrypi`:
- **hardening-common.cfg** — KSPP baseline (slab/usercopy/FORTIFY, strict RWX, stackprotector-strong, vmap stack, dmesg/devmem restrict).
- **hardening-arm64.cfg** — KASLR, KPTI-equiv, SW-PAN, PTR_AUTH/BTI (NOPs on pre-8.3 CPUs, safe on RPi4).
- **module-sig.cfg** — `MODULE_SIG_FORCE` + `MODULE_SIG_ALL`, per-build ephemeral key; kbuild auto-signs the in-tree module set.

Flips the M3 guardrail (`CONFIG_MODULE_SIG_FORCE=y` in a tracked `.cfg`) green once merged.

## Deliberately out of scope (later phases, per `docs/security/specs/M3-*`)
- **Tegra module signing** — excluded; its out-of-tree nvgpu/camera/display modules would fail to load under SIG_FORCE (**functional brick**). Needs build-time vendor-module signing with a persistent key + on-hardware bring-up, gated + flipped last.
- **Tegra hardening fragments** (common set minus the risky rows) — after RPi is proven.
- **Jetson serial-console gate** (task A2).

## Validation
- ✅ **This PR's CI** builds the hardened + signed RPi kernel (config-merge + compile).
- ⏳ **Needs a device before merge:** RPi boots; containers + USB gadget work; `cat /sys/module/module/parameters/sig_enforce` = Y; an unsigned `insmod` is rejected. Confirm no RPi out-of-tree module exists that SIG_FORCE would block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)