### PR TITLE
ci: use the runner image's baked RPi kernel mirror via PREMIRRORS

### DIFF
--- a/conf/template/include/local/common.inc
+++ b/conf/template/include/local/common.inc
@@ -1,6 +1,18 @@
 # Shared build settings — required by every board.
 
 DL_DIR = "${TOPDIR}/../downloads"
+
+# RPi kernel source mirror. The self-hosted runner image bakes a bitbake mirror
+# tarball of the 5+ GB raspberrypi/linux kernel tree at /opt/source-mirror
+# (wendylabsinc/ci, seed-kernel-source-mirror.sh). Without this, the
+# linux-raspberrypi do_fetch cold-clones that tree from GitHub at job time,
+# which intermittently stalls / exits 128 and fails the RPi builds. Point
+# PREMIRRORS at the baked tarball so the fetch is a local extract instead.
+#
+# Guarded on the directory existing, so local and dev builds (no mirror) are
+# unaffected; if the tarball is ever absent, this is a PREMIRRORS (not
+# BB_FETCH_PREMIRRORONLY), so bitbake still falls back to the upstream SRC_URI.
+PREMIRRORS:prepend = "${@'git://github.com/raspberrypi/linux.* file:///opt/source-mirror/ \n' if os.path.isdir('/opt/source-mirror') else ''}"
 # sstate-cache is partitioned per layer tree so cross-series builds (e.g.
 # scarthgap Orin and wrynose Thor on the same workspace) don't share
 # signatures or accidentally collide. Downloads stay shared — source


### PR DESCRIPTION
Fixes the recurring **Raspberry Pi build failures** — the RPi-only `do_fetch` errors cloning `github.com/raspberrypi/linux.git`.

## Root cause

The self-hosted runner image already bakes a 5.3 GB bitbake mirror tarball of the `raspberrypi/linux` kernel at `/opt/source-mirror` (shipped in `wendylabsinc/ci` #31, `seed-kernel-source-mirror.sh`). That script's own header says it *"Pairs with the WendyOS-Builder change in `conf/template/include/local/common.inc`, which adds `/opt/source-mirror` as a PREMIRRORS source"* — **but that paired change was never landed here.** A `git grep` for `PREMIRRORS` across `main` returns nothing.

So the fix was half-wired: the mirror sits in the image unused, and `linux-raspberrypi` `do_fetch` keeps cold-cloning the 5+ GB tree from GitHub at job time. That clone intermittently **stalls / exits 128** (confirmed in run 29924749731: a ~2 h stall, then MIRRORS exhausted, then the job is killed). The workflow's `make build || make build` retry can't catch it because a stall isn't a fast failure — the job times out or is cancelled before `make` returns.

I verified on the box that the live image (`localhost/wendy-ci-wendyos-builder:current`) does contain `/opt/source-mirror/git2_github.com.raspberrypi.linux.git.tar.gz` (5.3 GB), and that the tarball name matches bitbake's git-fetcher mirror convention exactly.

## The change

One line in `common.inc`: a `PREMIRRORS` entry pointing the git fetcher at the baked tarball, so the fetch becomes a local extract instead of an internet clone.

- **Guarded on the directory existing** (`os.path.isdir(/opt/source-mirror)`), so local and dev builds without the mirror are completely unaffected.
- It's a `PREMIRRORS`, not `BB_FETCH_PREMIRRORONLY` — if the tarball is ever missing, bitbake still falls back to the upstream GitHub `SRC_URI`.
- Scoped to `git://github.com/raspberrypi/linux.*` only — no effect on any other source.

## Validation

- The inline-python guard and the find-regex were unit-checked: empty when the dir is absent, active when present, matches the real kernel URL, ignores non-RPi URLs.
- **Live validation is this PR's own build**: it runs on the runner (which has `/opt/source-mirror`), so a green RPi build here whose kernel resolves from the mirror instead of a GitHub clone is the confirmation. I'll watch the RPi jobs on this run.

Pairs with `wendylabsinc/ci` #31.