### PR TITLE
wendyos-identity: refresh device-type from rootfs each boot

### DIFF
--- a/recipes-core/wendyos-etc-binds/files/setup-etc-binds.sh
+++ b/recipes-core/wendyos-etc-binds/files/setup-etc-binds.sh
@@ -39,18 +39,9 @@ then
     chmod 755 "${DATA_ETC}/wendyos"
 fi
 
-# Seed device-type to /data on first boot only. Hardware identity is
-# immutable for the life of the unit, so this copy runs once and the
-# /data copy persists across every subsequent boot and OTA.
-if [ -f /etc/wendyos/device-type ] && [ ! -f "${DATA_ETC}/wendyos/device-type" ]
-then
-    log_info "Seeding device-type to ${DATA_ETC}/wendyos/"
-    cp -p /etc/wendyos/device-type "${DATA_ETC}/wendyos/device-type"
-fi
-
-# Bind-mount entire /etc/wendyos/ directory
-# This persists device-uuid, device-name, device-type, and any other
-# identity files
+# Bind-mount entire /etc/wendyos/ so runtime identity (device-uuid, device-name)
+# persists across OTA. Image-derived files (version.txt, commit, device-type) are
+# refreshed from the rootfs below.
 if ! mountpoint -q /etc/wendyos
 then
     log_info "Bind-mounting ${DATA_ETC}/wendyos → /etc/wendyos"
@@ -83,6 +74,13 @@ if mountpoint -q /etc/wendyos && [ -f /usr/lib/wendyos/commit ]
 then
     log_info "Refreshing /etc/wendyos/commit from /usr/lib/wendyos/"
     cp -p /usr/lib/wendyos/commit /etc/wendyos/commit
+fi
+
+# Same OTA-freshness refresh for device-type (image-derived; see version.txt above).
+if mountpoint -q /etc/wendyos && [ -f /usr/lib/wendyos/device-type ]
+then
+    log_info "Refreshing /etc/wendyos/device-type from /usr/lib/wendyos/"
+    cp -p /usr/lib/wendyos/device-type /etc/wendyos/device-type
 fi
 
 # [Note]

--- a/recipes-core/wendyos-identity/wendyos-identity_1.0.bb
+++ b/recipes-core/wendyos-identity/wendyos-identity_1.0.bb
@@ -75,20 +75,23 @@ do_install() {
 
 do_install:append() {
     # Stable board identity for the wendy agent. Sourced as shell.
-    # BOARD is set in conf/machine/<machine>.conf; MACHINE is the yocto machine
-    # name; STORAGE ("nvme"/"emmc"/"sd") is set in the board template local.conf.
+    # BOARD is set in conf/machine/<machine>.conf; MACHINE is the yocto machine name.
+    # device-type is image-derived: bake on the read-only rootfs and symlink /etc to
+    # it (like version.txt/commit) so setup-etc-binds.sh refreshes the bind copy each boot.
     install -d ${D}${sysconfdir}/wendyos
-    printf 'BOARD=%s\n'   "${WENDYOS_BOARD_ID}" >  ${D}${sysconfdir}/wendyos/device-type
-    printf 'MACHINE=%s\n' "${MACHINE}"          >> ${D}${sysconfdir}/wendyos/device-type
+    install -d ${D}${nonarch_libdir}/wendyos
+    printf 'BOARD=%s\n'   "${WENDYOS_BOARD_ID}" >  ${D}${nonarch_libdir}/wendyos/device-type
+    printf 'MACHINE=%s\n' "${MACHINE}"          >> ${D}${nonarch_libdir}/wendyos/device-type
     # STORAGE lets the OTA client pick the storage-specific artifact directly
     # (e.g. jetson-agx-orin publishes both an NVMe and an eMMC image under one
     # manifest key). Without it the agent must infer the medium from the MACHINE
     # name, which fails for legacy/plain-string identities and can serve the
     # wrong image. Only emitted when the board declares a medium.
     if [ -n "${STORAGE}" ]; then
-        printf 'STORAGE=%s\n' "${STORAGE}"      >> ${D}${sysconfdir}/wendyos/device-type
+        printf 'STORAGE=%s\n' "${STORAGE}"      >> ${D}${nonarch_libdir}/wendyos/device-type
     fi
-    chmod 0644 ${D}${sysconfdir}/wendyos/device-type
+    chmod 0644 ${D}${nonarch_libdir}/wendyos/device-type
+    ln -sf ../../usr/lib/wendyos/device-type ${D}${sysconfdir}/wendyos/device-type
 }
 
 FILES:${PN} += "${bindir}/generate-uuid.sh"
@@ -101,12 +104,11 @@ FILES:${PN} += "${systemd_system_unitdir}/wendyos-device-name-generate.service"
 FILES:${PN} += "${systemd_system_unitdir}/wendyos-identity.service"
 FILES:${PN} += "${sysconfdir}/wendyos"
 FILES:${PN} += "${sysconfdir}/wendyos/device-type"
+FILES:${PN} += "${nonarch_libdir}/wendyos/device-type"
 FILES:${PN} += "${sysconfdir}/wendyos/version.txt"
 FILES:${PN} += "${nonarch_libdir}/wendyos/version.txt"
 FILES:${PN} += "${sysconfdir}/wendyos/commit"
 FILES:${PN} += "${nonarch_libdir}/wendyos/commit"
 FILES:${PN} += "${sysconfdir}/wendyos-build-id"
-
-CONFFILES:${PN} += "${sysconfdir}/wendyos/device-type"
 
 RDEPENDS:${PN} = "bash util-linux-uuidgen avahi-daemon coreutils iproute2"


### PR DESCRIPTION
device-type is image-derived; bake it to /usr/lib and symlink /etc, and refresh the bind-mounted /data copy each boot so an empty/stale copy can't shadow it.

Refs: WDY-1907