### PR TITLE
fix(updater): compare full agent versions and honour a version pin

### DIFF
--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/t234_flashpack_manifest*'
       - 'scripts/make-jetson-disk-img.py'
       - 'scripts/make_jetson_disk_img_test.py'
+      - 'recipes-core/wendyos-agent/files/*.sh'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
   push:
@@ -20,6 +21,7 @@ on:
       - 'scripts/t234_flashpack_manifest*'
       - 'scripts/make-jetson-disk-img.py'
       - 'scripts/make_jetson_disk_img_test.py'
+      - 'recipes-core/wendyos-agent/files/*.sh'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
 
@@ -34,10 +36,26 @@ jobs:
         run: jq empty .github/device-artifacts.json
 
       - name: shellcheck
-        run: shellcheck scripts/resolve-artifacts.sh scripts/resolve-artifacts.test.sh scripts/make-t234-flashpack.sh
+        run: |
+          shellcheck scripts/resolve-artifacts.sh scripts/resolve-artifacts.test.sh scripts/make-t234-flashpack.sh
+          shellcheck recipes-core/wendyos-agent/files/wendyos-agent-updater.sh \
+                     recipes-core/wendyos-agent/files/wendyos-agent-updater.test.sh \
+                     recipes-core/wendyos-agent/files/download-wendyos-agent.sh
 
       - name: Run resolver tests
         run: bash scripts/resolve-artifacts.test.sh
+
+      # The agent updater ships in the image and decides which agent every
+      # device runs; a comparison bug there silently moves the whole fleet
+      # (WDY-2038). Run under both shells a device might have: coreutils is in
+      # packagegroup-wendyos-base, busybox is the Yocto fallback.
+      - name: Run agent updater tests (GNU coreutils)
+        run: bash recipes-core/wendyos-agent/files/wendyos-agent-updater.test.sh
+
+      - name: Run agent updater tests (busybox)
+        run: |
+          docker run --rm -v "$PWD:/w" -w /w alpine:3 sh -c \
+            'apk add -q bash && bash recipes-core/wendyos-agent/files/wendyos-agent-updater.test.sh'
 
       - name: Run T234 flashpack manifest tests
         run: python3 -m unittest scripts/t234_flashpack_manifest_test.py

--- a/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
+++ b/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
@@ -6,10 +6,14 @@
 
 set -e
 
-# Load configuration
-if [ -f /etc/default/wendy-agent ]; then
-    source /etc/default/wendy-agent
-fi
+# Load configuration. The /data copy survives an OS OTA where the /etc one does
+# not, so it is read second and wins. See wendyos-agent-updater.sh.
+for conf in /etc/default/wendy-agent /data/etc/default/wendy-agent; do
+    if [ -f "${conf}" ]; then
+        # shellcheck source=/dev/null
+        source "${conf}"
+    fi
+done
 
 # Default values if not configured
 GITHUB_REPO="${WENDYOS_AGENT_GITHUB_REPO:-wendylabsinc/wendy-agent}"
