### PR TITLE
Driver add-ons: build and publish sysext driver images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1017,6 +1017,36 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Build driver add-ons
+        # Driver add-ons (systemd-sysext) are RPi-only today
+        # (WENDYOS_DRIVER_EXTENSIONS=1 on the RPi machines). Build the
+        # wendyos_hello test add-on so its .raw is published into the version's
+        # extensions[]. Reuses this build's sstate; the module + sysext are tiny.
+        # Built once per device, for the sd variant's MACHINE: extensions[] is
+        # per-device (storage-agnostic) and the .raw object path has no storage
+        # component, so per-variant builds would race two .raws into the same
+        # GCS object. The upload loop publishes it only from the variant whose
+        # MACHINE matches this build (DRV_LINK resolves only there).
+        if: startsWith(matrix.device, 'raspberry-pi-')
+        working-directory: ${{ github.workspace }}/wendyos
+        env:
+          MAP: ${{ steps.vars.outputs.map }}
+        run: |
+          set -euo pipefail
+          SD_MACHINE=""
+          for token in $MAP; do
+            IFS='|' read -r storage board machine <<< "$token"
+            if [[ "$storage" == "sd" ]]; then SD_MACHINE="$machine"; break; fi
+          done
+          if [[ -z "$SD_MACHINE" ]]; then
+            echo "no sd variant in map '$MAP'; skipping driver add-on"
+            exit 0
+          fi
+          make build MACHINE="$SD_MACHINE" IMAGE_TARGET=wendyos-driver-hello-image || {
+            echo "::warning::driver add-on build failed on first attempt; retrying once"
+            make build MACHINE="$SD_MACHINE" IMAGE_TARGET=wendyos-driver-hello-image
+          }
+
       # The persistent NVMe cache is written in place by the build (sstate,
       # downloads, repos are symlinked onto it) — no upload/save step needed.
 
@@ -1452,6 +1482,43 @@ jobs:
             SBOM_FILE=$(find "$DEPLOY_DIR" -maxdepth 1 -name '*.spdx.tar.zst' -print -quit 2>/dev/null || true)
             if [[ -n "$SBOM_FILE" && -f "$SBOM_FILE" ]]; then
               ARGS+=(--sbom "$SBOM_FILE")
+            fi
+
+            # Driver add-ons (RPi): publish the built sysext .raw into this
+            # version's extensions[]. Pin it to the kernel ABI the .ko was built
+            # for, read from the image's module dir. It rides the OS image's entry
+            # (a pure-extension entry would fail the "needs an image" check).
+            # Resolve the stable IMAGE_LINK_NAME symlink to this build's .raw; globbing
+            # real files could pick a stale timestamped artifact left in DEPLOY_DIR by
+            # an earlier build or a step retry.
+            DRV_LINK="$DEPLOY_DIR/wendyos-driver-hello-image-${MACHINE}.sysext.squashfs-xz"
+            DRV_RAW=$(readlink -f "$DRV_LINK" 2>/dev/null || true)
+            [[ -f "$DRV_RAW" ]] || DRV_RAW=""
+            if [[ -n "$DRV_RAW" ]]; then
+              # unsquashfs from the PATH or this build's native sysroot (squashfs-
+              # tools-native built the .raw, so it is always there); '|| true' so a
+              # missing tool / no match reaches the explicit error below instead of
+              # dying silently under set -e.
+              UNSQ=$(command -v unsquashfs || true)
+              [[ -n "$UNSQ" ]] || UNSQ=$(find "$GITHUB_WORKSPACE/build/tmp/sysroots-components" \
+                -type f -name unsquashfs -path '*squashfs-tools-native*' -print -quit 2>/dev/null || true)
+              DRV_KVER=""
+              if [[ -n "$UNSQ" ]]; then
+                DRV_KVER=$("$UNSQ" -l "$DRV_RAW" 2>/dev/null | grep -oE 'usr/lib/modules/[^/[:space:]]+' | head -1 | awk -F/ '{print $4}' || true)
+              fi
+              if [[ -z "$DRV_KVER" ]]; then
+                echo "::error::could not determine kernel version from $DRV_RAW (unsquashfs: ${UNSQ:-not found})" >&2
+                exit 1
+              fi
+              # No --extension-modules: the add-on bakes its own module list into
+              # the image (modules-load.d), so the manifest carries none and the
+              # device loads from the baked-in list.
+              ARGS+=(
+                --extension-file "$DRV_RAW"
+                --extension-name "wendyos-hello"
+                --extension-version "$UPLOAD_VERSION"
+                --extension-kernel "$DRV_KVER"
+              )
             fi
 
             # No retry loop: uploads go to unique per-version paths (no shared

--- a/classes/partuuid-rpi.bbclass
+++ b/classes/partuuid-rpi.bbclass
@@ -1,5 +1,5 @@
 
-# partuuid.bbclass - Generate and cache UUIDs for partition references
+# partuuid.bbclass - Derive stable UUIDs for partition references
 #
 # Exposes:
 #   WENDYOS_BOOT_PARTUUID
@@ -10,62 +10,35 @@
 #     - ${WORKDIR}/partuuids.conf
 #     - ${DEPLOY_DIR_IMAGE}/partuuids-${IMAGE_BASENAME}.conf
 #
-# Behavior:
-#   - Read PARTUUIDs from a cache file if it exists
-#   - Otherwise, generate fresh UUIDv4 values, write cache, and use them
+# The UUIDs are deterministic (UUIDv5 of PARTUUID_SEED), not random, because they
+# are task-signature inputs: an earlier revision cached UUIDv4s under ${TOPDIR},
+# a fresh workspace every CI run, so the base-files/cmdline/image chain never hit
+# sstate. They only need to be unique per disk, not per build - every device
+# flashing a given image already shares them.
 #
