### PR TITLE
usb-power-config: disable USB autosuspend for robotics peripherals (WDY-1924)

### DIFF
--- a/recipes-core/packagegroups/packagegroup-wendyos-base.bb
+++ b/recipes-core/packagegroups/packagegroup-wendyos-base.bb
@@ -31,6 +31,7 @@ RDEPENDS:${PN} = " \
     wendyos-motd \
     containerd-config \
     xdg-dbus-proxy \
+    usb-power-config \
     "
 
 # Recipes that bind-mount or otherwise depend on the /data partition the

--- a/recipes-support/usb-power-config/files/99-wendyos-usb-no-autosuspend.rules
+++ b/recipes-support/usb-power-config/files/99-wendyos-usb-no-autosuspend.rules
@@ -1,0 +1,16 @@
+# /etc/udev/rules.d/99-wendyos-usb-no-autosuspend.rules
+#
+# Keep USB autosuspend off for every USB device (WDY-1924).
+#
+# The kernel default (usbcore.autosuspend=2) suspends any USB device idle
+# for 2 seconds whose power/control is "auto". Low-traffic robotics
+# peripherals — USB-CAN adapters (e.g. CANable-2 gs_usb 1d50:606f) driving
+# robot arms — go idle whenever the arm is disabled, get autosuspended,
+# fail to resume, and drop off the bus entirely; recovery needs a physical
+# re-seat. Cameras stream constantly and never trip the timeout, which is
+# why only the quiet devices vanish.
+#
+# On a wall-powered robotics/edge device, bus stability beats USB power
+# saving, so pin every device to "on". systemd-udev-trigger replays "add"
+# for devices present before udev started, so this also covers coldplug.
+ACTION=="add", SUBSYSTEM=="usb", TEST=="power/control", ATTR{power/control}="on"

--- a/recipes-support/usb-power-config/usb-power-config_1.0.bb
+++ b/recipes-support/usb-power-config/usb-power-config_1.0.bb
@@ -1,0 +1,19 @@
+SUMMARY = "USB power management policy for robotics peripherals"
+DESCRIPTION = "Disables USB autosuspend via udev so low-traffic peripherals \
+    (USB-CAN adapters, sensors) stay on the bus instead of being suspended \
+    and dropping off after the 2s kernel default timeout (WDY-1924)."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://99-wendyos-usb-no-autosuspend.rules"
+
+S = "${UNPACKDIR}"
+
+do_install() {
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0644 ${UNPACKDIR}/99-wendyos-usb-no-autosuspend.rules ${D}${sysconfdir}/udev/rules.d/
+}
+
+FILES:${PN} = "${sysconfdir}/udev/rules.d/99-wendyos-usb-no-autosuspend.rules"
+
+RDEPENDS:${PN} = "udev"


### PR DESCRIPTION
Fixes [WDY-1924](https://linear.app/wendylabsinc/issue/WDY-1924).

## Problem

WendyOS ships the kernel default `usbcore.autosuspend=2`, so any USB device idle for 2 seconds with `power/control=auto` gets autosuspended. Low-traffic robotics peripherals — USB-CAN adapters (CANable-2 / gs_usb `1d50:606f`) driving robot arms — go idle whenever the arm is disabled, get suspended, fail to resume, and **drop off the bus entirely**; recovery needs a physical re-seat. Confirmed on two rigs (`wendy-arms`, `jetson-arm`); the powered-hub theory was ruled out (all hubs self-powered), and the app can't fix it itself because the container's `/sys` is read-only. This blocked a VR teleop demo.

## Fix

A new `usb-power-config` recipe installs one udev rule that pins every USB device's `power/control` to `on`:

```
ACTION=="add", SUBSYSTEM=="usb", TEST=="power/control", ATTR{power/control}="on"
```

Wired into `packagegroup-wendyos-base`, so all machines (Jetson JP6/JP7, RPi, QEMU) get it. `systemd-udev-trigger` replays `add` events at boot, so devices present before udev starts are covered too.

## Why this shape (vs. the issue's other options)

- **Global, not VID:PID-targeted:** any low-traffic peripheral is affected (CAN, some sensors); an allowlist is whack-a-mole. On a wall-powered robotics device, bus stability beats USB power saving — this is the issue's option 3 semantics via option 2's mechanism.
- **udev rule, not `usbcore.autosuspend=-1` bootarg:** bootarg wiring is per-machine — RPi has a hook (`WENDYOS_RPI_CMDLINE_EXTRAS`) but tegra has no `KERNEL_ARGS` override in this repo today. One udev rule covers everything.
- **Agent-applied fix (option 1, preferred in the issue)** lives in the wendy-agent repo (`oci/entitlements.go`), not here — the agent is a prebuilt binary in this image. It composes cleanly with this rule (writing `on` over `on` is a no-op) and can still ship separately.

## Verification

On a flashed build: leave a CAN adapter idle (arm disabled) >5 s, confirm it stays enumerated and `power/control` reads `on`, then confirm the arm enables without a physical re-seat. Recipe structure is a line-for-line mirror of the existing `usb-network-tuning` recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)