### PR TITLE
wendyos-agent: rotate binary backups + fix nightly no-op reinstall (WDY-2185)

### DIFF
--- a/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
+++ b/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
@@ -208,6 +208,11 @@ install_binary() {
 
     log "Created required directories"
 
+    # Free space before the ~22MB copy below, which on a full root fs fails
+    # under `set -e` before any prune runs. Outside the -f guard so a device
+    # with no installed binary still sheds a backlog.
+    prune_backups
+
     # Backup existing binary if it exists
     if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ]; then
         log "Backing up existing binary"

--- a/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
+++ b/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
@@ -156,6 +156,22 @@ download_binary() {
     log "Binary downloaded and prepared successfully"
 }
 
+# Prune old timestamped backups, keeping the newest N. Without this the
+# nightly updater leaks one ~22MB copy per run until the root filesystem
+# fills and agent/OS updates start failing with ENOSPC (WDY-2185). The
+# restore path only ever uses ${BINARY_NAME}.latest; timestamped copies are
+# forensic convenience, so a couple is plenty.
+KEEP_BACKUPS=2
+
+prune_backups() {
+    ls -t "${BACKUP_DIR}/${BINARY_NAME}".backup.* 2>/dev/null \
+        | tail -n "+$((KEEP_BACKUPS + 1))" \
+        | while IFS= read -r old; do
+            log "Pruning old backup: ${old}"
+            rm -f -- "${old}"
+        done
+}
+
 # Install the binary
 install_binary() {
     # Create directories if they don't exist
@@ -169,6 +185,7 @@ install_binary() {
     if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ]; then
         log "Backing up existing binary"
         cp "${INSTALL_DIR}/${BINARY_NAME}" "${BACKUP_DIR}/${BINARY_NAME}.backup.$(date +%Y%m%d_%H%M%S)"
+        prune_backups
     fi
 
     # Install new binary

--- a/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
+++ b/recipes-core/wendyos-agent/files/download-wendyos-agent.sh
@@ -182,12 +182,21 @@ download_binary() {
 KEEP_BACKUPS=2
 
 prune_backups() {
-    ls -t "${BACKUP_DIR}/${BINARY_NAME}".backup.* 2>/dev/null \
-        | tail -n "+$((KEEP_BACKUPS + 1))" \
-        | while IFS= read -r old; do
-            log "Pruning old backup: ${old}"
-            rm -f -- "${old}"
-        done
+    # Suffix is `date +%Y%m%d_%H%M%S`, fixed width, so glob order is
+    # chronological. LC_ALL=C pins collation to bytes; an unmatched glob stays
+    # literal and the -f test drops it.
+    local LC_ALL=C
+    local backups=() f i cut
+
+    for f in "${BACKUP_DIR}/${BINARY_NAME}".backup.*; do
+        [ -f "${f}" ] && backups+=("${f}")
+    done
+
+    cut=$(( ${#backups[@]} - KEEP_BACKUPS ))
+    for (( i = 0; i < cut; i++ )); do
+        log "Pruning old backup: ${backups[i]}"
+        rm -f -- "${backups[i]}"
+    done
 }
 
 # Install the binary

--- a/recipes-core/wendyos-agent/files/wendyos-agent-updater.sh
+++ b/recipes-core/wendyos-agent/files/wendyos-agent-updater.sh
@@ -64,10 +64,15 @@ check_network() {
 get_current_version() {
     local current_version=""
 
-    # Try to get version from the binary itself
+    # Try to get version from the binary itself.
+    # The version must be captured IN FULL, including the calver time suffix
+    # ("2026.07.27-003050", not just "2026.07.27"): release tags carry the
+    # suffix, so truncating here made current != latest on every nightly run —
+    # the updater re-downloaded and re-installed the SAME release each night,
+    # leaking a 22MB backup per run until the root fs filled (WDY-2185).
     if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ]; then
         if "${INSTALL_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
-            current_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+            current_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?' || echo "")
         fi
     fi
 
@@ -225,9 +230,27 @@ perform_update() {
     fi
 }
 
+# Prune old timestamped backups, keeping the newest N. Mirrors the rotation in
+# download-wendyos-agent.sh but runs on EVERY nightly check (even "already up
+# to date"), so devices that accumulated a backlog before rotation existed
+# (WDY-2185: 68 copies / 1.3GB on one pilot box) self-heal on the first run
+# after an OS image update ships this script — no manual fleet cleanup.
+KEEP_BACKUPS=2
+
+prune_backups() {
+    ls -t "${BACKUP_DIR}/${BINARY_NAME}".backup.* 2>/dev/null \
+        | tail -n "+$((KEEP_BACKUPS + 1))" \
+        | while IFS= read -r old; do
+            log "Pruning old backup: ${old}"
+            rm -f -- "${old}"
+        done
+}
+
 # Main execution
 main() {
     log "Starting wendy-agent update check"
+
+    prune_backups
 
     # Check network connectivity first
     check_network

--- a/recipes-core/wendyos-agent/files/wendyos-agent-updater.sh
+++ b/recipes-core/wendyos-agent/files/wendyos-agent-updater.sh
@@ -263,12 +263,21 @@ perform_update() {
 KEEP_BACKUPS=2
 
 prune_backups() {
-    ls -t "${BACKUP_DIR}/${BINARY_NAME}".backup.* 2>/dev/null \
-        | tail -n "+$((KEEP_BACKUPS + 1))" \
-        | while IFS= read -r old; do
-            log "Pruning old backup: ${old}"
-            rm -f -- "${old}"
-        done
+    # Suffix is `date +%Y%m%d_%H%M%S`, fixed width, so glob order is
+    # chronological. LC_ALL=C pins collation to bytes; an unmatched glob stays
+    # literal and the -f test drops it.
+    local LC_ALL=C
+    local backups=() f i cut
+
+    for f in "${BACKUP_DIR}/${BINARY_NAME}".backup.*; do
+        [ -f "${f}" ] && backups+=("${f}")
+    done
+
+    cut=$(( ${#backups[@]} - KEEP_BACKUPS ))
+    for (( i = 0; i < cut; i++ )); do
+        log "Pruning old backup: ${backups[i]}"
+        rm -f -- "${backups[i]}"
+    done
 }
 
 # Main execution

--- a/recipes-core/wendyos-agent/files/wendyos-agent-updater.test.sh
+++ b/recipes-core/wendyos-agent/files/wendyos-agent-updater.test.sh
@@ -136,6 +136,136 @@ else
     bad "get_target_version v-prefixed -> '$got'"
 fi
 
+# --- prune_backups (WDY-2185) -----------------------------------------------
+
+# seed_backups DIR N — N backups named as install_binary names them, oldest
+# first. The suffix is a real time, so step HHMMSS rather than printing %06d
+# and emitting impossible times like 000060.
+seed_backups() {
+    local dir="$1" n="$2" i
+    for (( i = 0; i < n; i++ )); do
+        : > "${dir}/${BINARY_NAME}.backup.20260101_$(
+            printf '%02d%02d%02d' $(( i / 3600 )) $(( (i / 60) % 60 )) $(( i % 60 ))
+        )"
+    done
+}
+
+# survivors DIR — remaining backup suffixes, space separated, in glob order.
+survivors() {
+    local dir="$1" f out=""
+    for f in "${dir}/${BINARY_NAME}".backup.*; do
+        [ -f "$f" ] && out="${out}${out:+ }${f##*.backup.}"
+    done
+    echo "$out"
+}
+
+# assert_prune N WANT — seed N backups, prune, expect exactly WANT left.
+assert_prune() {
+    local n="$1" want="$2" tmp got
+    tmp=$(mktemp -d)
+    BACKUP_DIR="$tmp"
+    seed_backups "$tmp" "$n"
+    prune_backups >/dev/null 2>&1
+    got=$(survivors "$tmp")
+    if [[ "$got" == "$want" ]]; then
+        ok "prune_backups keeps the newest 2 of $n"
+    else
+        bad "prune_backups with $n -> '$got' (want '$want')"
+    fi
+    rm -rf "$tmp"
+}
+
+assert_prune 0 ""
+assert_prune 1 "20260101_000000"
+assert_prune 2 "20260101_000000 20260101_000001"
+assert_prune 3 "20260101_000001 20260101_000002"
+assert_prune 5 "20260101_000003 20260101_000004"
+# The backlog found on the device, and a minute boundary.
+assert_prune 68 "20260101_000106 20260101_000107"
+
+# perform_update() restores from .latest and nothing else.
+tmp=$(mktemp -d)
+BACKUP_DIR="$tmp"
+seed_backups "$tmp" 5
+: > "$tmp/${BINARY_NAME}.latest"
+prune_backups >/dev/null 2>&1
+if [[ -f "$tmp/${BINARY_NAME}.latest" && "$(survivors "$tmp")" == "20260101_000003 20260101_000004" ]]; then
+    ok "prune_backups leaves ${BINARY_NAME}.latest alone"
+else
+    bad "prune_backups removed .latest or the wrong backups"
+fi
+rm -rf "$tmp"
+
+# By name, not mtime — a restored or rsynced backup dir carries arbitrary ones.
+tmp=$(mktemp -d)
+BACKUP_DIR="$tmp"
+seed_backups "$tmp" 4
+touch -t 200001010000 "$tmp/${BINARY_NAME}.backup.20260101_000003"
+touch -t 203001010000 "$tmp/${BINARY_NAME}.backup.20260101_000000"
+prune_backups >/dev/null 2>&1
+if [[ "$(survivors "$tmp")" == "20260101_000002 20260101_000003" ]]; then
+    ok "prune_backups orders by name, not mtime"
+else
+    bad "prune_backups mtime independence -> '$(survivors "$tmp")'"
+fi
+rm -rf "$tmp"
+
+# Wall clock, not a counter: a backwards clock step names a newer backup older
+# and discards it. The count bound still holds, which is what WDY-2185 needs.
+tmp=$(mktemp -d)
+BACKUP_DIR="$tmp"
+: > "$tmp/${BINARY_NAME}.backup.20260101_120000"
+: > "$tmp/${BINARY_NAME}.backup.20260101_120001"
+: > "$tmp/${BINARY_NAME}.backup.20250101_000000"   # taken last, clock stepped back
+prune_backups >/dev/null 2>&1
+if [[ "$(survivors "$tmp")" == "20260101_120000 20260101_120001" ]]; then
+    ok "prune_backups holds the count bound across a backwards clock step"
+else
+    bad "prune_backups clock step -> '$(survivors "$tmp")'"
+fi
+rm -rf "$tmp"
+
+# Globs sort by collating sequence, not bytes (POSIX XCU 2.13.3); LC_ALL=C
+# pins it.
+tmp=$(mktemp -d)
+BACKUP_DIR="$tmp"
+seed_backups "$tmp" 5
+LC_ALL=en_US.UTF-8 prune_backups >/dev/null 2>&1
+if [[ "$(survivors "$tmp")" == "20260101_000003 20260101_000004" ]]; then
+    ok "prune_backups is unaffected by the ambient locale"
+else
+    bad "prune_backups under en_US.UTF-8 -> '$(survivors "$tmp")'"
+fi
+rm -rf "$tmp"
+
+# main() prunes before anything else, so under `set -e` a non-zero return on an
+# empty or missing dir would abort the update check on every tick.
+tmp=$(mktemp -d)
+BACKUP_DIR="$tmp"
+if prune_backups >/dev/null 2>&1 && [[ -z "$(survivors "$tmp")" ]]; then
+    ok "prune_backups on an empty dir is a no-op"
+else
+    bad "prune_backups on an empty dir returned non-zero or removed something"
+fi
+rm -rf "$tmp"
+
+# shellcheck disable=SC2034  # read by the sourced prune_backups
+BACKUP_DIR="/nonexistent/wendy-agent-backups"
+if prune_backups >/dev/null 2>&1; then
+    ok "prune_backups on a missing dir is a no-op"
+else
+    bad "prune_backups on a missing dir returned non-zero"
+fi
+
+# Everything above tests the updater's copy; the download script has its own.
+updater_prune=$(sed -n '/^KEEP_BACKUPS=/,/^}/p' "${SCRIPT_DIR}/wendyos-agent-updater.sh")
+download_prune=$(sed -n '/^KEEP_BACKUPS=/,/^}/p' "${SCRIPT_DIR}/download-wendyos-agent.sh")
+if [[ -n "$updater_prune" && "$updater_prune" == "$download_prune" ]]; then
+    ok "prune_backups is identical in both scripts"
+else
+    bad "prune_backups has drifted between the updater and the download script"
+fi
+
 echo
 echo "$pass passed, $fail failed"
 [[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Fixes [WDY-2185](https://linear.app/wendylabsinc/issue/WDY-2185/nightly-agent-updater-leaks-unpruned-binary-backups-until-the-root-fs): the nightly agent auto-updater fills the root filesystem until `wendy cloud device update` (and the OS-update check behind it) fails with ENOSPC. Found on wendy-box-theta (ENMAX pilot): 68 × 22MB `wendy-agent.backup.*` files = 1.3GB, root fs at 100% with 16MB free.

## Fix 1 — backup rotation

`download-wendyos-agent.sh` kept a timestamped 22MB backup on **every install, forever**. Now it prunes to the newest 2 after each backup (`KEEP_BACKUPS=2`) — the restore path only ever reads `${BINARY_NAME}.latest`, so timestamped copies are purely forensic.

`wendyos-agent-updater.sh` additionally prunes on **every nightly check** (even "already up to date"), so already-deployed devices with a backlog self-heal on the first timer run after an OS image update ships this script — no manual fleet cleanup.

## Fix 2 — why it leaked *nightly* rather than per-release

`get_current_version()` truncated the calver version to its date part (`2026.07.27-003050` → `2026.07.27`, regex only matched `x.y.z`) while release tags keep the time suffix. Current never equalled latest, so `version_gt` reported an update **every night** and the updater re-downloaded + re-installed the *same* release — each run adding a backup. The regex now captures the full version including the `-HHMMSS` suffix; plain semver matches unchanged, and dev builds still exit early on the raw-string check (WDY-1770 behavior preserved).

## Verification

- `bash -n` on both scripts
- Prune fixture test: 68 fake backups → exactly 2 remain; empty/missing backup dir is a safe no-op under `set -e` (pipeline ends in `while`, glob failure suppressed)
- Regex: `2026.07.27-003050` captured in full; `1.0.3` unchanged; `2026.06.30-133859-dev` → numeric part only (dev check uses the raw string and runs before the version comparison)
- Equal full versions now compare "already up to date" → no reinstall, no backup

## Not in this PR (noted in WDY-2185)

- Immediate remediation of already-full devices (theta needs a one-time manual prune or this script arriving via OS image update — the A/B slot rewrite also clears the backlog)
- Moving `BACKUP_DIR` off the root fs to `/data`
- Root-fs image built at 7.3GB inside its 14GB A/B slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)