@@ -60,17 +64,17 @@ check_requirements() {
     local missing_tools=()
 
     for tool in curl jq tar gzip; do
-        if ! command -v $tool >/dev/null 2>&1; then
-            missing_tools+=($tool)
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            missing_tools+=("$tool")
         fi
     done
 
     if [ ${#missing_tools[@]} -gt 0 ]; then
         log "Installing missing tools: ${missing_tools[*]}"
         if command -v apt-get >/dev/null 2>&1; then
-            apt-get update && apt-get install -y ${missing_tools[*]}
+            apt-get update && apt-get install -y "${missing_tools[@]}"
         elif command -v opkg >/dev/null 2>&1; then
-            opkg update && opkg install ${missing_tools[*]}
+            opkg update && opkg install "${missing_tools[@]}"
         else
             error "Missing required tools: ${missing_tools[*]}"
         fi
@@ -80,23 +84,37 @@ check_requirements() {
 # Get release information from GitHub
 # Fetches latest stable release (excludes pre-releases)
 get_release_info() {
-    local api_url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
+    local api_url
 
-    log "Fetching latest stable release from GitHub (excludes pre-releases)..." >&2
+    if [ "${VERSION}" = "latest" ]; then
+        api_url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
+        log "Fetching latest stable release from GitHub (excludes pre-releases)..." >&2
+    else
+        # Pinned: fetch the release by tag. Unlike /releases/latest this also
+        # resolves pre-releases, so a nightly can be pinned.
+        api_url="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${VERSION}"
+        log "Fetching pinned release ${VERSION} from GitHub..." >&2
+    fi
 
     # Use wget if available, otherwise curl
     local release_json
     if command -v wget >/dev/null 2>&1; then
-        release_json=$(wget -q -O - "${api_url}" 2>/dev/null) || error "Failed to fetch latest release"
+        release_json=$(wget -q -O - "${api_url}" 2>/dev/null) || error "Failed to fetch release"
     else
-        release_json=$(curl -sL "${api_url}" 2>/dev/null) || error "Failed to fetch latest release"
+        release_json=$(curl -sL "${api_url}" 2>/dev/null) || error "Failed to fetch release"
     fi
 
-    # Validate we got a proper release
+    # Validate we got a proper release. A missing tag 404s into a JSON error
+    # body that both fetchers return successfully, so this check is what turns
+    # a bad pin into a clear failure.
     if command -v jq >/dev/null 2>&1; then
-        local tag_name=$(echo "${release_json}" | jq -r '.tag_name // empty')
+        local tag_name
+        tag_name=$(echo "${release_json}" | jq -r '.tag_name // empty')
         if [ -z "${tag_name}" ]; then
-            error "No stable releases found. Please create a release with semver tag (e.g., v1.0.0)"
+            if [ "${VERSION}" = "latest" ]; then
+                error "No stable release found in ${GITHUB_REPO}"
+            fi
+            error "No release found for pinned version ${VERSION} in ${GITHUB_REPO}"
         fi
     fi
 
@@ -199,7 +217,8 @@ main() {
 
     # Get version info if possible
     if "${INSTALL_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
-        local installed_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1 | head -1)
+        local installed_version
+        installed_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1 | head -1)
         log "Installed version: ${installed_version}"
     fi
 

--- a/recipes-core/wendyos-agent/files/wendyos-agent-updater.sh
+++ b/recipes-core/wendyos-agent/files/wendyos-agent-updater.sh
@@ -6,31 +6,30 @@
 
 set -e
 
-# Load configuration
-if [ -f /etc/default/wendy-agent ]; then
-    source /etc/default/wendy-agent
-fi
+# Load configuration. /etc is on the A/B rootfs and is replaced wholesale by an
+# OS OTA, so a pin written there is lost on the next `wendy os update`. /data is
+# the only writable storage that survives a slot switch, so a copy there is read
+# second and wins. Devices with no OTA stack (QEMU) have no /data and just skip
+# it. Keep this list in sync with download-wendyos-agent.sh.
+for conf in /etc/default/wendy-agent /data/etc/default/wendy-agent; do
+    if [ -f "${conf}" ]; then
+        # shellcheck source=/dev/null
+        source "${conf}"
+    fi
+done
 
-# Default values if not configured
+# Default values if not configured.
+#
+# WENDYOS_AGENT_VERSION pins the agent to one release tag (e.g.
+# "2026.07.27-081952"); "latest" tracks the newest stable release. A pin is an
+# operator override and is honoured exactly, including installing an OLDER
+# build than the one running -- that is the point of it. See check_update.
+#
+# Not to be confused with the WENDYOS_AGENT_VERSION in wendyos-agent_1.0.bb,
+# which is a build-time pin for the binary baked into the image. This one is
+# runtime only, read from /etc/default/wendy-agent.
 GITHUB_REPO="${WENDYOS_AGENT_GITHUB_REPO:-wendylabsinc/wendy-agent}"
 VERSION="${WENDYOS_AGENT_VERSION:-latest}"
-
-normalize_arch() {
-    case "$1" in
-        x86_64|amd64)
-            echo "amd64"
-            ;;
-        aarch64|arm64)
-            echo "arm64"
-            ;;
-        *)
-            echo "Unsupported architecture: $1" >&2
-            exit 1
-            ;;
-    esac
-}
-
-ARCH="$(normalize_arch "${WENDYOS_AGENT_ARCH:-$(uname -m)}")"
 
 # Paths
 INSTALL_DIR="/usr/local/bin"
@@ -60,40 +59,24 @@ check_network() {
     fi
 }
 
-# Get current installed version
+# Get the version string reported by the installed binary. `wendy-agent
+# --version` prints exactly the build's version.Version on its own line (e.g.
+# "dev", "2026.06.30-133859-dev", "2026.07.27-081952"). It is used verbatim:
+# agent versions are YYYY.MM.DD-HHMMSS, so extracting a semver-shaped prefix
+# drops the time and makes every build cut on a given day compare equal --
+# which downgrades a same-day nightly onto stable and reinstalls stable over
+# itself forever (WDY-2038). Falls back to the stored version file only if the
+# binary will not run.
 get_current_version() {
     local current_version=""
 
-    # Try to get version from the binary itself
-    if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ]; then
-        if "${INSTALL_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
-            current_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
-        fi
-    fi
-
-    # Fall back to stored version file
-    if [ -z "${current_version}" ] && [ -f "${VERSION_FILE}" ]; then
-        current_version=$(cat "${VERSION_FILE}")
+    if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ] && "${INSTALL_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
+        current_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1 | head -1 | tr -d '[:space:]')
+    elif [ -f "${VERSION_FILE}" ]; then
+        current_version=$(head -1 "${VERSION_FILE}" | tr -d '[:space:]')
     fi
 
     echo "${current_version}"
