### PR TITLE
security: pin + checksum-verify build-dep downloads and dev base image (H9, L3)

### DIFF
--- a/scripts/docker/dockerfile
+++ b/scripts/docker/dockerfile
@@ -2,8 +2,11 @@
 # Dockerized Yocto Build
 #
 
-# Use Ubuntu 24.04 LTS as the basis for the Docker image
-ARG BASE_IMAGE=ubuntu:24.04
+# Use Ubuntu 24.04 LTS as the basis for the Docker image, pinned by digest for a
+# reproducible, tamper-evident base (finding L3 — not the mutable :24.04 tag).
+# Refresh the digest when intentionally rebasing:
+#   docker buildx imagetools inspect ubuntu:24.04   # -> the manifest-list digest
+ARG BASE_IMAGE=ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 FROM ${BASE_IMAGE}
 
 LABEL maintainer="adrian.bularca@gmail.com"

--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -81,6 +81,12 @@ esac
 tmp_s5=$(mktemp -d)
 wget -qO "${tmp_s5}/s5cmd.tar.gz" \
     "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-${s5cmd_arch}.tar.gz"
+# Verify the download against the release's published checksums (finding H9).
+wget -qO "${tmp_s5}/checksums.txt" \
+    "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_checksums.txt"
+s5cmd_sha="$(awk -v f="s5cmd_${S5CMD_VERSION}_Linux-${s5cmd_arch}.tar.gz" '$2 == f {print $1}' "${tmp_s5}/checksums.txt")"
+[[ -n "${s5cmd_sha}" ]] || { echo "no checksum for s5cmd_${S5CMD_VERSION}_Linux-${s5cmd_arch}.tar.gz" >&2; exit 1; }
+echo "${s5cmd_sha}  ${tmp_s5}/s5cmd.tar.gz" | sha256sum -c -
 tar -xzf "${tmp_s5}/s5cmd.tar.gz" -C "${tmp_s5}" s5cmd
 install -m 0755 "${tmp_s5}/s5cmd" /usr/local/bin/s5cmd
 rm -rf "${tmp_s5}"
@@ -93,25 +99,21 @@ rm -rf "${tmp_s5}"
 # location). A profile.d entry and /usr/local/bin symlinks make it
 # reachable from login and non-login (docker exec) shells alike.
 #
-# Defaults to the latest stable release (resolved from go.dev). Pin a
-# specific version for a reproducible build by exporting
-# GO_VERSION=1.26.0 before running this script.
+# Pinned to a specific version AND checksum for a reproducible, verified
+# toolchain (finding H9 — no longer resolved live to whatever "latest" is).
+# To bump: set GO_VERSION and refresh BOTH checksums from https://go.dev/dl/
+# (each file has a .sha256 sidecar; the JSON index lists them too).
+GO_VERSION="${GO_VERSION:-1.26.5}"
 case "${arch}" in
-    amd64) go_arch="amd64" ;;
-    arm64) go_arch="arm64" ;;
+    amd64) go_arch="amd64"; go_sha256="5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053" ;;
+    arm64) go_arch="arm64"; go_sha256="fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49" ;;
     *)     echo "Unsupported arch for go: ${arch}" >&2; exit 1 ;;
 esac
-if [[ -n "${GO_VERSION:-}" ]]; then
-    go_tag="go${GO_VERSION}"
-else
-    # go.dev/VERSION?m=text returns the latest stable tag (e.g. "go1.26.0")
-    # on its first line.
-    go_tag="$(wget -qO- 'https://go.dev/VERSION?m=text' | head -1)"
-fi
-[[ "${go_tag}" == go* ]] || { echo "could not resolve Go version (got '${go_tag}')" >&2; exit 1; }
+go_tag="go${GO_VERSION}"
 tmp_go=$(mktemp -d)
 wget -qO "${tmp_go}/go.tar.gz" \
     "https://go.dev/dl/${go_tag}.linux-${go_arch}.tar.gz"
+echo "${go_sha256}  ${tmp_go}/go.tar.gz" | sha256sum -c -
 rm -rf /usr/local/go
 tar -C /usr/local -xzf "${tmp_go}/go.tar.gz"
 rm -rf "${tmp_go}"


### PR DESCRIPTION
## Pin + verify build-dep downloads and the dev base image (H9, L3)

From the 2026-07 security audit (`docs/security/hardening-findings.md`).

### H9 — `scripts/install-build-deps.sh`
- **Go**: pin `GO_VERSION` (default `1.26.5`) and verify the tarball against a hardcoded per-arch SHA256 with `sha256sum -c` before unpacking. Removes the live "latest" resolution (previously fetched from go.dev), so the toolchain is reproducible and integrity-checked.
- **s5cmd**: verify the download against the release's published `checksums.txt`.
- **AWS CLI**: left on HTTPS + AWS's own installer for now; GPG-signature verification is a follow-up (it needs AWS's public key committed deliberately, not reproduced from memory).

### L3 — `scripts/docker/dockerfile`
- Pin the dev container base by digest (`ubuntu:24.04@sha256:4fbb8e6a…`) instead of the mutable `:24.04` tag. Refresh with `docker buildx imagetools inspect ubuntu:24.04`.

### Please confirm on first CI run
The Go checksums, Go version, and the ubuntu digest were fetched from go.dev / Docker Hub from an environment without direct registry access; CI (which has network) validates them on build. If any is stale, the build fails clearly (checksum mismatch / manifest unknown) and is a one-line bump.

Closes the **H9** and **L3** guardrail assertions in `scripts/security-guardrails.test.sh` (that suite lands via PR #192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