-PARTUUID_CACHE_DIR  ?= "${TOPDIR}/uuid-cache"
-PARTUUID_CACHE_FILE ?= "${PARTUUID_CACHE_DIR}/partuuids.conf"
+# The seed includes MACHINE so the nvme and sd variants of the same device get
+# distinct UUIDs: both disks can be attached to one board at the same time, and
+# identical PARTUUIDs across them would make root=PARTUUID=... ambiguous.
+PARTUUID_SEED ?= "${DISTRO}/${MACHINE}"
+
+# Fixed namespace for the UUIDv5 derivation. Never change it: new values would
+# re-key every partuuid-dependent task signature and, worse, orphan the
+# fstab/cmdline references of already-flashed disks on the next OTA.
+PARTUUID_NAMESPACE = "b8f4a3d2-6e75-4d11-9c3a-2f08154cf05e"
 
 # Name of the audit file dropped next to images:
 PARTUUIDS_DEPLOY_NAME ?= "partuuids-${IMAGE_BASENAME}.conf"
 
 python __anonymous() {
-    import os, uuid
+    import uuid
 
-    cache_dir  = d.getVar('PARTUUID_CACHE_DIR')
-    cache_file = d.getVar('PARTUUID_CACHE_FILE')
-
-    # Ensure cache dir exists (safe at parse-time)
-    if not os.path.isdir(cache_dir):
-        os.makedirs(cache_dir, exist_ok=True)
-
-    boot_uuid = None
-    root_uuid = None
-    config_uuid = None
-
-    # try to read from the cache
-    if os.path.exists(cache_file):
-        try:
-            with open(cache_file, 'r') as f:
-                for line in f:
-                    if line.startswith('WENDYOS_BOOT_PARTUUID='):
-                        boot_uuid = line.split('=', 1)[1].strip()
-                    elif line.startswith('WENDYOS_ROOT_PARTUUID='):
-                        root_uuid = line.split('=', 1)[1].strip()
-                    elif line.startswith('WENDYOS_CONFIG_PARTUUID='):
-                        config_uuid = line.split('=', 1)[1].strip()
-        except Exception as e:
-            bb.warn(f"partuuids: failed to read cache: {e}")
-
-    if not boot_uuid or not root_uuid or not config_uuid:
-        # generate if missing and update the cache
-        boot_uuid = boot_uuid or str(uuid.uuid4())
-        root_uuid = root_uuid or str(uuid.uuid4())
-        config_uuid = config_uuid or str(uuid.uuid4())
-        try:
-            with open(cache_file, 'w') as f:
-                f.write(f"WENDYOS_BOOT_PARTUUID={boot_uuid}\n")
-                f.write(f"WENDYOS_ROOT_PARTUUID={root_uuid}\n")
-                f.write(f"WENDYOS_CONFIG_PARTUUID={config_uuid}\n")
-            bb.note(f"partuuids: generated & cached boot={boot_uuid} root={root_uuid} config={config_uuid}")
-        except Exception as e:
-            bb.warn(f"partuuids: failed to write cache: {e}")
+    ns = uuid.UUID(d.getVar('PARTUUID_NAMESPACE'))
+    seed = d.getVar('PARTUUID_SEED')
 
     # export the variables to datastore
-    d.setVar('WENDYOS_BOOT_PARTUUID', boot_uuid)
-    d.setVar('WENDYOS_ROOT_PARTUUID', root_uuid)
-    d.setVar('WENDYOS_CONFIG_PARTUUID', config_uuid)
+    d.setVar('WENDYOS_BOOT_PARTUUID', str(uuid.uuid5(ns, seed + '/boot')))
+    d.setVar('WENDYOS_ROOT_PARTUUID', str(uuid.uuid5(ns, seed + '/root')))
+    d.setVar('WENDYOS_CONFIG_PARTUUID', str(uuid.uuid5(ns, seed + '/config')))
 
     # make the variables available to WIC as well
     existing = (d.getVar('WICVARS') or '').split()
@@ -108,4 +81,4 @@ python do_generate_partuuids() {
 addtask generate_partuuids before do_configure after do_patch
 
 # re-run the task if these knobs change
-do_generate_partuuids[vardeps] += "WENDYOS_BOOT_PARTUUID WENDYOS_ROOT_PARTUUID WENDYOS_CONFIG_PARTUUID PARTUUID_CACHE_FILE PARTUUIDS_DEPLOY_NAME"
+do_generate_partuuids[vardeps] += "WENDYOS_BOOT_PARTUUID WENDYOS_ROOT_PARTUUID WENDYOS_CONFIG_PARTUUID PARTUUIDS_DEPLOY_NAME"

--- a/classes/sysext-image.bbclass
+++ b/classes/sysext-image.bbclass
@@ -1,0 +1,92 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+# Backported verbatim from meta-openembedded/meta-oe (blacksail) into meta-wendyos:
+# the class is absent from the scarthgap oe-core our default fleet (RPi, QEMU) builds
+# on. meta-wendyos is first in BBPATH, so on newer trees this identical copy simply
+# shadows the upstream one. Keep in sync with upstream when bumping meta-oe.
+
+# System extension images may – dynamically at runtime — extend the
+# /usr/ and /opt/ directory hierarchies with additional files. This is
+# particularly useful on immutable system images where a /usr/ and/or
+# /opt/ hierarchy residing on a read-only file system shall be
+# extended temporarily at runtime without making any persistent
+# modifications.
+
+## Example usage:
+# extension-image-example.bb
+#SUMMARY = "An example image to showcase a system extension image."
+#LICENSE = "MIT"
+#inherit discoverable-disk-image sysext-image
+#IMAGE_FEATURES = ""
+#IMAGE_LINGUAS = ""
+#IMAGE_INSTALL = "gdb"
+#
+## After building, the resulting 'extension-image-example-*sysext.rootfs.ddi'
+# can be deployed to an embedded system (running from a RO rootfs) and
+# 'merged' into the OS by following steps:
+## 1. place a symlink into the systemd-sysext image search path:
+# $> mkdir /run/extensions
+# $> ln -s /tmp/extension-example.sysext.ddi /run/extensions/example.raw
+## 2. list all available extensions:
+# $> systemd-sysext list
+## 3. and enable the found extensions:
+# $> SYSTEMD_LOG_LEVEL=debug systemd-sysext merge
+
+# Note: PACKAGECONFIG:pn-systemd needs to include 'sysext'
+
+# systemd-sysext [1] has a simple mechanism for version compatibility:
+# the extension to be loaded has to contain a file named
+# /usr/lib/extension-release.d/extension-release.NAME
+# with "NAME" part *exactly* matching the filename of the extensions
+# raw-device filename/
+#
+# From the extension-release file the "ID" and "VERSION_ID" fields are
+# matched against same fields present in `os-release` and the extension
+# is "merged" only if values in both fields from both files are an
+# exact match.
+#
+# Link: https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html
+
+inherit image
+
+# Include '.sysext' in the deployed image filename and symlink
+IMAGE_NAME = "${IMAGE_BASENAME}${IMAGE_MACHINE_SUFFIX}${IMAGE_VERSION_SUFFIX}.sysext"
+IMAGE_LINK_NAME = "${IMAGE_BASENAME}${IMAGE_MACHINE_SUFFIX}.sysext"
+EXTENSION_NAME = "${IMAGE_LINK_NAME}.${IMAGE_FSTYPES}"
+
+# Base extension identification fields
+EXTENSION_ID_FIELD ?= "${DISTRO}"
+EXTENSION_VERSION_FIELD ?= "${DISTRO_VERSION}"
+
+sysext_image_add_version_identifier_file() {
+    # Use matching based on Distro name and version
+    echo 'ID=${EXTENSION_ID_FIELD}' > ${WORKDIR}/extension-release.base
+    # os-release.bb does "sanitise_value(ver)", which needs to be done here too
+    echo 'VERSION_ID=${EXTENSION_VERSION_FIELD}' \
+        | sed 's,+,-,g;s, ,_,g' \
+        >> ${WORKDIR}/extension-release.base
+
+    # Instruct `systemd-sysext` to perform re-load once extension image is verified
+    echo 'EXTENSION_RELOAD_MANAGER=1' >> ${WORKDIR}/extension-release.base
+
+    install -d ${IMAGE_ROOTFS}${nonarch_libdir}/extension-release.d
+    install -m 0644 ${WORKDIR}/extension-release.base \
+        ${IMAGE_ROOTFS}${nonarch_libdir}/extension-release.d/extension-release.${EXTENSION_NAME}
+
+    # systemd-sysext expects an extension-release file of the exact same name as the image;
+    # by setting a xattr we allow renaming of the extension image file.
+    # (Kernel: this requires xattr support in the used filesystem)
+    setfattr -n user.extension-release.strict -v false \
+        ${IMAGE_ROOTFS}${nonarch_libdir}/extension-release.d/extension-release.${EXTENSION_NAME}
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "sysext_image_add_version_identifier_file"
+
+# remove 'os-release' from the packages to be installed into the image.
+# systemd-sysext otherwise raises the error:
+# Extension contains '/usr/lib/os-release', which is not allowed, refusing.
+PACKAGE_EXCLUDE += "os-release"

--- a/classes/wendyos-driver-module.bbclass
+++ b/classes/wendyos-driver-module.bbclass
@@ -1,0 +1,8 @@
+# Shared build for a WendyOS out-of-tree driver module. A per-driver recipe
+# inherits this and sets only a descriptor (SUMMARY, LICENSE, SRC_URI — plus a patch
+# if the source won't build against our kernel). module.bbclass compiles it against
+# the pinned base kernel, so the .ko gets the right vermagic/ABI; a sysext image
+# (inherit wendyos-sysext-image) then packs the kernel-module-* package into the
+# .raw the agent merges at runtime.
+
+inherit module

--- a/classes/wendyos-sysext-image.bbclass
+++ b/classes/wendyos-sysext-image.bbclass
@@ -1,0 +1,94 @@
+# WendyOS driver/firmware add-on, built as a systemd-sysext image.
+#
+# A per-driver image recipe inherits this and sets IMAGE_INSTALL to the driver's
+# kernel-module package (+ any firmware). The result is a single .raw the agent
+# stores on /data and merges onto the immutable /usr at runtime.
+
+inherit sysext-image
+
+# sysext-image's ROOTFS_POSTPROCESS runs setfattr (extension-release strict=false
+# xattr); attr-native puts setfattr on the do_rootfs PATH.
+DEPENDS += "attr-native"
+
+# One xz-compressed squashfs .raw: the kernel ships the xz decompressor for
+# sysext but not zlib (see sysext.cfg), and sysext-image requires a single fstype.
+IMAGE_FSTYPES = "squashfs-xz"
+
+# The RPi machine confs append " wic" to IMAGE_FSTYPES unscoped; :remove is applied
+# after :append at finalization, so this strips it and leaves exactly the squashfs
+# (otherwise EXTENSION_NAME gains a space and a bogus wic disk build runs).
+IMAGE_FSTYPES:remove = "wic"
+
+# The add-on is bound to this OS version: systemd merges it only when its
+# extension-release ID/VERSION_ID match /etc/os-release. That gates the OS
+# version, not the kernel ABI, so the agent must still check uname -r.
+#
+# Name the extension-release after a short, stable id (default: the recipe name),
+# not the long image filename. systemd-sysext merges an image X.raw only when its
+# extension-release is named exactly extension-release.X, and the strict-relax xattr
+# is not reliably honored from a squashfs — so the agent places the add-on under
+# this name (e.g. <id>.raw) and it matches without depending on the xattr.
+WENDYOS_SYSEXT_NAME ?= "${PN}"
+EXTENSION_NAME = "${WENDYOS_SYSEXT_NAME}"
+
+# An add-on is not a bootable rootfs: no image features, locales, or recommends —
+# keep it to exactly the driver payload.
+IMAGE_FEATURES = ""
+IMAGE_LINGUAS = ""
+NO_RECOMMENDATIONS = "1"
+
+# Bake the add-on's module list into the image so it is self-describing: the driver
+# declares its own modules here, and no --module (or manifest modules_load) is needed
+# at install time. wendyos-sysext-apply reads /usr/lib/modules-load.d/<name>.conf from
+# the merged add-on (a /data override still wins for bench/dev). Space-separated;
+# depmod resolves deps, so a top module pulls in what it needs (e.g. "apex" -> gasket).
+WENDYOS_SYSEXT_MODULES ?= ""
+
+wendyos_sysext_write_modules_load() {
+    if [ -n "${WENDYOS_SYSEXT_MODULES}" ]; then
+        install -d ${IMAGE_ROOTFS}/usr/lib/modules-load.d
+        conf=${IMAGE_ROOTFS}/usr/lib/modules-load.d/${WENDYOS_SYSEXT_NAME}.conf
+        : > $conf
+        for m in ${WENDYOS_SYSEXT_MODULES}; do
+            echo "$m" >> $conf
+        done
+    fi
+}
+ROOTFS_POSTPROCESS_COMMAND += "wendyos_sysext_write_modules_load;"
+
+# Strip the image to exactly the driver payload before it is packed. `inherit
+# sysext-image` builds a full rootfs and the module package hard-RDEPENDS the whole
+# kernel package, so the tree carries base-files, bash, glibc, ld-linux, etc.
+# systemd-sysext merges the extension's ENTIRE /usr onto the host, so those would
+# SHADOW the host's own copies (a stale glibc/bash could un-patch the host after a
+# same-VERSION_ID CVE fix) and bloat every .raw. Runs in IMAGE_PREPROCESS_COMMAND,
+# after do_rootfs and before the squashfs. Delete in place, not stage-and-copy:
+# under do_image's pseudo, cp -a to a dir outside the rootfs can't preserve
+# ownership (EINVAL). The host's own /lib->/usr/lib resolves the .ko.
+wendyos_sysext_strip_to_payload() {
+    root="${IMAGE_ROOTFS}"
+
+    find "$root" -mindepth 1 -maxdepth 1 ! -name usr -exec rm -rf {} +
+    if [ -d "$root/usr" ]; then
+        find "$root/usr" -mindepth 1 -maxdepth 1 ! -name lib -exec rm -rf {} +
+    fi
+    if [ -d "$root/usr/lib" ]; then
+        find "$root/usr/lib" -mindepth 1 -maxdepth 1 \
+            ! -name extension-release.d ! -name modules-load.d \
+            ! -name modprobe.d ! -name firmware ! -name modules \
+            -exec rm -rf {} +
+    fi
+    if [ -d "$root/usr/lib/modules" ]; then
+        for kv in "$root/usr/lib/modules"/*; do
+            [ -d "$kv" ] || continue
+            find "$kv" -mindepth 1 -maxdepth 1 ! -name updates -exec rm -rf {} +
+            [ -d "$kv/updates" ] || rm -rf "$kv"
+        done
+        rmdir "$root/usr/lib/modules" 2>/dev/null || true
+    fi
+
+    if [ ! -e "$root/usr/lib/extension-release.d" ]; then
+        bbfatal "wendyos-sysext: extension-release.d missing after strip; refusing to build an unmergeable add-on"
+    fi
+}
+IMAGE_PREPROCESS_COMMAND += "wendyos_sysext_strip_to_payload;"

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -125,6 +125,11 @@ WENDYOS_UPDATE_BOOTLOADER ?= "1"
 # set to "0" in a machine conf to opt out.
 WENDYOS_CONTAINER_RUNTIME ?= "1"
 
+# Driver add-ons (systemd-sysext). Pulls in the kernel FS prerequisites (loop,
+# squashfs, overlayfs) so drivers can be merged at runtime. RPi-only for now:
+# enabled in raspberrypi-common-wendyos.inc, off elsewhere.
+WENDYOS_DRIVER_EXTENSIONS ?= "0"
+
 # USB gadget network mode for the usb0 interface
 # "link-local"  - RFC 3927 self-assigned 169.254.x.x (discovery via mDNS/Avahi)
 # "dhcp-client" - Device is DHCP client (host must run DHCP server)

--- a/conf/machine/include/raspberrypi-common-wendyos.inc
+++ b/conf/machine/include/raspberrypi-common-wendyos.inc
@@ -31,6 +31,10 @@ WENDYOS_PERSIST_JOURNAL_LOGS ?= "0"
 WENDYOS_MDNS_INTERFACES ?= ""
 WENDYOS_DEBUG ?= "0"
 
+# Driver add-ons (systemd-sysext) are an RPi feature for now; enable here so the
+# distro-wide default stays "0" and Jetson/QEMU images are untouched.
+WENDYOS_DRIVER_EXTENSIONS ?= "1"
+
 # RPi boot config (consumed by rpi-config_%.bbappend)
 ENABLE_UART = "1"
 ENABLE_DWC2_PERIPHERAL = "${@oe.utils.ifelse(d.getVar('WENDYOS_USB_GADGET') == '1', '1', '0')}"

--- a/conf/template/include/local/common.inc
+++ b/conf/template/include/local/common.inc
@@ -18,6 +18,18 @@ PREMIRRORS:prepend = "${@'git://github.com/raspberrypi/linux.* file:///opt/sourc
 # signatures or accidentally collide. Downloads stay shared — source
 # tarballs are keyed by URL/checksum and reusable across series.
 SSTATE_DIR = "${TOPDIR}/../sstate-cache/${WENDYOS_LAYER_TREE}"
+
+# Optional CI source premirror. When a runner image bakes a Yocto source mirror
+# at WENDYOS_SOURCE_MIRROR_DIR, large git fetches resolve from it first instead of
+# a cold clone from upstream. This exists for the multi-GB raspberrypi/linux
+# kernel: a kernel-config change forces a kernel rebuild whose do_fetch would
+# otherwise time out on a fresh runner (mainline hits kernel sstate and never
+# fetches). The mirror holds standard bitbake mirror tarballs, e.g.
+# git2_github.com.raspberrypi.linux.git.tar.gz. Self-gating on directory
+# existence: the premirror is added only when the dir is present, so developer
+# builds — which have no such dir — are completely unaffected.
+WENDYOS_SOURCE_MIRROR_DIR ??= "/opt/source-mirror"
+PREMIRRORS:prepend = "${@'git://.*/.* file://%s/ gitsm://.*/.* file://%s/ ' % ((d.getVar('WENDYOS_SOURCE_MIRROR_DIR'),) * 2) if os.path.isdir(d.getVar('WENDYOS_SOURCE_MIRROR_DIR') or '') else ''}"
 #TMPDIR = "${TOPDIR}/tmp"
 DISTRO = "wendyos"
 #EXTRA_IMAGE_FEATURES ?= "debug-tweaks"

--- a/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/container.cfg
+++ b/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/container.cfg
@@ -28,7 +28,9 @@ CONFIG_CGROUP_PIDS=y
 CONFIG_CGROUP_RDMA=y
 
 # Filesystem support
-CONFIG_OVERLAY_FS=m
+# Built-in (=y): overlayfs is also a sysext driver-add-on prerequisite (sysext.cfg);
+# keeping both fragments at =y avoids a kernel config-audit mismatch.
+CONFIG_OVERLAY_FS=y
 CONFIG_OVERLAY_FS_REDIRECT_DIR=y
 CONFIG_EXT4_FS=y
 CONFIG_EXT4_FS_POSIX_ACL=y

--- a/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/sysext.cfg
+++ b/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/sysext.cfg
@@ -1,0 +1,11 @@
+# systemd-sysext driver add-on prerequisites.
+# A driver .raw is loop-mounted (squashfs) and merged onto /usr via overlayfs; the
+# module dir also gets a writable overlay so depmod sees the extension's modules.
+# Built-in (=y), not modules: these must be ready before the add-on is merged, and
+# module auto-load has proven unreliable on this minimal image. OVERLAY_FS=y also
+# promotes the =m set by container.cfg (built-in is a superset, fine for containerd).
+CONFIG_BLK_DEV_LOOP=y
+CONFIG_SQUASHFS=y
+CONFIG_SQUASHFS_XZ=y
+CONFIG_SQUASHFS_XATTR=y
+CONFIG_OVERLAY_FS=y

--- a/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/usb-peripherals.cfg
+++ b/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/usb-peripherals.cfg
@@ -1,0 +1,18 @@
+# Common USB peripheral support baked in (=y) for the RPi5 base image.
+#
+# The RPi kernel builds these as modules; on this minimal image module auto-load is
+# unreliable (same reason usb-serial is =y), so a plugged-in USB Ethernet adapter or
+# exFAT/NTFS drive may not bind. Promote the common drivers + removable-media
+# filesystems to built-in so they work on hotplug without udev/depmod.
+# (USB_STORAGE, USB_UAS and VFAT_FS are already =y in the base defconfig.)
+
+# USB Ethernet adapters -> eth*/usb* on hotplug (all firmware-free)
+CONFIG_USB_NET_CDCETHER=y        # CDC-ECM class adapters
+CONFIG_USB_NET_CDC_NCM=y         # CDC-NCM class adapters
+CONFIG_USB_RTL8152=y             # Realtek RTL8152/8153 USB GbE
+CONFIG_USB_NET_AX8817X=y         # ASIX AX88x72 USB 2.0
+CONFIG_USB_NET_AX88179_178A=y    # ASIX AX88179/178A USB 3.0 GbE
+
+# Removable-media filesystems for USB drives (VFAT already built-in)
+CONFIG_EXFAT_FS=y                # exFAT (default format on large USB drives)
+CONFIG_NTFS3_FS=y                # NTFS (Windows-formatted drives)

--- a/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/usb-serial.cfg
+++ b/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi/usb-serial.cfg
@@ -1,0 +1,22 @@
+# Host-side USB-serial adapter support for the common bridge chips.
+#
+# The stock RPi kernel builds USB_SERIAL + some bridges only as MODULES, so an
+# adapter enumerates on the bus but no /dev/ttyUSB* node appears until the module
+# is auto-loaded — unreliable on this minimal image (same reason we build the
+# sysext filesystems in).
+#
+# Built-in (=y) rather than modules: guarantees the driver binds on hotplug
+# without depending on udev/depmod module auto-load. Flip back to =m if module
+# auto-loading is confirmed end-to-end and a smaller kernel image is wanted.
+
+# USB-serial core — required by every usb-serial bridge driver below.
+CONFIG_USB_SERIAL=y
+
+# CDC-ACM class devices (Arduino Uno/Mega, many MCUs) -> /dev/ttyACM*
+CONFIG_USB_ACM=y
+
+# Common USB-serial bridge chips -> /dev/ttyUSB*
+CONFIG_USB_SERIAL_CH341=y       # WCH CH340/CH341 (many ESP/Arduino clones)
+CONFIG_USB_SERIAL_CP210X=y      # Silicon Labs CP210x
+CONFIG_USB_SERIAL_FTDI_SIO=y    # FTDI FT232/FT2232 etc.
+CONFIG_USB_SERIAL_PL2303=y      # Prolific PL2303

--- a/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/meta-rpi-extensions/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -5,6 +5,17 @@ SRC_URI:append:rpi = "${@' file://container.cfg' if d.getVar('WENDYOS_CONTAINER_
 
 # Add USB gadget kernel config when WENDYOS_USB_GADGET is enabled
 SRC_URI:append:rpi = "${@' file://usb-gadget.cfg' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
+
+# Add systemd-sysext filesystem prerequisites when driver add-ons are enabled
+SRC_URI:append:rpi = "${@' file://sysext.cfg' if d.getVar('WENDYOS_DRIVER_EXTENSIONS') == '1' else ''}"
+
+# Bake in the common USB-serial bridge chips (=y) so they bind on hotplug without
+# relying on module auto-load — the most common host peripherals (Arduino/ESP/GPS).
+SRC_URI:append:rpi = " file://usb-serial.cfg"
+
+# Bake in common USB Ethernet adapters + removable-media filesystems (=y) so USB
+# NICs and exFAT/NTFS drives work on hotplug without module auto-load.
+SRC_URI:append:rpi = " file://usb-peripherals.cfg"
 SRC_URI += "file://0001-dwc2-force-g_dma-false-for-BCM2712-in-peripheral-mod.patch"
 
 # CVE backports below are 6.6.y stable backports — they apply to (and are only

--- a/recipes-core/images/wendyos-driver-hello-image.bb
+++ b/recipes-core/images/wendyos-driver-hello-image.bb
@@ -1,0 +1,18 @@
+# Test driver add-on: packages the wendyos_hello self-test module as a .raw so
+# the on-device apply path (merge -> overlay -> depmod -> modprobe) can be
+# validated on real hardware without accelerator hardware.
+SUMMARY = "Test driver add-on (wendyos_hello) as a systemd-sysext image"
+LICENSE = "MIT"
+
+inherit wendyos-sysext-image
+
+# Stable add-on id → on-device file is wendyos-hello.raw (extension-release.wendyos-hello).
+WENDYOS_SYSEXT_NAME = "wendyos-hello"
+
+# The driver declares its own module — baked into the image, so `wendy device drivers
+# install wendyos-hello` needs no --module flag (a real driver like Coral would set
+# "gasket apex" here).
+WENDYOS_SYSEXT_MODULES = "wendyos_hello"
+
+# The recipe meta-package pulls in its split kernel-module-* .ko via RDEPENDS.
+IMAGE_INSTALL = "wendyos-driver-hello"

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -169,6 +169,12 @@ IMAGE_INSTALL:append = " \
     ${@oe.utils.ifelse(d.getVar('WENDYOS_CONTAINER_RUNTIME') == '1', ' packagegroup-wendyos-container', '')} \
     "
 
+# Driver add-ons (systemd-sysext): boot-time service that merges driver .raw
+# add-ons from /data. Gated on WENDYOS_DRIVER_EXTENSIONS (RPi-only for now).
+IMAGE_INSTALL:append = " \
+    ${@oe.utils.ifelse(d.getVar('WENDYOS_DRIVER_EXTENSIONS') == '1', ' wendyos-sysext-apply', '')} \
+    "
+
 # Note: gadget-network-config (standalone dnsmasq) removed.
 # USB gadget IPv4 mode is controlled by WENDYOS_USB_NET_MODE (see wendyos.conf).
 

--- a/recipes-core/packagegroups/packagegroup-base-rpi.inc
+++ b/recipes-core/packagegroups/packagegroup-base-rpi.inc
@@ -8,9 +8,11 @@
 # device"). An earlier :remove:rpi block here predated the RPi /data partition
 # (when there was no /data) and became a regression once /data was introduced.
 
-# Add RPi5-specific kernel modules
+# RPi USB-serial kernel modules. usbserial is now built into the kernel (=y, see
+# usb-serial.cfg) so it has no module package and is dropped here. option/usb-wwan
+# stay =m and remain hard RDEPENDS so a future kernel change that drops them fails
+# the build loudly rather than silently losing 3G-modem serial support.
 RDEPENDS:${PN}:append:rpi = " \
     kernel-module-option \
     kernel-module-usb-wwan \
-    kernel-module-usbserial \
     "

--- a/recipes-core/systemd/rpi-systemd.inc
+++ b/recipes-core/systemd/rpi-systemd.inc
@@ -3,6 +3,11 @@
 
 inherit journal-persist-rpi
 
+# Build systemd-sysext (off by default in oe-core) so signed driver/firmware add-ons
+# merge onto the immutable /usr at runtime. RPi-only for now — the driver add-on
+# feature currently targets RPi5; other machines gain it when they come into scope.
+PACKAGECONFIG:append = " sysext"
+
 # systemd persistent log
 # Install the drop-in and tmpfiles rule ONLY when this feature is enabled.
 do_install:append:journal_persist-on() {

--- a/recipes-core/wendyos-sysext-apply/files/wendyos-sysext-apply.service
+++ b/recipes-core/wendyos-sysext-apply/files/wendyos-sysext-apply.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=WendyOS: merge driver add-ons from /data (sysext + depmod)
+Documentation=man:systemd-sysext(8)
+# Late: needs /data mounted and grown before reading the add-on store. After= on a
+# unit that doesn't exist (grow-data-fs-online on non-RPi) is simply ignored.
+After=data.mount grow-data-fs-online.service
+Wants=data.mount
+ConditionPathExists=/data
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/wendyos-sysext-apply.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-core/wendyos-sysext-apply/files/wendyos-sysext-apply.sh
+++ b/recipes-core/wendyos-sysext-apply/files/wendyos-sysext-apply.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# Merge WendyOS driver add-ons stored on /data onto the running system.
+#
+# Runs late (after /data is mounted and grown). systemd-sysext merges an add-on's
+# /usr content READ-ONLY, so a merged-in .ko is absent from the base modules.dep;
+# we stack a writable overlay on the module dir and re-run depmod so modprobe can
+# resolve it. This works without systemd-sysext "mutable" mode (systemd 256+).
+# Idempotent: safe to re-run every boot and after each install.
+#
+# Trust: this layer does NOT verify signatures — it merges whatever is under
+# /data/extensions and modprobes names from modules-load.d, so anything able to
+# write /data can load a module as root. /data must be a trusted store; signing is
+# enforced by the agent/OTA layer, not here.
+set -u
+
+STORE=/data/extensions
+ENABLED="$STORE/enabled"
+RUNDIR=/run/extensions
+KVER="$(uname -r)"
+MODDIR="/usr/lib/modules/$KVER"
+OVL="$STORE/modules-overlay/$KVER"
+# Add-ons bake their module list into the image at /usr/lib/modules-load.d/<name>.conf;
+# it becomes visible here once the add-on is merged into /usr.
+MODLOADDIR="/usr/lib/modules-load.d"
+
+# True if any add-on is enabled (a .raw under $ENABLED).
+has_enabled() {
+    [ -n "$(find "$ENABLED" -maxdepth 1 -name '*.raw' -print -quit 2>/dev/null)" ]
+}
+
+# Skip only on a truly stock device (never had add-ons). If a prior apply left
+# state behind (stale /run links or a module overlay), fall through even when
+# enabled/ is empty, so removing the last add-on unmerges it instead of leaving
+# /usr stale until the next reboot.
+if ! has_enabled \
+   && [ -z "$(find "$RUNDIR" -maxdepth 1 -type l -print -quit 2>/dev/null)" ] \
+   && ! mountpoint -q "$MODDIR"; then
+    exit 0
+fi
+
+mkdir -p "$ENABLED" "$STORE/modules-load.d" "$OVL/upper" "$OVL/work" "$RUNDIR"
+
+# 1. Expose enabled add-ons to systemd-sysext via /run/extensions (tmpfs search
+#    dir). Clear stale links first (busybox find lacks -delete, so loop).
+for link in "$RUNDIR"/*; do
+    [ -L "$link" ] && rm -f "$link"
+done
+for raw in "$ENABLED"/*.raw; do
+    [ -e "$raw" ] || continue
+    ln -sf "$raw" "$RUNDIR/$(basename "$raw")"
+done
+
+# 2. Tear down any prior module overlay so refresh sees a clean /usr, then merge.
+#    (The overlay is a submount of /usr and would block sysext's /usr unmerge.)
+umount "$MODDIR" 2>/dev/null || umount -l "$MODDIR" 2>/dev/null || true
+if mountpoint -q "$MODDIR"; then
+    echo "wendyos-sysext-apply: could not unmount prior overlay on $MODDIR" >&2
+fi
+if ! systemd-sysext refresh; then
+    echo "wendyos-sysext-apply: systemd-sysext refresh failed" >&2
+    exit 1
+fi
+
+# Last add-on removed: the refresh above unmerged it; nothing left to overlay or
+# depmod, so stop before re-stacking an empty overlay.
+if ! has_enabled; then
+    exit 0
+fi
+
+# 3. Stack a writable overlay on the module dir so depmod can index merged modules.
+if ! mount -t overlay wendyos-modules \
+        -o "lowerdir=$MODDIR,upperdir=$OVL/upper,workdir=$OVL/work" "$MODDIR"; then
+    echo "wendyos-sysext-apply: overlay mount on $MODDIR failed" >&2
+    exit 1
+fi
+
+# 4. Rebuild the unified dependency index (base + all merged add-ons).
+if ! depmod -a "$KVER"; then
+    echo "wendyos-sysext-apply: depmod failed" >&2
+    exit 1
+fi
+
+# 5. Load each enabled add-on's modules (one name per line; '#' comments allowed).
+#    Source per add-on: a /data override ($STORE/modules-load.d/<name>.conf, written
+#    by the agent from --module / manifest modules_load) wins for bench/dev; else the
+#    list baked into the add-on image at $MODLOADDIR/<name>.conf (self-describing —
+#    the driver declares its own modules, no install-time flag needed). depmod above
+#    resolved deps, so a top module pulls in what it needs. Best-effort: keep going
+#    past a failure but exit non-zero so the unit reflects it.
+rc=0
+for raw in "$ENABLED"/*.raw; do
+    [ -e "$raw" ] || continue
+    name=$(basename "$raw" .raw)
+    conf="$STORE/modules-load.d/$name.conf"
+    [ -f "$conf" ] || conf="$MODLOADDIR/$name.conf"
+    [ -f "$conf" ] || continue
+    while IFS= read -r mod || [ -n "$mod" ]; do
+        mod=$(printf '%s' "$mod" | tr -d '[:space:]')     # strip CR/whitespace
+        case "$mod" in
+            ''|\#*) continue ;;
+            *[!A-Za-z0-9_.-]*)
+                echo "wendyos-sysext-apply: bad module name '$mod'" >&2; rc=1; continue ;;
+        esac
+        modprobe -- "$mod" || { echo "wendyos-sysext-apply: modprobe $mod failed" >&2; rc=1; }
+    done < "$conf"
+done
+exit "$rc"

--- a/recipes-core/wendyos-sysext-apply/wendyos-sysext-apply_1.0.bb
+++ b/recipes-core/wendyos-sysext-apply/wendyos-sysext-apply_1.0.bb
@@ -1,0 +1,35 @@
+SUMMARY = "Merge WendyOS driver add-ons (systemd-sysext) from /data at boot"
+DESCRIPTION = "Late-boot service that merges driver .raw add-ons stored on /data \
+onto the running /usr, overlays the kernel module dir so depmod can index them, \
+and modprobes the declared modules — enabling runtime driver install without \
+rebuilding the OS image."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit systemd
+
+SRC_URI = " \
+    file://wendyos-sysext-apply.sh \
+    file://wendyos-sysext-apply.service \
+"
+S = "${UNPACKDIR}"
+
+SYSTEMD_SERVICE:${PN} = "wendyos-sysext-apply.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${UNPACKDIR}/wendyos-sysext-apply.sh \
+        ${D}${sbindir}/wendyos-sysext-apply.sh
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/wendyos-sysext-apply.service \
+        ${D}${systemd_system_unitdir}/wendyos-sysext-apply.service
+}
+
+FILES:${PN} += " \
+    ${sbindir}/wendyos-sysext-apply.sh \
+    ${systemd_system_unitdir}/wendyos-sysext-apply.service \
+"
+
+# systemd-sysext ships with systemd (sysext PACKAGECONFIG); depmod/modprobe from kmod.
+RDEPENDS:${PN} = "systemd kmod"

--- a/recipes-kernel/wendyos-driver-hello/files/Makefile
+++ b/recipes-kernel/wendyos-driver-hello/files/Makefile
@@ -1,0 +1,14 @@
+obj-m := wendyos_hello.o
+
+SRC := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC)
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install
+
+clean:
+	rm -f *.o *~ core .depend .*.cmd *.ko *.mod.c *.mod
+	rm -f Module.markers Module.symvers modules.order
+	rm -rf .tmp_versions

--- a/recipes-kernel/wendyos-driver-hello/files/wendyos_hello.c
+++ b/recipes-kernel/wendyos-driver-hello/files/wendyos_hello.c
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Trivial out-of-tree module used to validate the WendyOS driver add-on pipeline
+// (compile -> sysext .raw -> merge -> depmod -> modprobe) end to end, without
+// needing real accelerator hardware. Stand-in for a vendor driver.
+
+#include <linux/module.h>
+#include <linux/init.h>
+
+static int __init wendyos_hello_init(void)
+{
+	pr_info("wendyos_hello: driver add-on loaded (sysext pipeline OK)\n");
+	return 0;
+}
+
+static void __exit wendyos_hello_exit(void)
+{
+	pr_info("wendyos_hello: driver add-on unloaded\n");
+}
+
+module_init(wendyos_hello_init);
+module_exit(wendyos_hello_exit);
+
+MODULE_LICENSE("GPL v2");
+MODULE_DESCRIPTION("WendyOS sysext driver-pipeline self-test module");
+MODULE_AUTHOR("WendyOS");

--- a/recipes-kernel/wendyos-driver-hello/wendyos-driver-hello_1.0.bb
+++ b/recipes-kernel/wendyos-driver-hello/wendyos-driver-hello_1.0.bb
@@ -1,0 +1,16 @@
+SUMMARY = "WendyOS sysext driver-pipeline self-test kernel module"
+DESCRIPTION = "A trivial out-of-tree module that validates the driver add-on \
+pipeline (compile -> sysext .raw -> merge -> depmod -> modprobe) end to end on \
+real hardware, without an accelerator. Stand-in for a real vendor driver."
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+inherit wendyos-driver-module
+
+SRC_URI = " \
+    file://Makefile \
+    file://wendyos_hello.c \
+"
+
+# file:// sources unpack to ${UNPACKDIR} (= ${WORKDIR}/sources on current oe-core).
+S = "${UNPACKDIR}"

--- a/tools/publisher/manifest_entry.go
+++ b/tools/publisher/manifest_entry.go
@@ -52,6 +52,10 @@ type ManifestEntry struct {
 	SBOMPath     string `json:"sbom_path,omitempty"`
 	SBOMSize     int64  `json:"sbom_size,omitempty"`
 	SBOMChecksum string `json:"sbom_checksum,omitempty"`
+
+	// Extensions are driver add-ons (systemd-sysext .raw images) uploaded with
+	// this build; carried through to the per-version manifest record verbatim.
+	Extensions []ExtensionMetadata `json:"extensions,omitempty"`
 }
 
 func (e *ManifestEntry) validate() error {

--- a/tools/publisher/manifest_entry_test.go
+++ b/tools/publisher/manifest_entry_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -23,6 +24,15 @@ func validEntry() ManifestEntry {
 		SBOMPath:          "images/jetson-agx-orin/0.15.1-nightly/wendyos-image.spdx.tar.zst",
 		SBOMSize:          14829056,
 		SBOMChecksum:      "9f2c1e6c0b7a4d3e8f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e",
+		Extensions: []ExtensionMetadata{{
+			Name:          "nvidia-drivers",
+			Version:       "1.0.0",
+			KernelVersion: "5.15.0-tegra",
+			Path:          "images/jetson-agx-orin/0.15.1-nightly/nvidia-drivers.raw",
+			SHA256:        "aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44",
+			SizeBytes:     4194304,
+			ModulesLoad:   []string{"nvidia", "nvidia_modeset"},
+		}},
 	}
 }
 
@@ -37,7 +47,7 @@ func TestManifestEntryRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("readManifestEntry: %v", err)
 	}
-	if got != want {
+	if !reflect.DeepEqual(got, want) {
 		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", got, want)
 	}
 }
@@ -131,5 +141,32 @@ func TestManifestEntryPRRoundTrip(t *testing.T) {
 	}
 	if out.PR != 123 {
 		t.Fatalf("PR = %d, want 123", out.PR)
+	}
+}
+
+func TestMergeExtensions(t *testing.T) {
+	a := ExtensionMetadata{Name: "hello", KernelVersion: "6.12", SHA256: "aaa"}
+	b := ExtensionMetadata{Name: "npu", KernelVersion: "6.12", SHA256: "bbb"}
+	a2 := ExtensionMetadata{Name: "hello", KernelVersion: "6.12", SHA256: "ccc"}
+	aOther := ExtensionMetadata{Name: "hello", KernelVersion: "6.6", SHA256: "ddd"}
+
+	// Second driver must not wipe the first.
+	got := mergeExtensions([]ExtensionMetadata{a}, []ExtensionMetadata{b})
+	if len(got) != 2 {
+		t.Fatalf("adding a sibling: got %d entries, want 2", len(got))
+	}
+	// Re-publishing the same (name, kernel) replaces in place.
+	got = mergeExtensions(got, []ExtensionMetadata{a2})
+	if len(got) != 2 || got[0].SHA256 != "ccc" {
+		t.Fatalf("upsert same key: got %+v", got)
+	}
+	// Same name for a different kernel is a distinct entry.
+	got = mergeExtensions(got, []ExtensionMetadata{aOther})
+	if len(got) != 3 {
+		t.Fatalf("same name new kernel: got %d entries, want 3", len(got))
+	}
+	// Nil existing behaves.
+	if got := mergeExtensions(nil, []ExtensionMetadata{a}); len(got) != 1 {
+		t.Fatalf("nil existing: got %d, want 1", len(got))
 	}
 }

--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -115,6 +115,40 @@ type DeviceManifest struct {
 	Versions map[string]VersionMetadata `json:"versions"`
 }
 
+// ExtensionMetadata describes one driver add-on (a systemd-sysext .raw) built
+// for a specific kernel and published alongside the OS version it targets. The
+// fields match the wendy CLI's driverResolution so the manifest resolves directly.
+type ExtensionMetadata struct {
+	Name          string   `json:"name"`
+	Version       string   `json:"version,omitempty"`
+	KernelVersion string   `json:"kernel_version"`
+	Path          string   `json:"path"`
+	SHA256        string   `json:"sha256"`
+	SizeBytes     int64    `json:"size_bytes"`
+	Signature     string   `json:"signature,omitempty"`
+	ModulesLoad   []string `json:"modules_load,omitempty"`
+}
+
+// mergeExtensions upserts incoming entries into existing, keyed by
+// (name, kernel_version), preserving previously-published drivers.
+func mergeExtensions(existing, incoming []ExtensionMetadata) []ExtensionMetadata {
+	merged := append([]ExtensionMetadata(nil), existing...)
+	for _, in := range incoming {
+		replaced := false
+		for i, e := range merged {
+			if e.Name == in.Name && e.KernelVersion == in.KernelVersion {
+				merged[i] = in
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			merged = append(merged, in)
+		}
+	}
+	return merged
+}
+
 // VersionMetadata contains metadata about a specific OS version
 type VersionMetadata struct {
 	InstallMode        string     `json:"install_mode,omitempty"`
@@ -214,6 +248,9 @@ type VersionMetadata struct {
 	EMMCFlashpackPath      string `json:"emmc_flashpack_path,omitempty"`
 	EMMCFlashpackChecksum  string `json:"emmc_flashpack_checksum,omitempty"`
 	EMMCFlashpackSizeBytes int64  `json:"emmc_flashpack_size_bytes,omitempty"`
+	// Extensions are driver add-ons (systemd-sysext .raw images) targeting this
+	// OS version, keyed on kernel_version so the CLI picks the matching build.
+	Extensions []ExtensionMetadata `json:"extensions,omitempty"`
 }
 
 // MasterManifest represents the top-level manifest
@@ -1069,6 +1106,12 @@ func main() {
 	flashpackFile := flag.String("flashpack-file", "", "Optional Jetson flashpack (.tar.zst) file path to upload")
 	bmapFile := flag.String("bmap-file", "", "Optional .bmap block-map file to upload alongside the OS image")
 	sbomFile := flag.String("sbom", "", "Optional SPDX SBOM bundle (.spdx.tar.zst) to upload alongside the OS image and record in the manifest")
+	extensionFile := flag.String("extension-file", "", "Optional driver add-on .raw (systemd-sysext image) to upload and record in the manifest")
+	extensionName := flag.String("extension-name", "", "Driver add-on name = EXTENSION_NAME, the on-device <name>.raw (required with --extension-file)")
+	extensionVersion := flag.String("extension-version", "", "Driver add-on version")
+	extensionKernel := flag.String("extension-kernel", "", "Kernel version (uname -r) the driver .ko was built for (required with --extension-file)")
+	extensionModules := flag.String("extension-modules", "", "Comma-separated kernel module names to load after merge")
+	extensionSig := flag.String("extension-sig", "", "Base64 detached signature over the .raw sha256 (from wendyos-sign; empty until a signing key ships)")
 	storage := flag.String("storage", "", "Storage type for multi-artifact devices: nvme or sd (omit for single-storage devices)")
 	updateOnly := flag.Bool("update-only", false, "Only update manifests without uploading")
 	skipMasterManifest := flag.Bool("skip-master-manifest", false, "Skip master manifest update (a separate job will handle it)")
@@ -1184,6 +1227,9 @@ func main() {
 		if *sbomFile != "" {
 			log.Fatal("--sbom is not supported for firmware uploads")
 		}
+		if *extensionFile != "" {
+			log.Fatal("--extension-file is not supported for firmware uploads")
+		}
 	} else if *createDevice {
 		// For creating a device, we only need the device type
 		if err := validateDeviceType(*deviceType); err != nil {
@@ -1291,6 +1337,24 @@ func main() {
 					log.WithError(err).Fatal("Invalid SBOM file")
 				}
 			}
+
+			// Validate driver add-on if provided. name + kernel are required so
+			// the object lands at <name>.raw and the CLI can match by kernel.
+			if *extensionFile != "" {
+				if err := validateFileExists(*extensionFile); err != nil {
+					log.WithError(err).Fatal("Invalid extension file")
+				}
+				if *extensionName == "" {
+					log.Fatal("--extension-name is required with --extension-file")
+				}
+				if *extensionKernel == "" {
+					log.Fatal("--extension-kernel is required with --extension-file")
+				}
+			} else if *extensionName != "" || *extensionVersion != "" || *extensionKernel != "" ||
+				*extensionModules != "" || *extensionSig != "" {
+				// Metadata without an artifact would be silently dropped.
+				log.Fatal("--extension-* flags require --extension-file")
+			}
 		}
 	}
 
@@ -1382,6 +1446,7 @@ func main() {
 			entry.RecoveryPath, entry.RecoverySize, entry.RecoveryChecksum,
 			entry.FlashpackPath, entry.FlashpackSize, entry.FlashpackChecksum,
 			entry.SBOMPath, entry.SBOMSize, entry.SBOMChecksum,
+			entry.Extensions,
 			entry.Storage, entry.Nightly, entry.Stability, *notifyDiscord, true,
 		)
 		return
@@ -1619,6 +1684,36 @@ func main() {
 			bmapUploadChan = uploadFileAsync(ctx, bucket, prefix, *bmapFile, *deviceType, *version)
 		}
 
+		// Driver add-on (.raw). It is already squashfs-xz, so it must be uploaded
+		// verbatim (never the OS-image compress path) — the device checks
+		// sha256(downloaded)==manifest.sha256, so sha256 is taken over the exact
+		// local bytes. Symlinking to <name>.raw makes the basename-derived
+		// uploader land the object at the on-device name without a rename.
+		var extUploadChan <-chan uploadResult
+		var extChecksum string
+		if *extensionFile != "" {
+			log.Info("Processing driver add-on (.raw)...")
+			sum, sumErr := calculateChecksum(*extensionFile)
+			if sumErr != nil {
+				log.WithError(sumErr).Fatal("Failed to checksum extension file")
+			}
+			extChecksum = sum
+			absExt, absErr := filepath.Abs(*extensionFile)
+			if absErr != nil {
+				log.WithError(absErr).Fatal("Failed to resolve extension file path")
+			}
+			extLinkDir, tmpErr := os.MkdirTemp("", "wendy-ext-*")
+			if tmpErr != nil {
+				log.WithError(tmpErr).Fatal("Failed to stage extension upload")
+			}
+			defer os.RemoveAll(extLinkDir)
+			linkPath := filepath.Join(extLinkDir, *extensionName+".raw")
+			if linkErr := os.Symlink(absExt, linkPath); linkErr != nil {
+				log.WithError(linkErr).Fatal("Failed to stage extension upload")
+			}
+			extUploadChan = uploadFileAsync(ctx, bucket, prefix, linkPath, *deviceType, *version)
+		}
+
 		// The seekable-zstd OS image now IS the main file (compressFile produced
 		// it in place of a gzip .img.gz), so there is no separate .zst artifact
 		// to generate or upload here — the manifest .zst fields reuse the main
@@ -1688,6 +1783,32 @@ func main() {
 			log.Info("SBOM file uploaded successfully")
 		}
 
+		// Build the driver add-on record from the upload result + local sha256.
+		var extensions []ExtensionMetadata
+		if extUploadChan != nil {
+			extUpload := <-extUploadChan
+			if extUpload.err != nil {
+				log.WithError(extUpload.err).Fatal("Failed to upload extension file")
+			}
+			log.Info("Extension file uploaded successfully")
+			var modules []string
+			for _, m := range strings.Split(*extensionModules, ",") {
+				if m = strings.TrimSpace(m); m != "" {
+					modules = append(modules, m)
+				}
+			}
+			extensions = append(extensions, ExtensionMetadata{
+				Name:          *extensionName,
+				Version:       *extensionVersion,
+				KernelVersion: *extensionKernel,
+				Path:          extUpload.path,
+				SHA256:        extChecksum,
+				SizeBytes:     extUpload.size,
+				Signature:     *extensionSig,
+				ModulesLoad:   modules,
+			})
+		}
+
 		// Seekable-zstd manifest fields. When the main OS image is itself a
 		// seekable .zst (Jetson raw .img), it doubles as the .zst artifact, so
 		// reuse the single upload rather than a second identical object.
@@ -1729,6 +1850,7 @@ func main() {
 				SBOMPath:          sbomUpload.path,
 				SBOMSize:          sbomUpload.size,
 				SBOMChecksum:      sbomResult.checksum,
+				Extensions:        extensions,
 			}
 			if err := writeManifestEntry(*metadataOut, entry); err != nil {
 				log.WithError(err).Fatal("Failed to write manifest entry")
@@ -1747,6 +1869,7 @@ func main() {
 			recoveryUpload.path, recoveryUpload.size, recoveryResult.checksum,
 			flashpackUpload.path, flashpackUpload.size, flashpackResult.checksum,
 			sbomUpload.path, sbomUpload.size, sbomResult.checksum,
+			extensions,
 			*storage, *nightly, *stability, *notifyDiscord, *skipMasterManifest,
 		)
 	} else {
@@ -1821,7 +1944,7 @@ func main() {
 			recoverySize = recoveryAttrs.Size
 		}
 
-		updateManifests(ctx, bucket, prefix, *deviceType, *version, imagePath, attrs.Size, mainChecksum, "", "", "", 0, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, "", 0, "", "", 0, "", *storage, *nightly, *stability, *notifyDiscord, *skipMasterManifest)
+		updateManifests(ctx, bucket, prefix, *deviceType, *version, imagePath, attrs.Size, mainChecksum, "", "", "", 0, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, "", 0, "", "", 0, "", nil, *storage, *nightly, *stability, *notifyDiscord, *skipMasterManifest)
 	}
 }
 
@@ -2007,7 +2130,7 @@ func uploadFile(ctx context.Context, bucket *storage.BucketHandle, prefix, local
 	return destinationPath, nil
 }
 
-func updateManifests(ctx context.Context, bucket *storage.BucketHandle, prefix, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, flashpackPath string, flashpackSize int64, flashpackChecksum string, sbomPath string, sbomSize int64, sbomChecksum string, storage string, isNightly bool, stability string, notifyDiscord bool, skipMasterManifest bool) {
+func updateManifests(ctx context.Context, bucket *storage.BucketHandle, prefix, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, flashpackPath string, flashpackSize int64, flashpackChecksum string, sbomPath string, sbomSize int64, sbomChecksum string, extensions []ExtensionMetadata, storage string, isNightly bool, stability string, notifyDiscord bool, skipMasterManifest bool) {
 	logger := log.WithFields(logrus.Fields{
 		"device_type":     deviceType,
 		"version":         version,
@@ -2033,7 +2156,7 @@ func updateManifests(ctx context.Context, bucket *storage.BucketHandle, prefix, 
 
 	if skipMasterManifest {
 		logger.Info("Updating device manifest (master manifest will be updated by a separate publish job)")
-		if err := updateDeviceManifest(ctx, deviceLogger, bucket, prefix, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, flashpackPath, flashpackSize, flashpackChecksum, sbomPath, sbomSize, sbomChecksum, storage, isNightly); err != nil {
+		if err := updateDeviceManifest(ctx, deviceLogger, bucket, prefix, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, flashpackPath, flashpackSize, flashpackChecksum, sbomPath, sbomSize, sbomChecksum, extensions, storage, isNightly); err != nil {
 			logger.WithError(err).Fatal("Failed to update device manifest")
 		}
 	} else {
@@ -2055,7 +2178,7 @@ func updateManifests(ctx context.Context, bucket *storage.BucketHandle, prefix, 
 
 		go func() {
 			defer wg.Done()
-			deviceErrChan <- updateDeviceManifest(ctx, deviceLogger, bucket, prefix, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, flashpackPath, flashpackSize, flashpackChecksum, sbomPath, sbomSize, sbomChecksum, storage, isNightly)
+			deviceErrChan <- updateDeviceManifest(ctx, deviceLogger, bucket, prefix, deviceType, version, filePath, fileSize, fileChecksum, bmapPath, zstPath, zstChecksum, zstSize, otaUpdatePath, otaUpdateSize, otaUpdateChecksum, recoveryPath, recoverySize, recoveryChecksum, flashpackPath, flashpackSize, flashpackChecksum, sbomPath, sbomSize, sbomChecksum, extensions, storage, isNightly)
 		}()
 
 		go func() {
@@ -2426,7 +2549,7 @@ func validateRecoveryPromotion(deviceType string, source VersionMetadata, paths 
 	return nil
 }
 
-func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, prefix, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, flashpackPath string, flashpackSize int64, flashpackChecksum string, sbomPath string, sbomSize int64, sbomChecksum string, storageType string, isNightly bool) error {
+func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *storage.BucketHandle, prefix, deviceType, version, filePath string, fileSize int64, fileChecksum string, bmapPath string, zstPath, zstChecksum string, zstSize int64, otaUpdatePath string, otaUpdateSize int64, otaUpdateChecksum string, recoveryPath string, recoverySize int64, recoveryChecksum string, flashpackPath string, flashpackSize int64, flashpackChecksum string, sbomPath string, sbomSize int64, sbomChecksum string, extensions []ExtensionMetadata, storageType string, isNightly bool) error {
 	manifestPath := deviceManifestPath(prefix, deviceType)
 	logger = logger.WithField("manifest_path", manifestPath)
 	logger.Info("Processing device manifest")
@@ -2640,6 +2763,14 @@ func updateDeviceManifest(ctx context.Context, logger *logrus.Entry, bucket *sto
 				"sbom_size":     sbomSize,
 				"sbom_checksum": sbomChecksum,
 			}).Info("Updating SBOM metadata")
+		}
+
+		// Upsert driver add-ons by (name, kernel) rather than replacing the
+		// list: each publisher run carries at most one extension, so a whole-
+		// list replace would wipe previously-published sibling drivers.
+		if len(extensions) > 0 {
+			versionMetadata.Extensions = mergeExtensions(versionMetadata.Extensions, extensions)
+			logger.WithField("extension_count", len(versionMetadata.Extensions)).Info("Updating extension metadata")
 		}
 
 		// Validate that at least one file is provided
@@ -3245,6 +3376,12 @@ func promoteNightlyToStable(ctx context.Context, bucket *storage.BucketHandle, p
 		RecoveryPath:       recoveryDestPath,
 		RecoveryChecksum:   sourceVersionMeta.RecoveryChecksum,
 		RecoverySizeBytes:  sourceVersionMeta.RecoverySizeBytes,
+
+		// Carry driver add-ons across promotion (else --promote silently drops
+		// extensions[]). Path still points at the source version's .raw, which
+		// promotion does not delete; a later refinement can copy each .raw into
+		// the stable version dir like the image/OTA/flashpack artifacts.
+		Extensions: sourceVersionMeta.Extensions,
 	}
 	applyPromotedRecoveryFields(&stableVersionMeta, sourceVersionMeta, promotionRecoveryPaths)
 
@@ -3535,6 +3672,10 @@ func swapImageFile(ctx context.Context, bucket *storage.BucketHandle, prefix, de
 		SDRootfsOnlyZstPath:        existingVersion.SDRootfsOnlyZstPath,
 		SDRootfsOnlyZstChecksum:    existingVersion.SDRootfsOnlyZstChecksum,
 		SDRootfsOnlyZstSizeBytes:   existingVersion.SDRootfsOnlyZstSizeBytes,
+
+		// Driver add-ons are per-version artifacts, not derived from the swapped
+		// image, so preserve them (else --swap silently drops extensions[]).
+		Extensions: existingVersion.Extensions,
 	}
 
 	// Recovery: use new if provided, otherwise preserve existing


### PR DESCRIPTION
Builds kernel driver add-ons as systemd-sysext images and adds the on-device
path that merges them, so a driver can be installed on a running device without
reflashing it.

## What's here

- **`wendyos-sysext-image` / `wendyos-driver-module` classes** — compile an
  out-of-tree module against the pinned kernel and pack it into a single
  xz-squashfs `.raw`, stripped to just the driver payload, with a stable
  extension name and the module list baked in so an add-on is self-describing.
- **`wendyos-sysext-apply`** — merges enabled add-ons onto `/usr` at boot,
  overlays the module directory, runs depmod and modprobes the declared modules;
  unmerges again when the last add-on is removed.
- **systemd `sysext` support and the RPi kernel prerequisites** (loop,
  squashfs-xz, overlayfs), gated by `WENDYOS_DRIVER_EXTENSIONS`.
- **`wendyos_hello` test add-on** plus CI that builds it and publishes the `.raw`
  into the device manifest's `extensions[]`, keyed by name and kernel.
- **USB peripheral drivers** (serial, ethernet, exFAT/NTFS) built into the RPi
  kernel instead of shipped as modules.
- **Deterministic PARTUUIDs** instead of random-per-workspace ones, so the
  base-files, cmdline and image tasks reuse sstate across CI runs rather than
  rebuilding every time.

## Testing

Built for Raspberry Pi 5 and validated on hardware: the CI-published add-on
resolves from the registry, installs, merges into `/usr`, and its module loads.
Removal unmerges it, and a failed apply leaves the previously working add-on
in place.

Refs: WDY-1925, WDY-1926, WDY-1927, WDY-1929
