### PR TITLE
data-setup: fix first-boot /data race that collapsed device identity (WDY-1888)

### DIFF
--- a/recipes-core/wendyos-data-setup/files/wendyos-data-init.service
+++ b/recipes-core/wendyos-data-setup/files/wendyos-data-init.service
@@ -1,11 +1,21 @@
 [Unit]
 Description=WendyOS /data partition first-boot init (format + grow)
 DefaultDependencies=no
-# Runs after udev has populated /dev/disk/by-partlabel, before /data is
+# Wait for udev to announce the data partition, then run before /data is
 # mounted and before anything that needs /data.
-After=systemd-udevd.service
+#
+# This must be a device dependency, NOT ConditionPathExists: conditions are
+# evaluated the moment the job runs, which races udev's coldplug of the disk.
+# On a genuinely first boot losing that race skipped the format ("skipped,
+# unmet condition check ConditionPathExists=..."), data.mount then failed on
+# the unformatted partition, and the whole Requires= chain hanging off it
+# (etc-binds -> uuid/device-name generation) collapsed — the device came up
+# advertising mDNS placeholder names (WDY-1888). Every wendyos-update board
+# carves a "data" partition, so if the device never appears the board is
+# broken anyway and data.mount fails on its own device timeout regardless.
+Wants=dev-disk-by\x2dpartlabel-data.device
+After=systemd-udevd.service dev-disk-by\x2dpartlabel-data.device
 Before=data.mount
-ConditionPathExists=/dev/disk/by-partlabel/data
 
 [Service]
 Type=oneshot

--- a/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
+++ b/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
@@ -53,6 +53,22 @@ set_txt() {
 
 set_txt id "$UUID"
 
+# Self-heal a missing device name before publishing: the generator's queued
+# job is lost when a failed first-boot /data mount collapses its Requires=
+# chain (WDY-1888), and this publisher is the last identity step that still
+# runs. generate-device-name.sh is idempotent and writes through the (by now
+# retried and bound) /etc/wendyos, so this is a real name, not a junk
+# fallback. Re-derive the hostname from it so the device does not keep the
+# machine-id fallback hostname until the next reboot (avahi starts after us
+# and picks the new hostname up).
+if [ ! -s "$DEVICE_NAME_FILE" ] && [ -x /usr/bin/generate-device-name.sh ]; then
+    echo "Warning: $DEVICE_NAME_FILE missing; generating it (self-heal)"
+    /usr/bin/generate-device-name.sh || true
+    if [ -s "$DEVICE_NAME_FILE" ] && [ -x /usr/sbin/generate-hostname.sh ]; then
+        /usr/sbin/generate-hostname.sh || true
+    fi
+fi
+
 # Only set name/displayname when we actually have a device name; otherwise leave
 # whatever is there (placeholder or a prior good value) for a later run — never
 # burn a junk fallback into the advertisement.


### PR DESCRIPTION
Stacked on #199 (same test artifact needs both fixes to flash an Orin Nano).

## Problem

A freshly flashed device boots advertising **placeholder mDNS identity** (`name=WENDY_DEVICE_NAME`, `displayname=WENDY_DISPLAY_NAME`) with a machine-id fallback hostname (`wendyos-<tail8>`), healing only on the next reboot.

Root cause (live-debugged on an Orin Nano devkit): `wendyos-data-init.service` gates on `ConditionPathExists=/dev/disk/by-partlabel/data`, but conditions are evaluated when the job runs — racing udev's coldplug of the disk:

```
[11.53] systemd[1]: WendyOS /data partition first-boot init (format + grow) skipped, unmet condition check ConditionPathExists=/dev/disk/by-partlabel/data
[12.39] systemd[1]: data.mount: Mount process exited, code=exited, status=32/n/a
```

On a true first boot the partition is unformatted, so the skipped format makes `data.mount` fail, and the `Requires=` chain collapses: `wendyos-etc-binds` aborts and the queued jobs for `wendyos-uuid-generate`/`wendyos-device-name-generate` are removed without ever running. The mount self-retries after data-init's second activation formats the partition, but the generators never get a second job. `Wants=`-only consumers (hostname, mDNS publisher) run degraded — hence the placeholders.

## Fix

1. **`wendyos-data-init.service`** — replace the racy path condition with a device dependency (`Wants=` + `After=` on `dev-disk-by\x2dpartlabel-data.device`) so the job waits for udev. Every `WENDYOS_OTA=wendy` board carves a `data` partition; a never-appearing device is a broken board and `data.mount` fails on its own device timeout exactly as before.
2. **`update-mdns-uuid.sh`** — defense in depth: self-heal a missing device name (mirroring the existing UUID self-heal) and re-derive the hostname from it, so any future loss of the generator jobs degrades to a late-but-real identity instead of placeholders.

## Verification (on-device, Orin Nano devkit)

- **Repro without fix**: zeroing the data-partition superblock (fresh-flash state) + reboot deterministically reproduces the placeholder fingerprint (condition-skip in kmsg, mount exit 32, generators `inactive dead` with zero timestamps).
- **With fix** (unit + script hand-applied, superblock zeroed again): first boot formats and mounts cleanly — `data-init 14.65s → data.mount 14.71s → etc-binds 15.88s → uuid-generate 16.08s → device-name-generate 16.19s`, zero condition-skips — and the device came up as a freshly generated `Swift Iris` / `wendyos-swift-iris.local` with correct mDNS TXT records on the very first boot.
- Final validation once this PR's flashpack publishes: `wendy os install --device-type jetson-orin-nano --pr <this>` should yield a properly named device on first boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)