-}
-
-# Get the raw, unmodified version string reported by the installed binary.
-# `wendy-agent --version` prints exactly the build's version.Version on its own
-# line (e.g. "dev", "2026.06.30-133859-dev", or "2026.06.17-194156"). Unlike
-# get_current_version() this preserves the "-dev" suffix so is_dev_build() can
-# see it. Falls back to the stored version file only if the binary won't run.
-get_raw_current_version() {
-    local raw_version=""
-
-    if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ] && "${INSTALL_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
-        raw_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1 | head -1 | tr -d '[:space:]')
-    elif [ -f "${VERSION_FILE}" ]; then
-        raw_version=$(head -1 "${VERSION_FILE}" | tr -d '[:space:]')
-    fi
-
-    echo "${raw_version}"
 }
 
 # Report whether a version string is a development build. Mirrors version.IsDev
@@ -135,45 +118,92 @@ get_latest_version() {
     echo "${latest_version}"
 }
 
-# Compare versions
-version_gt() {
-    # Returns 0 if version1 > version2
-    local version1="$1"
-    local version2="$2"
+# Resolve the version this device should be running: the pin when one is set,
+# otherwise the newest stable release.
+get_target_version() {
+    if [ "${VERSION}" != "latest" ]; then
+        echo "${VERSION#v}"
+        return 0
+    fi
 
-    if [ -z "${version1}" ] || [ -z "${version2}" ]; then
+    get_latest_version
+}
+
+# Report whether version1 is strictly newer than version2. Mirrors
+# version.CompareVersions in the Go CLI: split on "." and "-", compare fields
+# numerically when both sides are numeric and lexicographically otherwise, so
+# "2026.07.27-081952" > "2026.07.27-003050". Arithmetic rather than `sort -V`
+# so shell and Go agree, and so there is no capability probe whose failure
+# branch treated "any difference" as "newer".
+version_gt() {
+    local version1="${1#v}"
+    local version2="${2#v}"
+
+    if [ -z "${version1}" ] || [ -z "${version2}" ] || [ "${version1}" = "${version2}" ]; then
         return 1
     fi
 
-    # Use sort -V if available
-    if command -v sort >/dev/null 2>&1 && sort --help 2>&1 | grep -q -- '-V'; then
-        [ "$(printf '%s\n' "${version1}" "${version2}" | sort -V | tail -1)" = "${version1}" ] && [ "${version1}" != "${version2}" ]
-    else
-        # Simple comparison
-        [ "${version1}" != "${version2}" ]
+    local a b n i ap bp
+    IFS='.-' read -r -a a <<< "${version1}"
+    IFS='.-' read -r -a b <<< "${version2}"
+
+    n=${#a[@]}
+    if [ "${#b[@]}" -gt "${n}" ]; then
+        n=${#b[@]}
     fi
+
+    for ((i = 0; i < n; i++)); do
+        ap="${a[i]:-0}"
+        bp="${b[i]:-0}"
+        if [ "${ap}" = "${bp}" ]; then
+            continue
+        fi
+        # 10# forces base 10: agent timestamps like 081952 are not valid octal.
+        if [[ "${ap}" =~ ^[0-9]+$ && "${bp}" =~ ^[0-9]+$ ]]; then
+            if [ "$((10#${ap}))" -gt "$((10#${bp}))" ]; then return 0; else return 1; fi
+        fi
+        if [[ "${ap}" > "${bp}" ]]; then return 0; else return 1; fi
+    done
+
+    return 1
 }
 
 # Check if update is needed
 check_update() {
-    local current_version=$(get_current_version)
-    local latest_version=$(get_latest_version)
+    local current_version target_version
+    current_version=$(get_current_version)
+    target_version=$(get_target_version)
 
-    if [ -z "${latest_version}" ]; then
-        log "Could not determine latest version"
+    if [ -z "${target_version}" ]; then
+        log "Could not determine target version"
         return 1
     fi
 
     log "Current version: ${current_version:-unknown}"
-    log "Latest stable version: ${latest_version}"
+
+    # Pinned: converge on exactly this tag. An explicit pin outranks the
+    # never-go-backwards rule below, so this WILL install an older build --
+    # that is what a pin is for (e.g. holding a fleet on a known-good agent
+    # while a regression is investigated).
+    if [ "${VERSION}" != "latest" ]; then
+        log "Pinned version: ${target_version}"
+        if [ "${current_version#v}" = "${target_version}" ]; then
+            log "Already at the pinned version"
+            return 1
+        fi
+        log "Pin mismatch: ${current_version:-unknown} -> ${target_version}"
+        return 0
+    fi
+
+    log "Latest stable version: ${target_version}"
 
     if [ -z "${current_version}" ]; then
         log "No current version found, update needed"
         return 0
     fi
 
-    if version_gt "${latest_version}" "${current_version}"; then
-        log "Update available: ${current_version} -> ${latest_version}"
+    if version_gt "${target_version}" "${current_version}"; then
+        log "Update available: ${current_version} -> ${target_version}"
         return 0
     else
         log "Already up to date"
@@ -197,7 +227,7 @@ perform_update() {
 
         # Store the new version
         mkdir -p "$(dirname "${VERSION_FILE}")"
-        get_latest_version > "${VERSION_FILE}"
+        get_target_version > "${VERSION_FILE}"
 
         # Restart the service if it was running
         if systemctl is-enabled --quiet wendyos-agent.service; then
@@ -244,7 +274,7 @@ main() {
     # place rather than replacing it with the latest stable release. This
     # mirrors the CLI/Agent fix that stops prompting/pushing such overwrites.
     local raw_version
-    raw_version=$(get_raw_current_version)
+    raw_version=$(get_current_version)
     if is_dev_build "${raw_version}"; then
         log "Installed agent is a dev build (${raw_version:-unknown}), skipping auto-update"
         exit 0
@@ -260,5 +290,8 @@ main() {
     fi
 }
 
-# Run main function
-main "$@"
+# Run main function, unless sourced by the unit tests, which want the
+# functions without the update check firing.
+if [ -z "${WENDYOS_UPDATER_LIB_ONLY:-}" ]; then
+    main "$@"
+fi

--- a/recipes-core/wendyos-agent/files/wendyos-agent-updater.test.sh
+++ b/recipes-core/wendyos-agent/files/wendyos-agent-updater.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Tests for wendyos-agent-updater.sh — plain bash, no framework, same shape as
+# scripts/resolve-artifacts.test.sh.
+#
+# Covers the two halves of WDY-2038 and the version pin:
+#   (a) the installed version is read verbatim, not truncated to a semver
+#       prefix. Agent versions are YYYY.MM.DD-HHMMSS; grepping out
+#       [0-9]+\.[0-9]+\.[0-9]+ yielded "2026.07.27", which loses to every
+#       same-day tag -- so the updater downgraded a newer nightly onto stable
+#       and reinstalled stable over itself on every single tick.
+#   (b) version_gt agrees with version.CompareVersions in the Go CLI, so the
+#       shell updater and `wendy device list` cannot disagree about which of
+#       two agents is newer.
+#   (c) a WENDYOS_AGENT_VERSION pin converges on exactly that tag, including
+#       downgrading onto it, and releases the device back to stable tracking
+#       when removed.
+#
+# Sourced with WENDYOS_UPDATER_LIB_ONLY=1 so main() does not run.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+pass=0
+fail=0
+ok()  { pass=$((pass + 1)); echo "ok   - $1"; }
+bad() { fail=$((fail + 1)); echo "FAIL - $1"; }
+
+WENDYOS_UPDATER_LIB_ONLY=1
+export WENDYOS_UPDATER_LIB_ONLY
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/wendyos-agent-updater.sh"
+
+# --- version_gt -------------------------------------------------------------
+# assert_gt EXPECTED("gt"|"no") A B
+assert_gt() {
+    local want="$1" a="$2" b="$3" got
+    if version_gt "$a" "$b"; then got=gt; else got=no; fi
+    if [[ "$got" == "$want" ]]; then
+        ok "version_gt '$a' '$b' -> $want"
+    else
+        bad "version_gt '$a' '$b' -> $got (want $want)"
+    fi
+}
+
+# The exact WDY-2038 pair: a same-day nightly must beat same-day stable.
+assert_gt gt 2026.07.27-081952 2026.07.27-003050
+assert_gt no 2026.07.27-003050 2026.07.27-081952
+# Identical builds are never "newer" -- this is the reinstall-every-tick guard.
+assert_gt no 2026.07.27-003050 2026.07.27-003050
+# Day boundary, and a time field that is not valid octal (081952, 003050).
+assert_gt gt 2026.07.28-000000 2026.07.27-235959
+assert_gt no 2026.07.27-235959 2026.07.28-000000
+assert_gt gt 2026.07.27-100000 2026.07.27-081952
+assert_gt gt 2027.01.01-000000 2026.12.31-235959
+# Ordinary ordering, and the "v" prefix a release tag may carry.
+assert_gt gt 2026.07.27-003050 2026.07.20-100000
+assert_gt gt v2026.07.27-003050 2026.07.20-100000
+assert_gt no 2026.07.20-100000 v2026.07.27-003050
+# A truncated value must LOSE to the full tag it was truncated from. This is
+# the comparison that produced the downgrade once get_current_version had
+# thrown the time away; it stays here to document the mechanism.
+assert_gt gt 2026.07.27-003050 2026.07.27
+# Empty operands are never newer (no version file, unreadable binary).
+assert_gt no "" 2026.07.27-003050
+assert_gt no 2026.07.27-003050 ""
+
+# --- get_current_version ----------------------------------------------------
+# Point the reader at a stub binary that prints VER, and assert it comes back
+# verbatim rather than semver-truncated.
+assert_current() {
+    local want="$1" printed="$2" tmp
+    tmp=$(mktemp -d)
+    # shellcheck disable=SC2034  # read by the sourced get_current_version
+    INSTALL_DIR="$tmp"
+    VERSION_FILE="$tmp/current-version"
+    # shellcheck disable=SC2016  # $1 is for the generated stub, not this shell
+    printf '#!/bin/sh\n[ "$1" = "--version" ] && echo "%s"\n' "$printed" > "$tmp/$BINARY_NAME"
+    chmod +x "$tmp/$BINARY_NAME"
+    local got
+    got=$(get_current_version)
+    if [[ "$got" == "$want" ]]; then
+        ok "get_current_version('$printed') -> '$want'"
+    else
+        bad "get_current_version('$printed') -> '$got' (want '$want')"
+    fi
+    rm -rf "$tmp"
+}
+
+assert_current 2026.07.27-081952 2026.07.27-081952
+assert_current 2026.07.27-003050 2026.07.27-003050
+assert_current 2026.06.30-133859-dev 2026.06.30-133859-dev
+assert_current dev dev
+
+# Falls back to the stored version file when the binary will not run.
+tmp=$(mktemp -d)
+# shellcheck disable=SC2034  # read by the sourced get_current_version
+INSTALL_DIR="$tmp/absent"
+VERSION_FILE="$tmp/current-version"
+echo "2026.07.03-194041" > "$VERSION_FILE"
+got=$(get_current_version)
+if [[ "$got" == "2026.07.03-194041" ]]; then
+    ok "get_current_version falls back to the version file"
+else
+    bad "version-file fallback -> '$got'"
+fi
+rm -rf "$tmp"
+
+# --- is_dev_build -----------------------------------------------------------
+# A dev build outranks a pin: whoever hand-installed it is the most explicit
+# actor in the system (WDY-1770).
+for v in dev 2026.06.30-133859-dev; do
+    if is_dev_build "$v"; then ok "is_dev_build '$v'"; else bad "is_dev_build '$v' should be true"; fi
+done
+for v in 2026.07.27-003050 "" developer; do
+    if is_dev_build "$v"; then bad "is_dev_build '$v' should be false"; else ok "is_dev_build '$v' false"; fi
+done
+
+# --- get_target_version -----------------------------------------------------
+# Unpinned resolves via the network, so only the pinned branch is unit-tested;
+# the unpinned path is covered by the integration run in the PR description.
+# shellcheck disable=SC2034  # read by the sourced get_target_version
+VERSION="2026.07.27-081952"
+got=$(get_target_version)
+if [[ "$got" == "2026.07.27-081952" ]]; then
+    ok "get_target_version honours the pin"
+else
+    bad "get_target_version pinned -> '$got'"
+fi
+
+# shellcheck disable=SC2034  # read by the sourced get_target_version
+VERSION="v2026.07.27-081952"
+got=$(get_target_version)
+if [[ "$got" == "2026.07.27-081952" ]]; then
+    ok "get_target_version strips a leading v from the pin"
+else
+    bad "get_target_version v-prefixed -> '$got'"
+fi
+
+echo
+echo "$pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Closes WDY-2038

## Problem

The auto-updater read the installed agent version through a semver grep:

```sh
current_version=$(wendy-agent --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
```

Agent releases are tagged `YYYY.MM.DD-HHMMSS`, so `2026.07.27-081952` was reduced to `2026.07.27`, a value that compares lower than any same-day tag. Running the unmodified script against the live GitHub API produces:

| Installed | Read as | Decision |
|---|---|---|
| `2026.07.27-081952` (same-day nightly) | `2026.07.27` | Downgrade to `2026.07.27-003050` |
| `2026.07.27-003050` (current stable) | `2026.07.27` | "Update available: 2026.07.27 -> 2026.07.27-003050"; stop agent, re-download, reinstall |

The second case was not part of the original report. Any device running a date-versioned agent evaluated an update as available on every run of the updater, stopping `wendyos-agent.service` and reinstalling the build already present. The "Already up to date" branch was unreachable.

This is not a regression. The script was added on 2025-11-16; releases had used the date-based format since 2025-06-04. The original semver assumption is also visible in `download-wendyos-agent.sh`, which reports "Please create a release with semver tag (e.g., v1.0.0)".

The issue noted that `sort -V` ordering had only been checked with BSD sort. The behaviour reproduces identically under GNU coreutils 9.1 and busybox. `coreutils` is listed in `packagegroup-wendyos-base`, so GNU sort is what devices use.

## Changes

**1. Read the installed version verbatim.** `get_raw_current_version` already did this for the dev-build check. The two functions are consolidated into one, so the version used for the dev-build check and the version used for comparison cannot diverge.

**2. Replace `version_gt`.** The new implementation compares fields arithmetically, mirroring `version.CompareVersions` in the Go CLI, so the updater and `wendy device list`'s staleness check share one set of semantics. This also removes the `sort --help | grep -- '-V'` capability probe, whose fallback branch treated any difference as newer. Arithmetic uses a `10#` prefix, as values such as `081952` are not valid octal.

**3. `WENDYOS_AGENT_VERSION` is now implemented.** The variable has been assigned and logged since the first commit but never used for selection; both scripts always requested `/releases/latest`. It now resolves `/releases/tags/<tag>`, which also returns prereleases, allowing a device to be held on a specific build.

A pin is treated as an operator override and will install an older build than the one running. Unset or `latest` retains the existing behaviour of tracking the newest stable release. Precedence is dev build, then pin, then latest stable; the WDY-1770 dev-build exemption is unchanged.

**4. Configuration is also read from `/data`.** `/etc/default/wendy-agent` is on the A/B rootfs. Only `/etc/wendyos` and `/etc/NetworkManager/system-connections` are bind-mounted from `/data`, so a pin written to `/etc` does not survive an OS update. Both scripts now read `/etc/default/wendy-agent` followed by `/data/etc/default/wendy-agent`, with the latter taking precedence. Devices without a `/data` partition (QEMU) skip it.

## Usage

```sh
# Hold this device on a specific agent build, across OS updates.
echo 'WENDYOS_AGENT_VERSION=2026.07.27-081952' > /data/etc/default/wendy-agent

# Return the device to stable tracking.
rm /data/etc/default/wendy-agent
```

## Testing

`recipes-core/wendyos-agent/files/wendyos-agent-updater.test.sh` is table-driven plain bash with no framework, following the existing `scripts/resolve-artifacts.test.sh`. `scripts-ci.yml` gains shellcheck coverage of all three scripts and runs the tests under both GNU coreutils and busybox. 25 of 25 pass under both. shellcheck reports no findings; four pre-existing findings in `download-wendyos-agent.sh` were resolved so the file could be included in the gate.

Integration testing used the unmodified scripts against real releases, with the installed arm64 binary executed to confirm the resulting version:

| Scenario | Result |
|---|---|
| Unpinned | Converges on stable `2026.07.27-003050` |
| Pin to earlier release `2026.07.03-194041` | Installs the pinned release |
| Repeat run, same pin | "Already at the pinned version", no download |
| Pin to nightly `2026.07.27-081952` | Installs the prerelease |
| Pin removed | Remains on `081952`; stable is not newer |
| Invalid pin `9999.99.99-000000` | "No release found for pinned version ...", binary unchanged |
| Pin present only in `/data` | Applied |
| `/data` pin conflicting with `/etc` pin | `/data` takes precedence |
| Dev build with a pin set | "skipping auto-update" |

`version_gt` was additionally compared against the Go `CompareVersions` implementation across a set of version pairs: 18 of 19 agree. The exception is `1.0.0` versus `1.0`, where Go compares `"0"` against `""` lexicographically and reports greater, while this implementation treats a missing trailing field as `0` and reports equal. Agent versions always have four fields, so the case does not arise in practice.

## Notes for review

- This change ships in the image rather than in an agent update. The script is installed by the Yocto recipe, so it reaches devices via `wendy os update` or a reflash. Remediating the existing fleet still requires cutting a stable agent release carrying the WDY-2009 and WDY-2010 fixes.
- An invalid pin is retried on every run, and `perform_update` stops the agent before the missing tag is detected, so a mistyped pin causes a stop/restart cycle each time. The device recovers via the backup restore and service start. This matches the existing behaviour for a network failure mid-download. The release could be resolved before the service is stopped if that is preferred.
- The following were identified while tracing the trigger and are not addressed here; each may warrant a separate issue. `wendyos-agent-updater.service` is `WantedBy=multi-user.target` in addition to being timer-driven, so it runs twice per boot and the randomised delay does not apply to the first run. `OnCalendar=daily` resolves to 00:00 UTC, while the unit comment and `docs/wendyos/services/README.md` both state 03:00. The download has no timeout and `Type=oneshot` defaults `TimeoutStartSec` to infinity, so a stalled fetch can leave the agent stopped indefinitely.
- `configuration-files.md` in the WendyOS repository lists `WENDYOS_AGENT_VERSION` as supported. That becomes accurate with this change, but the entry should be updated to describe the `/data` location and the exact-tag semantics. Proposed as a separate change.