### PR TITLE
ci: warm expensive sstate on a fat runner before the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,8 @@ jobs:
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
       devices: ${{ steps.set.outputs.devices }}
+      warm-matrix: ${{ steps.set.outputs.warm-matrix }}
+      warm-devices: ${{ steps.set.outputs.warm-devices }}
       version: ${{ steps.version.outputs.version }}
       is-release: ${{ steps.version.outputs.is-release }}
     steps:
@@ -70,6 +72,39 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.version }}
+
+      # Heavy-input detection for the warm-caches job: these path sets name the
+      # inputs whose change invalidates expensive sstate (kernel config/patches,
+      # machine/distro/template conf including per-board repos.overrides,
+      # bbclasses, systemd, the upstream layer pins). Grouped per device family
+      # so an RPi-only kernel tweak does not occupy the warm runner with Jetson
+      # no-ops. Skipped on tag/dispatch runs (no diff to filter; those refs were
+      # already warmed by the branch runs that produced them) — outputs then
+      # default empty and warm-caches is skipped.
+      - id: filter
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_type == 'branch')
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            global:
+              - 'classes/**'
+              - 'conf/distro/**'
+              - 'conf/template/**'
+              - 'recipes-core/systemd/**'
+              - 'scripts/upstream-repos.env'
+            rpi:
+              - 'meta-rpi-extensions/**'
+              - 'recipes-kernel/**'
+              - 'conf/machine/raspberrypi*'
+              - 'conf/machine/include/raspberrypi*'
+            jetson:
+              - 'meta-tegra-extensions/**'
+              - 'meta-tegra-extensions-jp6/**'
+              - 'meta-tegra-extensions-jp7/**'
+              - 'conf/machine/jetson-*'
+            x86:
+              - 'meta-x86-extensions/**'
+              - 'conf/machine/genericx86*'
 
       # Compute the build version exactly once so every matrix job and the
       # publish job agree on a single version string for the whole run.
@@ -111,6 +146,10 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_DEVICE: ${{ inputs.device }}
+          FILTER_GLOBAL: ${{ steps.filter.outputs.global }}
+          FILTER_RPI: ${{ steps.filter.outputs.rpi }}
+          FILTER_JETSON: ${{ steps.filter.outputs.jetson }}
+          FILTER_X86: ${{ steps.filter.outputs.x86 }}
         run: |
           set -euo pipefail
 
@@ -150,6 +189,37 @@ jobs:
           # requires single-line key=value pairs (no implicit multiline support).
           ALL_MATRIX=$(echo "${ALL_MATRIX}" | jq -c .)
 
