### PR TITLE
security: default-deny host firewall (nftables) — finding H3

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -136,6 +136,12 @@ WENDYOS_USB_NET_MODE ?= "link-local"
 # Set to "" to allow all interfaces (discoverable on LAN)
 WENDYOS_MDNS_INTERFACES ?= ""
 
+# Host firewall (finding H3, 2026-07 security hardening audit).
+# "1" ships wendyos-firewall: a default-deny INPUT nftables ruleset applied at
+# boot by a systemd oneshot. OUTPUT/FORWARD stay permissive so container (CNI)
+# networking is unaffected. Set "0" to opt out (e.g. during bring-up/debug).
+WENDYOS_FIREWALL ?= "1"
+
 # Enable UEFI/EFI debug build for verbose boot/capsule debug output
 # Set to "1" to enable DEBUG mode (verbose UART output)
 # Set to "0" for RELEASE mode (minimal output, production default)

--- a/recipes-core/packagegroups/packagegroup-wendyos-base.bb
+++ b/recipes-core/packagegroups/packagegroup-wendyos-base.bb
@@ -33,6 +33,13 @@ RDEPENDS:${PN} = " \
     xdg-dbus-proxy \
     "
 
+# Host firewall (finding H3, 2026-07 hardening audit): default-deny INPUT
+# nftables ruleset applied at boot. Enabled by default; set WENDYOS_FIREWALL
+# = "0" in local.conf or a machine conf to opt out.
+RDEPENDS:${PN}:append = " \
+    ${@'wendyos-firewall' if (d.getVar('WENDYOS_FIREWALL') or '1') == '1' else ''} \
+    "
+
 # Recipes that bind-mount or otherwise depend on the /data partition the
 # OTA stack provides. Gated on WENDYOS_OTA != "none" (set in wendyos.conf):
 # with no OTA stack (e.g. QEMU) there is no /data partition and these

--- a/recipes-networking/wendyos-firewall/files/wendyos-firewall.nft
+++ b/recipes-networking/wendyos-firewall/files/wendyos-firewall.nft
@@ -1,0 +1,90 @@
+#!/usr/sbin/nft -f
+#
+# WendyOS host firewall -- finding H3 (2026-07 security hardening audit).
+#
+# Goal: close the INPUT attack surface (every listening service was previously
+# exposed on every network) WITHOUT bricking the device.
+#
+#   * INPUT chain  : DEFAULT-DENY, with an explicit allow-list (below).
+#   * FORWARD chain: LEFT PERMISSIVE (policy accept). The CNI bridge plugin
+#                    (10.88.0.0/16, ipMasq=true) + portmap drive container
+#                    traffic through the forward + nat hooks; filtering here
+#                    risks breaking nerdctl/container networking. Future work.
+#   * OUTPUT chain : LEFT PERMISSIVE (policy accept). Device-originated traffic.
+#
+# IMPORTANT: this file is applied with a SCOPED table replace, NOT
+# `flush ruleset`. `flush ruleset` would also wipe the nat/masquerade/portmap
+# rules that the CNI bridge + portmap plugins install (via iptables-nft) and
+# break container networking on any reload. We only ever create/replace our
+# own `inet wendyos_filter` table and never touch other tables.
+
+# Ensure the table exists so the following `delete` never errors on first load,
+# then delete + recreate it so re-applying this file is idempotent and only
+# affects our table (leaving CNI's iptables-nft tables intact).
+table inet wendyos_filter
+delete table inet wendyos_filter
+
+table inet wendyos_filter {
+	chain input {
+		type filter hook input priority filter; policy drop;
+
+		# Established/related fast-path; drop clearly invalid packets early.
+		ct state established,related accept
+		ct state invalid drop
+
+		# Loopback.
+		iif lo accept
+
+		# Trusted interfaces -- accept everything arriving on them:
+		#   usb0 - USB gadget link to the directly-connected management host.
+		#          This is the trusted out-of-band control path (wendy CLI /
+		#          agent / SSH over USB); it must never be filtered.
+		#   cni0 - container bridge (10.88.0.0/16). Containers reach host
+		#          services (DNS, portmap hairpin, agent) via this interface.
+		iifname { "usb0", "cni0" } accept
+
+		# ICMPv6 -- REQUIRED for IPv6 to work at all. Neighbor discovery and
+		# router solicitation/advertisement (SLAAC on usb0 via radvd) live
+		# here; dropping ICMPv6 breaks IPv6 connectivity. Allow all of it.
+		meta l4proto ipv6-icmp accept
+
+		# ICMPv4 -- echo/ping, path-MTU discovery, etc.
+		ip protocol icmp accept
+
+		# DHCPv4 client: replies from a DHCP server (sport 67) to us (dport 68).
+		udp sport 67 udp dport 68 accept
+
+		# DHCPv6 client: replies from a DHCPv6 server (sport 547) to us (546).
+		udp sport 547 udp dport 546 accept
+
+		# mDNS / Avahi service discovery (multicast, 5353/udp).
+		udp dport 5353 accept
+
+		# wendy-agent gRPC control plane. gRPC is HTTP/2 over TCP; the mDNS
+		# advert (_wendyos._udp in
+		# recipes-connectivity/avahi/files/wendyos-mdns.service) names port
+		# 50051, so allow TCP (the actual transport) and UDP (belt-and-braces
+		# to match the advertised record).
+		tcp dport 50051 accept
+		udp dport 50051 accept
+
+		# SSH. Deliberate anti-lockout measure BEYOND the audit's minimum
+		# allow-list: keeps a remote recovery path open if the usb0 management
+		# link is unavailable. Tighten/remove once fleet SSH exposure is
+		# reviewed (e.g. restrict to usb0 only, which is already covered above).
+		tcp dport 22 accept
+
+		# Everything else on INPUT is dropped by the chain policy.
+	}
+
+	chain forward {
+		# Permissive on purpose -- see header. Do not add a drop policy here
+		# without accounting for CNI container forwarding + masquerade.
+		type filter hook forward priority filter; policy accept;
+	}
+
+	chain output {
+		# Permissive on purpose -- device-originated traffic.
+		type filter hook output priority filter; policy accept;
+	}
+}

