### PR TITLE
Persist /etc/wendy-agent on /data across A/B slots (WDY-1884)

### DIFF
--- a/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
+++ b/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
@@ -88,6 +88,15 @@ do_install() {
     install -d ${D}/var/lib/wendyos-agent
     install -d ${D}/var/lib/wendy-agent
     install -d ${D}/opt/wendy
+
+    # Agent identity/enrollment state. Shipped (rather than left to the agent's
+    # runtime MkdirAll) so wendyos-etc-binds has a mount point to bind
+    # /data/etc/wendy-agent onto on every platform (WDY-1884). 0700 matches the
+    # mode the agent uses — it holds the device private key. Path is literal, not
+    # ${sysconfdir}: the agent, generate-hostname.sh and setup-etc-binds.sh all
+    # hardcode /etc/wendy-agent, so a relocatable prefix here could only drift
+    # away from them.
+    install -d -m 0700 ${D}/etc/wendy-agent
 }
 
 FILES:${PN} = "/usr/local/bin/wendy-agent \
@@ -95,7 +104,8 @@ FILES:${PN} = "/usr/local/bin/wendy-agent \
                /opt/wendy \
                ${systemd_system_unitdir}/* \
                /var/lib/wendyos-agent \
-               /var/lib/wendy-agent"
+               /var/lib/wendy-agent \
+               /etc/wendy-agent"
 
 # Skip QA checks for the pre-built, vendored binary:
 #   already-stripped - upstream ships a stripped release binary.

--- a/recipes-core/wendyos-etc-binds/files/setup-etc-binds.sh
+++ b/recipes-core/wendyos-etc-binds/files/setup-etc-binds.sh
@@ -215,12 +215,77 @@ else
     log_info "/etc/${NM_CONNECTIONS} already mounted, skipping"
 fi
 
+# PHASE 3: agent identity/enrollment state persistence (/etc/wendy-agent)
+log_info "Phase 3: Setting up agent state persistence"
+
+# Device key, PEMs, provisioning.json, clock floor, and the hostname set by
+# 'wendy device rename'. Per-slot on the rootfs, so an A/B OTA unenrolls the
+# device and reverts its name (WDY-1884). Bound as a directory, not per-file:
+# the agent's PEM writes use rename(), which fails EBUSY on a bound file.
+AGENT_DIR="/etc/wendy-agent"
+DATA_AGENT="${DATA_ETC}/wendy-agent"
+
+if ! mountpoint -q "${AGENT_DIR}"
+then
+    SEED_OK=1
+    if [ ! -d "${DATA_AGENT}" ] && [ -n "$(ls -A "${AGENT_DIR}" 2>/dev/null)" ]
+    then
+        # Binding over live rootfs state would mask the only copy, so the seed
+        # is load-bearing: on failure, skip the bind. Staged and renamed so an
+        # interrupted copy cannot leave a half-populated ${DATA_AGENT}.
+        log_info "Migrating existing ${AGENT_DIR} state to ${DATA_AGENT}"
+        STAGE="${DATA_ETC}/.wendy-agent.incoming"
+        rm -rf "${STAGE}"
+        if cp -a "${AGENT_DIR}" "${STAGE}" && sync
+        then
+            mv "${STAGE}" "${DATA_AGENT}" || SEED_OK=0
+        else
+            SEED_OK=0
+        fi
+        rm -rf "${STAGE}"
+
+        if [ "${SEED_OK}" -eq 1 ]
+        then
+            log_info "Migrated agent state to ${DATA_AGENT}"
+        else
+            log_error "Failed to migrate ${AGENT_DIR} to ${DATA_AGENT}; NOT binding (state stays on the rootfs)"
+        fi
+
+        # Rootfs copy is left in place: a rollback to a pre-fix slot has no bind
+        # mount and would find no state.
+    fi
+
+    if [ "${SEED_OK}" -eq 1 ]
+    then
+        if [ ! -d "${DATA_AGENT}" ]
+        then
+            log_info "Creating ${DATA_AGENT} for persistent agent state"
+            mkdir -p "${DATA_AGENT}"
+        fi
+        chmod 700 "${DATA_AGENT}"
+        mkdir -p "${AGENT_DIR}"
+
+        log_info "Bind-mounting ${DATA_AGENT} → ${AGENT_DIR}"
+        mount --bind "${DATA_AGENT}" "${AGENT_DIR}"
+
+        if mountpoint -q "${AGENT_DIR}"
+        then
+            log_info "Successfully mounted ${AGENT_DIR}"
+        else
+            log_error "Failed to bind-mount ${AGENT_DIR}"
+        fi
+    fi
+else
+    log_info "${AGENT_DIR} already mounted, skipping"
+fi
+
 # Verification...
 log_info "Verifying all bind mounts are active"
 
 MOUNT_CHECKS=(
     "/etc/wendyos"
     "/etc/${NM_CONNECTIONS}"
+    "/etc/wendy-agent"
 )
 
 FAILED=0


### PR DESCRIPTION
Closes WDY-1884

## Problem

`/etc/wendy-agent` holds the device private key, device/CA PEMs, `provisioning.json`, the `.provisioned` marker, the clock floor, and the hostname set by `wendy device rename`. It sits on the rootfs, and only `/data` persists across A/B slots.

So an OS update leaves the device with no key or certs: it drops out of its org, falls back to unprovisioned, and needs an operator to re-enroll it. It also loses its name. WDY-1884.

## Change

Two files, image-side only. No agent change: `hostname.go` and `generate-hostname.sh` both hardcode `/etc/wendy-agent` and ignore `WENDY_CONFIG_PATH`, so relocating the path would have moved enrollment state while leaving `wendy device rename` broken. Binding the path covers all consumers.

`recipes-core/wendyos-etc-binds/files/setup-etc-binds.sh` — new Phase 3 binding `/data/etc/wendy-agent` over `/etc/wendy-agent`, alongside the existing `/etc/wendyos` and NetworkManager binds, and added to `MOUNT_CHECKS`.

- Directory bind, not per-file: the agent's PEM writes use `rename()`, which fails `EBUSY` on a bound file. Same constraint that keeps `/etc/hostname` out of this script.
- State on the booted slot's rootfs is seeded to `/data` before the bind, since binding over it would hide the only copy. On seed failure the bind is skipped, leaving the device on its rootfs copy.
- The seed stages to `.wendy-agent.incoming` and renames the directory, so an interrupted copy can't leave a half-populated `/data/etc/wendy-agent` that the next boot treats as complete.
- The rootfs copy is not removed. Deleting it would break rollback to a pre-fix slot, which has no bind mount. Tradeoff: `device-key.pem` remains in a shadowed copy on that slot's rootfs (`THREAT_MODEL.md` TM-I-02).

`recipes-core/wendyos-agent/wendyos-agent_1.0.bb` — ships `/etc/wendy-agent` at 0700 as the bind target, so the mount point exists on every platform rather than depending on the agent's runtime `MkdirAll`. `rpi-image.inc`'s pre-creation only covers RPi, and Tegra/x86 bind targets use `x-systemd.mkdir`, which a shell-script bind can't.

No systemd ordering changes needed: `wendyos-hostname.service` already declares `After=wendyos-etc-binds.service`, and the agent starts later still.

## Known limitation: one final loss on the hop onto this change

An OTA writes the whole rootfs slot and boots the other slot, whose `/etc` comes from the image. An enrolled device's state is on the previous slot's rootfs, which isn't mounted, so the seed can't see it. Already-enrolled devices therefore re-enroll once when they take this update. Slot switches after that preserve state.

Closing this would mean mounting the inactive slot read-only and seeding from it. Feasible — `rootfsA`/`rootfsB` are addressable by partlabel — but it adds slot-identity logic and a foreign read-only mount to a script running `Before=sysinit.target`, plus a separate path for Tegra. Left out of this PR.

The seed still covers same-slot cases: a device that enrolled while the bind was failing, and a `/data` wipe that left state on the booted rootfs.

## Validation

Tested on a Raspberry Pi 4 against this PR's images. All seven device builds pass.

The signal is `wendy device rename`, which writes `/etc/wendy-agent/hostname` and is read at boot by `generate-hostname.sh`. `SetHostname` has no provisioning gate, so this works on an unprovisioned device.

Before the fix, booted slot B:

- `/etc/wendyos` and `/var/lib/wendy` bound from `/data`; `/etc/wendy-agent` not a mountpoint.
- Inactive slot A still held `hostname = pi4-slotcanary`; the booted slot had no `hostname`.
- `systemctl reboot` on the same slot preserved the rename, so the loss follows the slot switch rather than the reboot.

After `os update --pr 210`:

- Slot switched B → A (`mmcblk0p4` → `mmcblk0p3`); `PHASE 3` present in `/usr/sbin/setup-etc-binds.sh`; mount point 0700, timestamped to the Yocto epoch.
- `/etc/wendy-agent` bound from `/dev/mmcblk0p5[/etc/wendy-agent]`.
- `wendy device rename` wrote to `/data/etc/wendy-agent/hostname`; the slot's rootfs copy stayed empty.
- Second OTA, A → B (`mmcblk0p3` → `mmcblk0p4`): hostname `pi4-canary3` preserved.
- Seed skipped when `/data` was already populated — journal shows the bind only.
- Name lost once on the delivering OTA, per the limitation above.
