### PR TITLE
fix(systemd): enable PAM support so user@.service can start

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -8,6 +8,20 @@
 
 PACKAGECONFIG:remove = "polkit"
 
+# Enable PAM support. user@.service (PAMName=systemd-user) needs pam_systemd.so
+# and /etc/pam.d/systemd-user to set $XDG_RUNTIME_DIR when starting a user
+# manager instance — without it, user@<uid>.service fails outright ("Trying to
+# run as user instance, but $XDG_RUNTIME_DIR is not set") even though
+# user-runtime-dir@<uid>.service already created the runtime directory itself;
+# that oneshot only creates the directory, it can't inject environment into a
+# different unit's process. This breaks every rootless per-user session on the
+# image (e.g. audio-config's PipeWire/WirePlumber session for the wendy user),
+# not just lingering ones. 'pam' isn't in DISTRO_FEATURES (unlike polkit
+# above), so it's not part of systemd's default PACKAGECONFIG; the module and
+# PAM config are both already covered by the upstream recipe's FILES:${PN}, so
+# no extra install step is needed here.
+PACKAGECONFIG:append = " pam"
+
 # Disable debug source package splitting to avoid pseudo uid lookup failures.
 # do_package hardlinks source files (owned by uid 1000 / build user) into PKGD.
 # OEOuthashBasic then calls getpwuid(1000) via pseudo, which redirects to the


### PR DESCRIPTION
## Summary
Root-caused the actual reason PipeWire/WirePlumber (and Bluetooth audio via BlueZ A2DP) never work on real hardware — traced from #213, which fixed a real race but turned out not to be the whole story.

**Confirmed on a Raspberry Pi 5 via `wendy device shell`:**
- `pipewire-user-setup.service` fails every boot.
- `user@1000.service` fails immediately: `Trying to run as user instance, but $XDG_RUNTIME_DIR is not set.`
- `user-runtime-dir@1000.service` (the oneshot that creates `/run/user/1000`) succeeds every time — it's not a race, `user@.service` genuinely can never start.
- `/etc/pam.d/systemd-user` and `pam_systemd.so` don't exist anywhere on the rootfs.

`user@.service` specifies `PAMName=systemd-user`; it relies on `pam_systemd.so` (via that PAM stack) to inject `$XDG_RUNTIME_DIR` into the user manager's process environment — `user-runtime-dir@.service` only creates the directory, it has no way to set environment for a different unit's process. Without PAM, no rootless per-user systemd session can ever start on this image — not just for `wendy`'s audio session, potentially anything else relying on `systemctl --user`.

**Why it's missing**: `'pam'` isn't in `DISTRO_FEATURES`, so systemd's own default `PACKAGECONFIG` (gated by `bb.utils.filter('DISTRO_FEATURES', '... pam ...', d)` in the upstream recipe) never enables it. `recipes-core/systemd/systemd_%.bbappend` already manages `PACKAGECONFIG` directly for this recipe (it explicitly removes `polkit`), so this fix appends `pam` there — scoped to systemd's own build, no changes to global `DISTRO_FEATURES`. The module and PAM config file are already covered by the upstream recipe's `FILES:${PN}`, so no extra install step is needed.

## Test plan
- [ ] Rebuild + reflash a Raspberry Pi 5 image with this change and confirm:
  - `systemctl status user@1000.service` succeeds
  - `pipewire-user-setup.service` succeeds
  - `ps aux | grep -E "pipewire|wireplumber"` shows the wendy-user session processes
  - `busctl --system tree org.bluez` shows a registered `MediaEndpoint1`
  - A Bluetooth speaker connects and plays audio end-to-end

I don't have a way to rebuild/reflash the image myself, so this needs a hardware verification pass before merge. This complements #213 (still correct/needed as a defensive fix for the underlying race even once PAM works).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CtcSqFXhd4ETmswG2J67BD