### PR TITLE
tegra-flash-init: present the Orin flashing gadget as an IAD composite for Windows

### DIFF
--- a/meta-tegra-extensions/recipes-core/initrdscripts/tegra-flash-init/0003-flash-init-composite-gadget-for-windows.patch
+++ b/meta-tegra-extensions/recipes-core/initrdscripts/tegra-flash-init/0003-flash-init-composite-gadget-for-windows.patch
@@ -1,0 +1,74 @@
+From 0000000000000000000000000000000000000003 Mon Sep 17 00:00:00 2001
+From: Wendy Labs <engineering@wendy.dev>
+Date: Thu, 17 Jul 2026 12:00:00 +1000
+Subject: [PATCH] flash-init: present the flashing gadget as an IAD composite
+
+Windows fails to enumerate the initrd flashing gadget: a USBPcap trace of
+an AGX Orin recovery shows GET_DESCRIPTOR(DEVICE) completing with
+USBD_STATUS_INVALID_PARAMETER + USBD_STATUS_XACT_ERROR on EP0, so usbstor
+never binds and the flash stalls waiting for the flashpkg LUN. A usbmon
+capture of the identical gadget on Linux shows a completely clean EP0
+enumeration, so the device descriptor is valid — the failure is a
+Windows-xHCI <-> tegra-xudc EP0 transaction interaction specific to this
+gadget's shape (bcdUSB is not the cause; 0x0210 and 0x0200 both fail).
+
+The decisive contrast: WendyOS's runtime gadget (an IAD composite,
+bDeviceClass 0xEF, NCM+ACM) enumerates fine on the same Windows host and
+tegra-xudc, while the flashing gadget (a bare single-function mass-storage
+device, bDeviceClass 0x00) does not. Match the runtime's Windows-friendly
+profile: declare an IAD composite device class and add a CDC-ACM function
+alongside mass storage, so the gadget presents as a multi-interface
+composite the way the runtime one does. Also declare plain USB 2.0
+(bcdUSB 0x0200); the gadget is High-Speed only and never negotiates
+SuperSpeed, so this drops the unused BOS advertisement. init-flash.sh
+still drives the mass_storage.l4t_storage LUN unchanged; the extra ACM
+interface only changes how the device enumerates. Linux/macOS are
+unaffected (they already enumerate the gadget cleanly).
+
+Upstream-Status: Inappropriate [wendy-specific]
+---
+ initrd-flash.scheme.in | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/initrd-flash.scheme.in b/initrd-flash.scheme.in
+index e846bf8..cda51b8 100644
+--- a/initrd-flash.scheme.in
++++ b/initrd-flash.scheme.in
+@@ -1,9 +1,9 @@
+ attrs :
+ {
+-    bcdUSB = 0x210;
+-    bDeviceClass = 0x0;
+-    bDeviceSubClass = 0x0;
+-    bDeviceProtocol = 0x0;
++    bcdUSB = 0x200;
++    bDeviceClass = 0xEF;
++    bDeviceSubClass = 0x02;
++    bDeviceProtocol = 0x01;
+     bMaxPacketSize0 = 0x40;
+     idVendor = 0x1D6B;
+     idProduct = 0x104;
+@@ -43,6 +43,11 @@ functions :
+         };
+         os_descs = ( );
+     };
++    acm_l4t :
++    {
++        instance = "l4t_console";
++        type = "acm";
++    };
+ };
+ configs = (
+     {
+@@ -62,5 +67,9 @@ configs = (
+             {
+                 name = "ums.0";
+                 function = "mass_storage_l4t";
++            },
++            {
++                name = "acm.0";
++                function = "acm_l4t";
+             } );
+     } );
+--
+2.50.1

--- a/meta-tegra-extensions/recipes-core/initrdscripts/tegra-flash-init_%.bbappend
+++ b/meta-tegra-extensions/recipes-core/initrdscripts/tegra-flash-init_%.bbappend
@@ -10,3 +10,14 @@ SRC_URI += "file://0001-flash-init-export-device-identity.patch"
 # removable-LUN backing file as "host done with this LUN" so the installer
 # advances past each LUN on macOS as well as Linux.
 SRC_URI += "file://0002-flash-init-accept-medium-eject-release.patch"
+
+# Windows enumeration: Windows fails GET_DESCRIPTOR(DEVICE) on the flashing
+# gadget with XACT_ERROR/INVALID_PARAMETER on EP0 (usbstor never binds; the
+# flash stalls waiting for the LUN), while Linux/macOS enumerate the identical
+# gadget cleanly — so it is a Windows-xHCI/tegra-xudc EP0 quirk, not descriptor
+# content (bcdUSB is not the cause). WendyOS's runtime IAD composite gadget
+# (bDeviceClass 0xEF, NCM+ACM) enumerates on the same Windows host, so present
+# the flashing gadget the same way: an IAD composite (0xEF) with a CDC-ACM
+# function beside mass storage. init-flash.sh still drives the mass_storage LUN
+# unchanged; only the enumeration shape changes.
+SRC_URI += "file://0003-flash-init-composite-gadget-for-windows.patch"


### PR DESCRIPTION
Windows could not flash T234 Orins over USB recovery: the flashing initrd's mass-storage gadget failed USB **enumeration** on Windows. A USBPcap trace showed `GET_DESCRIPTOR(DEVICE)` completing with `USBD_STATUS_INVALID_PARAMETER` + `USBD_STATUS_XACT_ERROR` on EP0, so `usbstor` never bound and the flash stalled waiting for the flashpkg LUN.

The identical gadget enumerates cleanly on Linux and macOS (a `usbmon` capture confirmed a clean EP0 handshake), so the device descriptor is valid — the failure is a Windows-xHCI ↔ tegra-xudc EP0 interaction. It is **not** bcdUSB (0x0210 and 0x0200 both fail identically) and **not** a tegra-xudc driver quirk (the r39.2 downstream driver sets none of the relevant control quirks for T234).

The one structural difference that tracks the behaviour: WendyOS's **runtime** gadget is an IAD composite (bDeviceClass 0xEF, NCM+ACM) and enumerates fine on the same Windows host, while the flashing gadget was a bare single-function mass-storage device (bDeviceClass 0x00). This patch makes the flashing gadget match that Windows-friendly shape:

- declare an IAD composite device class (0xEF / 0x02 / 0x01);
- add a CDC-ACM function beside mass storage, so the gadget presents as a multi-interface composite — Windows enumerates it as Composite → `MI_00` Mass Storage + `MI_01` ACM COM port;
- declare plain USB 2.0 (bcdUSB 0x0200; the gadget is High-Speed only, so the BOS advertisement is unused).

`init-flash.sh` still drives the `mass_storage.l4t_storage` LUN unchanged; only the enumeration shape changes. Linux/macOS already enumerate the gadget cleanly and are unaffected.

**Validated end-to-end (2026-07-20):** with this build, a full `wendy os install --device-type jetson-agx-orin --storage emmc` recovery flash completed on Windows 11 — gadget enumerated, identity verified, all 17 partitions + QSPI programming written, and the device rebooted into the freshly-flashed WendyOS. (A separate host-side fix — taking the target disk offline before the raw write to stop Windows auto-mounting the stale ESP — was also required; that lives in the `wendy` CLI, not this repo.)