+          # --- warm-caches selection --------------------------------------
+          # Union of the device families whose heavy inputs changed (paths
+          # filter step above); 'global' inputs invalidate every family.
+          # Selection preserves ALL_MATRIX's longest-pole-first order. Empty
+          # when the filter step was skipped (tag/dispatch) or nothing heavy
+          # changed -> the warm-caches job is skipped entirely.
+          FAMILIES=""
+          if [[ "${FILTER_GLOBAL:-}" == "true" ]]; then
+            FAMILIES="rpi jetson x86"
+          else
+            [[ "${FILTER_RPI:-}"    == "true" ]] && FAMILIES="${FAMILIES} rpi"
+            [[ "${FILTER_JETSON:-}" == "true" ]] && FAMILIES="${FAMILIES} jetson"
+            [[ "${FILTER_X86:-}"    == "true" ]] && FAMILIES="${FAMILIES} x86"
+          fi
+          WARM_REGEX=""
+          for fam in ${FAMILIES}; do
+            case "${fam}" in
+              rpi)    WARM_REGEX="${WARM_REGEX}|^raspberry-pi-" ;;
+              jetson) WARM_REGEX="${WARM_REGEX}|^jetson-" ;;
+              x86)    WARM_REGEX="${WARM_REGEX}|^generic-x86-64$" ;;
+            esac
+          done
+          WARM_REGEX="${WARM_REGEX#|}"
+          WARM_ENTRIES='[]'
+          if [[ -n "${WARM_REGEX}" ]]; then
+            WARM_ENTRIES=$(echo "${ALL_MATRIX}" | jq -c --arg re "${WARM_REGEX}" '[.[] | select(.device | test($re))]')
+          fi
+          echo "warm-matrix={\"include\":${WARM_ENTRIES}}" >> "$GITHUB_OUTPUT"
+          echo "warm-devices=$(echo "${WARM_ENTRIES}" | jq -r '[.[].device] | join(" ")')" >> "$GITHUB_OUTPUT"
+          echo "Warm families: '${FAMILIES# }' -> $(echo "${WARM_ENTRIES}" | jq -r 'length') device(s)"
+
           emit_all() {
             echo "matrix={\"include\":${ALL_MATRIX}}" >> "$GITHUB_OUTPUT"
             echo "devices=jetson-agx-thor jetson-agx-orin jetson-orin-nano generic-x86-64 raspberry-pi-5 raspberry-pi-4 raspberry-pi-3" >> "$GITHUB_OUTPUT"
@@ -188,6 +258,396 @@ jobs:
           exit 0
 
   # ---------------------------------------------------------------------------
+  # warm-caches: pre-build expensive sstate on the fat warm runner profile.
+  # Dispatched only when detect-changes' paths filter flags heavy inputs
+  # (kernel config/patches, machine/distro/template conf, bbclasses, systemd,
+  # layer pins), and only for the affected device families. Runs the exact
+  # same build as the matrix job below -- same auto.conf flags, same agent
+  # pin, same board loop -- but on wendyos-builder-warm (64Gi, serial), so the
+  # one-time rebuild runs at full speed instead of thrashing the 16Gi matrix
+  # cgroup, and its sstate lands in the shared cache for the matrix jobs to
+  # restore (WDY-1925 postmortem, 2026-07-27). Artifacts are discarded --
+  # banking sstate is the entire point.
+  # NOTE: the steps are a verbatim copy of the build job's pre-publish steps;
+  # only the checkout version and the PRIV_TAG differ. Keep them in sync.
+  # ---------------------------------------------------------------------------
+  warm-caches:
+    name: Warm caches (${{ matrix.device }})
+    needs: detect-changes
+    if: needs.detect-changes.outputs.warm-devices != ''
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, x64, wendyos-builder-warm]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.detect-changes.outputs.warm-matrix) }}
+    env:
+      WENDYOS_HOST_BUILD: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          path: wendyos
+          ref: ${{ inputs.version }}
+
+      # Point the three build caches at the tenant's persistent NVMe pool.
+      # common.inc pins DL_DIR/SSTATE_DIR to ${TOPDIR}/../{downloads,sstate-cache},
+      # siblings of build/ in the workspace — so symlinking those onto the cache
+      # makes the existing paths resolve onto NVMe with no build-logic changes.
+      # Both are content-hashed and race-tolerant across the matrix. repos/ is
+      # NOT race-tolerant and is handled separately (private reflink snapshot) in
+      # the bootstrap step below.
+      - name: Wire caches to persistent NVMe
+        run: |
+          set -euo pipefail
+          base=/opt/wendy-cache/wendyos-builder
+          for d in sstate-cache downloads; do
+            ln -sfn "$base/$d" "$GITHUB_WORKSPACE/$d"
+            echo "linked $GITHUB_WORKSPACE/$d -> $base/$d"
+          done
+
+      # ---------- Build ----------
+
+      # Resolve every storage variant of this device to its (board, machine).
+      # Emits a single-line 'map' of space-separated 'storage|board|machine'
+      # tokens consumed by the build loop and the per-variant post-build steps,
+      # plus 'first-board' for the one-time bootstrap below. The map preserves
+      # the storage order from the matrix entry, so the first variant listed is
+      # the one that seeds sstate for the rest.
+      - name: Derive build variables
+        id: vars
+        env:
+          DEVICE: ${{ matrix.device }}
+          STORAGES: ${{ matrix.storages }}
+        run: |
+          set -euo pipefail
+          MAP=""
+          for STORAGE in $STORAGES; do
+            case "$DEVICE:$STORAGE" in
+              raspberry-pi-3:sd)    BOARD=rpi3-sd;               MACHINE=raspberrypi3-64-wendyos ;;
+              raspberry-pi-4:sd)    BOARD=rpi4-sd;               MACHINE=raspberrypi4-64-wendyos ;;
+              raspberry-pi-5:sd)    BOARD=rpi5-sd;               MACHINE=raspberrypi5-wendyos ;;
+              raspberry-pi-5:nvme)  BOARD=rpi5-nvme;             MACHINE=raspberrypi5-nvme-wendyos ;;
+              jetson-agx-orin:nvme) BOARD=jetson-agx-orin;       MACHINE=jetson-agx-orin-devkit-nvme-wendyos ;;
+              jetson-agx-orin:emmc) BOARD=jetson-agx-orin-emmc;  MACHINE=jetson-agx-orin-devkit-emmc-wendyos ;;
+              jetson-orin-nano:nvme) BOARD=jetson-orin-nano-nvme; MACHINE=jetson-orin-nano-devkit-nvme-wendyos ;;
+              jetson-orin-nano:sd)   BOARD=jetson-orin-nano-sd;   MACHINE=jetson-orin-nano-devkit-wendyos ;;
+              jetson-agx-thor:nvme) BOARD=jetson-agx-thor;       MACHINE=jetson-agx-thor-devkit-nvme-wendyos ;;
+              generic-x86-64:disk)  BOARD=generic-x86-64;       MACHINE=genericx86-64-wendyos ;;
+              *) echo "Unknown device/storage: $DEVICE/$STORAGE"; exit 1 ;;
+            esac
+            MAP="$MAP $STORAGE|$BOARD|$MACHINE"
+          done
+          MAP="${MAP# }"
+          FIRST_BOARD=$(echo "$MAP" | cut -d' ' -f1 | cut -d'|' -f2)
+          echo "map=$MAP" >> "$GITHUB_OUTPUT"
+          echo "first-board=$FIRST_BOARD" >> "$GITHUB_OUTPUT"
+          echo "Variants for $DEVICE: $MAP"
+
+      # Isolate repos/ per job so no two runs can rewrite one another's layer
+      # tree. The matrix shares one seed on the NVMe cache and clone_repos does
+      # git fetch/checkout there — unsafe under concurrency, and a cross-run
+      # checkout at a different SRCREV would corrupt an in-flight build. reflink
+      # (XFS reflink=1 on this pool) gives each job an instant, space-free
+      # copy-on-write snapshot of the seed; the build reads only that private
+      # copy. reflink can't cross filesystems, so the snapshot lives on the pool
+      # and is symlinked into the workspace. WENDYOS_HOST_BUILD (job env) keeps
+      # bootstrap in host-build mode (no Docker image build).
+      - name: Bootstrap build environment (repos isolated via reflink)
+        working-directory: ${{ github.workspace }}
+        env:
+          BOARD: ${{ steps.vars.outputs.first-board }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+          PRIV_TAG: ${{ github.run_id }}-${{ github.run_attempt }}-warm-${{ matrix.device }}
+        run: |
+          set -euo pipefail
+          # The launcher bind-mounts each declared cache subdir individually, so
+          # only sstate-cache/, downloads/ and repos/ are writable — the parent
+          # dir is not. Keep the seed, per-job snapshots, and the lock all inside
+          # the writable repos/ mount (same XFS, so reflink still applies).
+          base=/opt/wendy-cache/wendyos-builder/repos
+          seed="$base/seed"
+          priv="$base/runs/$PRIV_TAG"
+          mkdir -p "$seed" "$base/runs"
+          exec 9>"$base/.lock"
+          if [[ "$IS_PR" == "true" ]]; then
+            # PR: never write the shared seed. Take a read-consistent snapshot
+            # under a shared lock, then advance only the private copy.
+            flock -s 9
+            rm -rf "$priv"
+            cp -a --reflink=always "$seed" "$priv"
+            flock -u 9
+            ln -sfn "$priv" "$GITHUB_WORKSPACE/repos"
+            ./wendyos/bootstrap.sh
+          else
+            # main/tag/dispatch: advance the seed to this run's SRCREVs and
+            # snapshot it, both under an exclusive lock, so the seed stays warm
+            # for future snapshots. bootstrap runs against the seed (symlink),
+            # then we swap the symlink for the private snapshot at the same path
+            # (make build re-sources oe-init from ./repos, so the swap is
+            # transparent). Held only for the fast bootstrap + snapshot.
+            flock -x 9
+            ln -sfn "$seed" "$GITHUB_WORKSPACE/repos"
+            ./wendyos/bootstrap.sh
+            rm -f "$GITHUB_WORKSPACE/repos"
+            rm -rf "$priv"
+            cp -a --reflink=always "$seed" "$priv"
+            ln -sfn "$priv" "$GITHUB_WORKSPACE/repos"
+            flock -u 9
+          fi
+          echo "repos: private reflink snapshot at $priv"
+
+      # Back build/tmp with the launcher's NVMe scratch mount. Two constraints
+      # must hold together, and each of the two prior attempts satisfied only one:
+      #
+      #   1. Yocto's pseudo (fakeroot) records canonical absolute paths and does
+      #      NOT tolerate TMPDIR being (or sitting behind) a symlink. Leaving
+      #      TMPDIR at its default while symlinking build/tmp -> /wendy/build-tmp
+      #      made rootfs-time postinstall scriptlets run under pseudo fail
+      #      ("Postinstall scriptlets of ['rpcbind'] have failed" at do_rootfs)
+      #      on every board and branch (self-hosted only).
+      #   2. The upload/packaging steps read $GITHUB_WORKSPACE/build/tmp/deploy.
+      #      A bare TMPDIR=/wendy/build-tmp override also moves DEPLOY_DIR there
+      #      (Yocto default ${TMPDIR}/deploy), so images become invisible to
+      #      those steps (surfaces on non-PR builds, which run them).
+      #
+      # A bind mount would give a real path for both, but the runner has no
+      # passwordless sudo. So: set TMPDIR explicitly to a real scratch path
+      # (pseudo uses the canonical dir, never a symlink) AND also symlink
+      # build/tmp -> that path so the shell-level upload steps'
+      # $GITHUB_WORKSPACE/build/tmp/deploy paths still resolve. Bitbake never
+      # uses the symlink (TMPDIR is pinned), so pseudo stays happy.
+      #
+      # The /wendy scratch is bind-mounted from the box and SHARED by every job
+      # container scheduled on it (exactly like the /opt/wendy-cache pool). A
+      # fixed TMPDIR=/wendy/build-tmp therefore lets two concurrent jobs on the
+      # same box drive bitbake against one TMPDIR — an unsupported config that
+      # corrupts both builds (work/, buildstats/ and hosttools/ vanish mid-run
+      # with FileNotFoundError). Give each job its own real subdirectory, keyed
+      # by the same PRIV_TAG the repos snapshot uses, so the scratch is isolated
+      # per job just like repos/.
+      - name: Back build/tmp with the platform NVMe scratch
+        env:
+          PRIV_TAG: ${{ github.run_id }}-${{ github.run_attempt }}-warm-${{ matrix.device }}
+        run: |
+          set -euo pipefail
+          # Per-job real scratch path for bitbake/pseudo. Clear any stale dir a
+          # prior run with the same tag might have left (tag is unique per run
+          # attempt, so this only matters after a re-run of the same attempt).
+          scratch="/wendy/build-tmp/$PRIV_TAG"
+          rm -rf "$scratch"
+          mkdir -p "$scratch"
+          {
+            echo ''
+            echo '# wendy-ci: back TMPDIR with the platform NVMe scratch (per-job)'
+            echo "TMPDIR = \"$scratch\""
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+          # Alias build/tmp -> the same path so upload steps that read
+          # $GITHUB_WORKSPACE/build/tmp/deploy resolve to the real artifacts.
+          # bootstrap created build/ but not build/tmp yet (bitbake makes it on
+          # first run); clear any stray dir/symlink, then symlink onto scratch.
+          rm -rf "$GITHUB_WORKSPACE/build/tmp"
+          ln -sfn "$scratch" "$GITHUB_WORKSPACE/build/tmp"
+          echo "TMPDIR pinned to $scratch; build/tmp aliased to it"
+
+      - name: Stamp build provenance (version + commit)
+        # Bake the build's tag/ID and the exact builder commit into the image so
+        # they surface on the boot screen (/etc/issue) and in /etc/wendyos/commit.
+        # VERSION is the same string the publish step uploads under
+        # (pr-<N> | nightly-<ts> | X.Y.Z); COMMIT is the full builder SHA — the PR
+        # head on pull_request (the reviewed commit, not the ephemeral merge SHA),
+        # otherwise github.sha. Runs on every build. See WENDYOS_BUILD_* in
+        # conf/template/include/local/common.inc.
+        env:
+          BUILD_VERSION: ${{ needs.detect-changes.outputs.version }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+            BUILD_COMMIT="$PR_HEAD_SHA"
+          else
+            BUILD_COMMIT="$PUSH_SHA"
+          fi
+          {
+            echo ''
+            echo '# CI: build provenance stamped into the image'
+            echo "WENDYOS_BUILD_VERSION = \"${BUILD_VERSION}\""
+            echo "WENDYOS_BUILD_COMMIT = \"${BUILD_COMMIT}\""
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+          echo "Stamped version=${BUILD_VERSION} commit=${BUILD_COMMIT}"
+
+      - name: Enable debug for nightly builds
+        # Release images are production builds — no debug tools by default.
+        # Nightly and workflow_dispatch builds get debug tooling so CI-flashed
+        # devices include diagnostic utilities out of the box. Release builds
+        # triggered by promote.yml can opt in via inputs.debug.
+        if: (needs.detect-changes.outputs.is-release != 'true' && github.event_name != 'pull_request') || inputs.debug == true
+        run: |
+          {
+            echo ''
+            echo '# Nightly CI: enable debug tooling on all devices'
+            echo 'WENDYOS_DEBUG = "1"'
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+
+      - name: Enable developer profile (PR builds)
+        # PR images are open-book debug builds: full debug tooling, SSH, serial
+        # boot output, and a serial (UART) login as the wendy user (passwordless
+        # sudo) so the PR is debuggable on real hardware — root stays locked.
+        # Login is opt-in (both knobs default off), so enable UART login here.
+        # Never applied to nightly or release (fortress) builds.
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            echo ''
+            echo '# PR CI: open-book developer profile'
+            echo 'WENDYOS_DEBUG = "1"'
+            echo 'WENDYOS_SSHD = "1"'
+            echo 'WENDYOS_DEBUG_UART = "1"'
+            echo 'WENDYOS_ENABLE_UART_LOGIN = "1"'
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+
+      - name: Enable SBOM generation for release builds
+        # SPDX SBOM generation (create-spdx) is expensive — a do_create_spdx
+        # task per recipe plus rootfs-time image/runtime SPDX. It is only ever
+        # consumed on release builds (attached to the GitHub release by the
+        # publish job). promote.yml rebuilds from scratch at the release tag
+        # rather than reusing nightly artifacts, so a nightly's SBOM can never
+        # feed a release — nightly and PR builds skip it entirely. The distro
+        # gates `INHERIT += "create-spdx"` on WENDYOS_SBOM, set here.
+        if: needs.detect-changes.outputs.is-release == 'true'
+        run: |
+          {
+            echo ''
+            echo '# Release build: generate SPDX SBOM (attached to the GitHub release)'
+            echo 'WENDYOS_SBOM = "1"'
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+
+      - name: Enable SSH when explicitly requested
+        # SSH is disabled by default (WENDYOS_SSHD ??= "0" in common.inc).
+        # Pass inputs.sshd = true on workflow_dispatch or promote.yml to opt in.
+        if: inputs.sshd == true
+        run: |
+          {
+            echo ''
+            echo '# CI: enable SSH server on all devices (explicitly requested)'
+            echo 'WENDYOS_SSHD = "1"'
+          } >> "$GITHUB_WORKSPACE/build/conf/auto.conf"
+
+      # Note: SSTATE_DIR / DL_DIR are pinned to ${TOPDIR}/../{sstate-cache,downloads}
+      # by conf/template/include/local/common.inc, which resolve onto the NVMe
+      # cache via the symlinks wired above — no auto.conf override needed.
+
+      # Resolve the latest *stable* wendyos-agent release (tag + asset sha256)
+      # and export them so the wendyos-agent recipe pins this exact version.
+      # This is what makes "ship the latest agent on every run" actually work:
+      # the recipe embeds the version + checksum in SRC_URI, so a new release
+      # changes the do_fetch signature and sstate re-fetches instead of reusing
+      # a stale cached binary. Authenticated to avoid the 60/hr anon API limit.
+      #
+      # Arch-aware: the release publishes one tarball per arch and the recipe
+      # fetches wendy-agent-linux-<arch>-<version>.tar.gz for the arch matching
+      # the MACHINE (arm64 for Tegra/RPi, amd64 for generic-x86-64 via
+      # WENDYOS_AGENT_RELEASE_ARCH:x86-wendyos). WENDYOS_AGENT_SHA256 must be the
+      # checksum for THAT tarball, so resolve the digest for this job's arch —
+      # passing the arm64 sha to an amd64 build fails do_fetch on checksum.
+      - name: Resolve latest wendyos-agent version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEVICE: ${{ matrix.device }}
+        run: |
+          set -euo pipefail
+          case "$DEVICE" in
+            generic-x86-64) ARCH=amd64 ;;
+            *)              ARCH=arm64 ;;
+          esac
+
+          release_json="$(curl -sSfL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/wendylabsinc/WendyOS/releases/latest")"
+
+          version="$(jq -r '.tag_name' <<<"$release_json")"
+          sha="$(jq -r --arg arch "$ARCH" '.assets[]
+            | select(.name | test("^wendy-agent-linux-\($arch)-.*\\.tar\\.gz$"))
+            | .digest' <<<"$release_json" | sed 's/^sha256://')"
+
+          if [[ -z "$version" || "$version" == "null" || -z "$sha" || "$sha" == "null" ]]; then
+            echo "Failed to resolve wendyos-agent version/sha for arch '$ARCH' (version='$version' sha='$sha')" >&2
+            exit 1
+          fi
+
+          echo "Resolved wendyos-agent $version for $ARCH (sha256=$sha)"
+          {
+            echo "WENDYOS_AGENT_VERSION=$version"
+            echo "WENDYOS_AGENT_SHA256=$sha"
+          } >> "$GITHUB_ENV"
+
+      # Build every storage variant of this device, one after another, in the
+      # single build tree bootstrapped above. Each variant only needs its own
+      # DEVICE/STORAGE/MACHINE, which all live in the board local.conf; repos,
+      # bblayers, and auto.conf (the TMPDIR pin, provenance, debug/dev flags, and
+      # resolved agent version) are storage-independent and stay put. So per
+      # variant we just re-point build/conf/local.conf at that variant's board
+      # and re-run the build: the first variant compiles the MACHINE-independent
+      # bulk and writes it to the shared NVMe sstate; every later variant
+      # restores that bulk from sstate and only builds its MACHINE-specific delta
+      # (kernel, bootloader, rootfs assembly, disk image). Switching MACHINE
+      # forces a bitbake re-parse but no recompile of cached tasks. The variants
+      # share one TMPDIR safely — they run sequentially and deploy under
+      # tmp/deploy/images/<machine>/.
+      - name: Build image (all storage variants)
+        working-directory: ${{ github.workspace }}/wendyos
+        env:
+          MAP: ${{ steps.vars.outputs.map }}
+        run: |
+          set -euo pipefail
+          # Mirror how bootstrap.sh composes build/conf/local.conf: prepend the
+          # WENDYOS_LAYER_TREE line (needed for the SSTATE_DIR partitioning in
+          # common.inc) it recorded in build/.wendyos-env, then the board template.
+          # shellcheck source=/dev/null
+          TREE=$(. "$GITHUB_WORKSPACE/build/.wendyos-env"; echo "$WENDYOS_LAYER_TREE")
+          for token in $MAP; do
+            IFS='|' read -r storage board machine <<< "$token"
+            echo "::group::build $storage ($machine)"
+            {
+              printf 'WENDYOS_LAYER_TREE = "%s"\n\n' "$TREE"
+              cat "conf/template/boards/$board/local.conf"
+            } > "$GITHUB_WORKSPACE/build/conf/local.conf"
+            # Tegra builds on the shared NVMe cache intermittently fail their
+            # first (colder) attempt — transient do_fetch and sstate/recipe-sysroot
+            # population glitches — and pass on retry (validated: both Orin and
+            # Thor needed one). The retry is cheap: sstate and downloads persist,
+            # so the second pass reuses everything the first produced.
+            make build MACHINE="$machine" || {
+              echo "::warning::make build failed on first attempt for $machine; retrying once"
+              make build MACHINE="$machine"
+            }
+            echo "::endgroup::"
+          done
+
+
+      # Remove this job's private repos snapshot from the persistent pool. The
+      # ephemeral workspace is discarded automatically, but the reflink copy
+      # lives on the cache pool, so it must be cleaned up explicitly (CoW means
+      # only the blocks that diverged from the seed are freed).
+      - name: Release private repos snapshot
+        if: always()
+        env:
+          PRIV_TAG: ${{ github.run_id }}-${{ github.run_attempt }}-warm-${{ matrix.device }}
+        run: rm -rf "/opt/wendy-cache/wendyos-builder/repos/runs/$PRIV_TAG"
+
+      # Remove this job's private TMPDIR from the shared /wendy scratch. Unlike
+      # sstate/downloads (persistent caches), TMPDIR is disposable per-build
+      # working state, and the scratch is shared across job containers on the
+      # box, so leaving it behind would accumulate and eventually fill the pool.
+      - name: Release platform scratch
+        if: always()
+        env:
+          PRIV_TAG: ${{ github.run_id }}-${{ github.run_attempt }}-warm-${{ matrix.device }}
+        run: rm -rf "/wendy/build-tmp/$PRIV_TAG"
+
+  # ---------------------------------------------------------------------------
   # build: per-device Yocto image build.
   # Runs on the self-hosted ephemeral-runner platform (wendylabsinc/ci). Each
   # job is a fresh podman container on a box with a persistent NVMe cache
@@ -195,8 +655,13 @@ jobs:
   # ---------------------------------------------------------------------------
   build:
     name: Build ${{ matrix.device }} (${{ matrix.storages }})
-    needs: detect-changes
-    if: needs.detect-changes.outputs.devices != ''
+    needs: [detect-changes, warm-caches]
+    # Waits for warm-caches when it ran (so the matrix restores its sstate
+    # instead of racing the fat build) and proceeds when it was skipped --
+    # !cancelled() keeps the skipped-warm path alive, since a plain `needs`
+    # on a skipped job would skip this job too. A FAILED warm build stops the
+    # run here: the matrix would fail the same way, just eight times slower.
+    if: ${{ !cancelled() && needs.detect-changes.outputs.devices != '' && (needs.warm-caches.result == 'success' || needs.warm-caches.result == 'skipped') }}
     permissions:
       contents: read
       # GitHub mints the OIDC token (not the runner), so GCP Workload Identity


### PR DESCRIPTION
## Problem

A PR touching kernel config, machine/distro/template conf, bbclasses, systemd or the layer pins invalidates sstate that the 16Gi matrix jobs cannot affordably rebuild. Measured on WDY-1925 (2026-07-27): the compile working set does not fit the cgroup, so the build runs in permanent direct reclaim — PSI memory `full=27%`, 1.8e9 workingset refaults (~7 TB re-read from NVMe), compilers at ~25% efficiency. Even 240 minutes was not enough to get the kernel to `populate_sysroot`, so nothing was ever banked and every retry started from zero (six timeouts in a row on that branch).

## Change

New `warm-caches` job between `detect-changes` and the matrix:

- **Detection**: `dorny/paths-filter@v4` (latest) flags heavy inputs per device family — `global` (classes/, conf/distro/, conf/template/ incl. per-board repos.overrides, recipes-core/systemd/, scripts/upstream-repos.env layer pins), `rpi`, `jetson`, `x86` (kernel fragments, machine confs, family extension layers). The existing `set` step maps hit families to matrix devices, preserving the longest-pole-first order.
- **Warming**: one warm job per affected device runs the exact same build steps on the `wendyos-builder-warm` runner profile (64Gi, serial — wendylabsinc/ci#34). Its sstate lands in the shared NVMe cache; artifacts are discarded — banking sstate is the point.
- **Matrix**: unchanged 16Gi jobs now `needs: warm-caches` and simply restore. Nothing heavy changed → filter comes back empty → warm job skipped, zero behavior change. Tag/dispatch runs skip the filter entirely (no diff to filter; those refs were warmed by the branch runs that produced them).

The warm steps are a **verbatim copy** of the build job's pre-publish steps (only deltas: `actions/checkout@v7` and a `warm-` PRIV_TAG prefix) so both jobs stamp identical auto.conf flags and agent pins — required for the task hashes to match. Kept adjacent with a sync note.

Dry-ran the matrix script: rpi-only change → warms exactly the 3 Pis; global change → all 7 devices; no heavy change / dispatch → skipped.

## Deploy order

⚠️ Merge **wendylabsinc/ci#34 first** and let it deploy — the `wendyos-builder-warm` label must exist in the launcher table before this workflow requests it, otherwise warm jobs sit on "Waiting for a runner" forever.