--- a/recipes-networking/wendyos-firewall/files/wendyos-firewall.service
+++ b/recipes-networking/wendyos-firewall/files/wendyos-firewall.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=WendyOS host firewall (nftables default-deny INPUT, finding H3)
+Documentation=https://github.com/wendylabsinc/meta-wendyos-jetson
+# Apply the ruleset before the network comes up so no window exists where a
+# listening service is exposed unfiltered.
+Wants=network-pre.target
+Before=network-pre.target
+# nftables package ships the nft binary; if a stock nftables.service exists,
+# order after it so our scoped table is the last word without racing it.
+After=nftables.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Loads only our `inet wendyos_filter` table (the file does a scoped
+# delete+recreate, never `flush ruleset`), so CNI/container nat rules survive.
+ExecStart=/usr/sbin/nft -f /etc/nftables.d/wendyos-firewall.nft
+ExecReload=/usr/sbin/nft -f /etc/nftables.d/wendyos-firewall.nft
+# Remove only our table on stop; `-` so a missing table is not an error.
+ExecStop=-/usr/sbin/nft delete table inet wendyos_filter
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-networking/wendyos-firewall/wendyos-firewall_1.0.bb
+++ b/recipes-networking/wendyos-firewall/wendyos-firewall_1.0.bb
@@ -1,0 +1,41 @@
+SUMMARY = "WendyOS host firewall (default-deny nftables INPUT ruleset)"
+DESCRIPTION = "Finding H3 of the 2026-07 security hardening audit. Installs a \
+conservative default-deny INPUT nftables ruleset plus a systemd oneshot that \
+applies it at boot. INPUT is default-deny with an explicit allow-list \
+(loopback, established/related, ICMP/ICMPv6, DHCP client, mDNS, the wendy-agent \
+port, and the usb0/cni0 trusted interfaces); OUTPUT and FORWARD stay permissive \
+so container (CNI bridge + masquerade) networking keeps working."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://wendyos-firewall.nft \
+    file://wendyos-firewall.service \
+    "
+
+S = "${UNPACKDIR}"
+
+inherit systemd
+
+# nftables provides the nft binary the service invokes at boot.
+RDEPENDS:${PN} = "nftables"
+
+do_install() {
+    # Ruleset lives under /etc/nftables.d/ (name matches *.nft so tooling and
+    # the security guardrail pick it up). Applied by our systemd oneshot.
+    install -d ${D}${sysconfdir}/nftables.d
+    install -m 0644 ${UNPACKDIR}/wendyos-firewall.nft \
+        ${D}${sysconfdir}/nftables.d/wendyos-firewall.nft
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/wendyos-firewall.service \
+        ${D}${systemd_system_unitdir}/wendyos-firewall.service
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/nftables.d/wendyos-firewall.nft \
+    ${systemd_system_unitdir}/wendyos-firewall.service \
+    "
+
+SYSTEMD_SERVICE:${PN} = "wendyos-firewall.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"


### PR DESCRIPTION
## What & why

Finding **H3** from the **2026-07 security hardening audit**: WendyOS currently ships **no host firewall**, so every listening service (wendy-agent gRPC 50051, mDNS, containerd/CNI, etc.) is exposed on **every** network interface. This PR adds a conservative **default-deny INPUT** `nftables` ruleset applied at boot.

> [!WARNING]
> **UNTESTED ON HARDWARE.** This has only been syntax/behaviour-checked with `nft -c -f` and an apply/reload test in a container — never flashed to a Jetson or Pi. A wrong rule here can make a device **unreachable**. The reviewer **must** flash this to a real device on the bench and **be prepared to re-flash / recover via serial console** if connectivity breaks. Do not roll this to a fleet before hands-on validation.

## Design

- **INPUT: default-deny** (`policy drop`) with an explicit allow-list.
- **OUTPUT and FORWARD: left permissive** (`policy accept`) on purpose — the priority is INPUT hardening. The CNI bridge (`10.88.0.0/16`, `ipMasq=true`) + `portmap` drive container traffic through the forward/nat hooks; filtering those risks breaking `nerdctl`/container networking. Hardening them is deferred.
- **No `flush ruleset`.** The ruleset does a *scoped* `delete table` + recreate of only our `inet wendyos_filter` table. `flush ruleset` would also wipe the nat/masquerade/portmap rules that CNI installs via `iptables-nft` and break containers on every reload. Verified: a pre-existing `ip cni_nat` table survives our apply **and** reload.

## What the ruleset allows (and why)

| Rule | Why |
|------|-----|
| `ct state established,related accept` / `ct state invalid drop` | Return traffic for device-initiated connections; drop malformed early. |
| `iif lo accept` | Loopback — local IPC. |
| `iifname { "usb0", "cni0" } accept` | **usb0** = USB gadget link to the directly-connected host (the trusted out-of-band management path: wendy CLI/agent/SSH). **cni0** = container bridge; containers reach host services (DNS, portmap hairpin, agent) over it. |
| `meta l4proto ipv6-icmp accept` | **Critical for IPv6.** Neighbor Discovery + Router Advertisement/Solicitation (SLAAC on usb0 via `radvd`) are ICMPv6; dropping them breaks IPv6. |
| `ip protocol icmp accept` | ICMPv4 ping / path-MTU discovery. |
| `udp sport 67 dport 68 accept` | DHCPv4 client replies. |
| `udp sport 547 dport 546 accept` | DHCPv6 client replies (belt-and-braces; default is SLAAC). |
| `udp dport 5353 accept` | mDNS / Avahi discovery. |
| `tcp dport 50051 accept` + `udp dport 50051` | **wendy-agent gRPC control plane.** gRPC is HTTP/2 over TCP; UDP added to match the `_wendyos._udp` mDNS advert in `recipes-connectivity/avahi/files/wendyos-mdns.service` (port verified against the tree, not hardcoded blind). |
| `tcp dport 22 accept` | **SSH — deliberate anti-lockout measure beyond the audit minimum.** Keeps a remote recovery path if usb0 is unavailable. Flagged in-code to tighten later (e.g. restrict to usb0, already covered). Remove if fleet policy forbids LAN SSH. |

Everything else inbound is dropped.

## Changes

- `recipes-networking/wendyos-firewall/files/wendyos-firewall.nft` — the ruleset (installed to `/etc/nftables.d/wendyos-firewall.nft`).
- `recipes-networking/wendyos-firewall/files/wendyos-firewall.service` — systemd oneshot that applies it, ordered `Before=network-pre.target` (no unfiltered window at boot).
- `recipes-networking/wendyos-firewall/wendyos-firewall_1.0.bb` — recipe; `RDEPENDS` on `nftables`, auto-enables the service.
- `recipes-core/packagegroups/packagegroup-wendyos-base.bb` — ships it by default, gated on `WENDYOS_FIREWALL`.
- `conf/distro/wendyos.conf` — new `WENDYOS_FIREWALL ?= "1"` flag.

## How to test on hardware

1. Flash the image. Keep a **serial console** attached as the recovery channel.
2. **Firewall loaded:** `systemctl status wendyos-firewall` and `nft list table inet wendyos_filter` — expect `policy drop` on `input`.
3. **Agent reachable:** from the connected host, `wendy device list` / connect over usb0; confirm the gRPC control plane on 50051 responds.
4. **mDNS discovery:** device is discoverable (`avahi-browse -a` / `wendy` discovery).
5. **SSH:** confirm SSH still works over usb0 (and LAN, given the 22 rule).
6. **Container networking (do not skip):** `nerdctl run` a container, verify outbound (`ping`/DNS from inside), and a published port (`-p`) is reachable — this exercises FORWARD + masquerade + portmap that must remain intact.
7. **IPv6:** confirm SLAAC still assigns addresses on usb0 (`ip -6 addr`) — validates ICMPv6/ND is allowed.

## How to roll back

- **Fastest, on-device:** `systemctl stop wendyos-firewall` (removes only our table, leaves CNI intact), or `nft delete table inet wendyos_filter`. Disable persistently: `systemctl disable wendyos-firewall`.
- **Build-time:** set `WENDYOS_FIREWALL = "0"` in `local.conf`/machine conf and rebuild — the package is dropped from the image.
- **Worst case:** re-flash the prior image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)