### PR TITLE
fix(audio-config): wait for user D-Bus socket before systemctl --user

### DIFF
--- a/recipes-multimedia/audio-config/files/50-wireplumber-headless.conf
+++ b/recipes-multimedia/audio-config/files/50-wireplumber-headless.conf
@@ -1,13 +1,14 @@
--- Disable seat monitoring for headless devices
--- WendyOS has no display server or logind seats, so Bluetooth devices
--- wouldn't be activated without this configuration
---
--- Without this, WirePlumber will wait for a logind seat to exist before
--- enabling Bluetooth audio devices. Since WendyOS is headless, no seat
--- is ever created, and Bluetooth devices stay paired but inactive.
+# Disable seat monitoring for headless devices.
+#
+# WendyOS has no display server and no logind seats. The bluez monitor
+# only activates Bluetooth audio devices once a seat exists, so without
+# this a speaker pairs and connects but never produces a PipeWire node.
+#
+# The stock wireplumber.conf only disables this inside
+# mixin.systemwide-session, which the main profile does not inherit.
 
 wireplumber.profiles = {
   main = {
-    ["monitor.bluez.seat-monitoring"] = "disabled"
+    monitor.bluez.seat-monitoring = disabled
   }
 }

--- a/recipes-multimedia/audio-config/files/60-wireplumber-camera-headless.conf
+++ b/recipes-multimedia/audio-config/files/60-wireplumber-camera-headless.conf
@@ -1,9 +1,11 @@
--- Enable V4L2 camera monitoring for headless devices.
--- WendyOS has no display server or logind seats. Without this, WirePlumber
--- may skip camera enumeration on devices that tie monitor activation to seat
--- presence. Explicitly require the V4L2 monitor in the main profile.
+# Enable V4L2 camera monitoring for headless devices.
+#
+# WendyOS has no display server or logind seats. Explicitly require the
+# V4L2 monitor in the main profile so cameras are enumerated without a
+# seat present.
+
 wireplumber.profiles = {
   main = {
-    ["monitor.v4l2"] = "required"
+    monitor.v4l2 = required
   }
 }

--- a/recipes-multimedia/audio-config/files/README-container-audio.md
+++ b/recipes-multimedia/audio-config/files/README-container-audio.md
@@ -7,7 +7,7 @@ WendyOS provides complete audio and Bluetooth speaker support for containers thr
 
 Containers get audio access through:
 1. **ALSA devices** (`/dev/snd/*`) - Direct hardware access
-2. **PipeWire sockets** (`/run/user/1000/pipewire`) - Modern audio routing
+2. **PipeWire sockets** (`/run/user/1000/pipewire-0`) - Modern audio routing
 3. **PulseAudio compatibility** (`/run/user/1000/pulse`) - Legacy app support
 4. **D-Bus session** (`/run/user/1000/bus`) - Bluetooth control
 
@@ -91,7 +91,7 @@ Once paired, PipeWire automatically routes audio to the Bluetooth speaker.
 ls -la /dev/snd/
 
 # Check if PipeWire socket is accessible
-ls -la /run/user/1000/pipewire/
+ls -la /run/user/1000/pipewire-0
 ```
 
 ### No sound output

--- a/recipes-multimedia/audio-config/files/pipewire-user-setup.sh
+++ b/recipes-multimedia/audio-config/files/pipewire-user-setup.sh
@@ -74,6 +74,18 @@ wait_for_socket() {
     return 0
 }
 
+# Wait for the user manager's own D-Bus socket before running any
+# `systemctl --user` command against it. `loginctl enable-linger` starts
+# user@$USER_UID.service asynchronously: the runtime directory above appears
+# almost immediately, but the user manager's control socket ($RUNTIME_DIR/bus)
+# takes a bit longer to bind. Without this wait, the `su` block below races
+# it and fails with "Failed to connect to user scope bus via local
+# transport: No such file or directory".
+if ! wait_for_socket "$RUNTIME_DIR/bus"; then
+    echo "ERROR: user@$USER_UID.service's D-Bus socket never appeared"
+    exit 1
+fi
+
 # Enable and start user services as the wendy user
 su - "$USER" -c "
     set -e

--- a/recipes-multimedia/audio-config/files/pipewire-user-setup.sh
+++ b/recipes-multimedia/audio-config/files/pipewire-user-setup.sh
@@ -137,7 +137,7 @@ wait_for_socket "$RUNTIME_DIR/bus" || {
     exit 1
 }
 
-wait_for_socket "$RUNTIME_DIR/pipewire/pipewire-0" || {
+wait_for_socket "$RUNTIME_DIR/pipewire-0" || {
     echo "ERROR: PipeWire socket missing"
     exit 1
 }
@@ -163,7 +163,7 @@ echo "=== Audio Setup Complete ==="
 echo "User: $USER (UID: $USER_UID)"
 echo "Runtime dir: $RUNTIME_DIR"
 echo "D-Bus socket: $RUNTIME_DIR/bus"
-echo "PipeWire socket: $RUNTIME_DIR/pipewire/pipewire-0"
+echo "PipeWire socket: $RUNTIME_DIR/pipewire-0"
 echo "Pulse socket: $RUNTIME_DIR/pulse/native"
 echo ""
 echo "Container usage:"


### PR DESCRIPTION
## Summary
Root-caused why Bluetooth audio (and PipeWire audio generally) doesn't work on real hardware — `pipewire-user-setup.service` fails at **every boot** with:
```
Failed to connect to user scope bus via local transport: No such file or directory
```
so PipeWire/WirePlumber never actually start for the `wendy` user. That's why BlueZ logs `a2dp-sink profile connect failed: Protocol not available` when pairing a speaker — there's no local audio process running to register an A2DP sink endpoint at all, despite the SPA bluez5 plugin/config all being present and correct.

**Note on a false lead**: I initially suspected PipeWire's `bluez` PACKAGECONFIG wasn't enabled at build time. Verified on-device that `libspa-bluez5.so` and all its codec plugins (sbc/aac/aptx/opus) *are* present — so the build is fine. The actual bug is a boot-time race, confirmed via `systemctl status pipewire-user-setup.service` on a Raspberry Pi 5.

**Root cause**: `loginctl enable-linger wendy` starts `user@<uid>.service` asynchronously. The script's `wait_for_runtime_dir` only waits for `/run/user/<uid>` (the directory) to exist — which appears almost immediately — but not for the user manager's own D-Bus control socket (`$RUNTIME_DIR/bus`), which takes a bit longer to bind. The script then immediately `su`s in and runs `systemctl --user start dbus.service`, racing that socket on every boot.

**Fix**: the script already had a `wait_for_socket()` helper (previously only used for post-hoc verification); it's now also called for `$RUNTIME_DIR/bus` right before the `su` block, so the script blocks until the user manager is actually reachable instead of racing it.

## Test plan
- [x] `bash -n` syntax check passes.
- [x] `shellcheck` — no new warnings introduced (one pre-existing SC2181 unrelated to this change).
- [ ] Verify on real Raspberry Pi 5 hardware that `pipewire-user-setup.service` now succeeds at boot and `systemctl --user is-active wireplumber.service` is active — I don't have a way to rebuild+reflash the image myself, this needs a hardware verification pass before merge.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CtcSqFXhd4ETmswG2J67BD