### PR TITLE
publisher: scope upload timeouts per file instead of one shared 30m context

### DIFF
--- a/tools/publisher/parallel_upload.go
+++ b/tools/publisher/parallel_upload.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
@@ -40,6 +41,16 @@ const (
 	// flushes; 32 MiB keeps the socket busier. This is a per-part in-flight
 	// buffer, not the whole part, so memory stays bounded.
 	partChunkSize = 32 << 20 // 32 MiB
+
+	// Per-file upload timeout parameters for uploadTimeoutFor. The floor
+	// throughput is deliberately far below the ~113 MB/s a healthy runner
+	// link sustains: it is the worst degradation we tolerate before giving
+	// up, sized so that concurrent big files sharing a saturated link still
+	// fit their individual budgets (the 0.18.1 release saw ~4-7 MB/s per
+	// file and blew the old shared 30-minute context).
+	uploadTimeoutFloor     = 10 * time.Minute
+	uploadTimeoutHeadroom  = 5 * time.Minute
+	uploadFloorBytesPerSec = 2 << 20 // 2 MiB/s
 )
 
 // crc32cTable is the Castagnoli table GCS uses for its CRC32C object checksums.
@@ -55,6 +66,19 @@ var (
 	// which is only the case in tests that never set it.
 	uploadSem chan struct{}
 )
+
+// uploadTimeoutFor returns the deadline budget for uploading one file of the
+// given size: transfer time at the floor throughput plus fixed headroom for
+// compose/finalize round-trips, never less than the floor. Each file gets its
+// own budget so one slow multi-GB upload cannot starve the others of a shared
+// deadline.
+func uploadTimeoutFor(size int64) time.Duration {
+	timeout := time.Duration(size/uploadFloorBytesPerSec)*time.Second + uploadTimeoutHeadroom
+	if timeout < uploadTimeoutFloor {
+		return uploadTimeoutFloor
+	}
+	return timeout
+}
 
 // acquireUploadSlot blocks until a slot on the global upload semaphore is free
 // or ctx is cancelled. A nil semaphore (tests) never blocks.

--- a/tools/publisher/parallel_upload_test.go
+++ b/tools/publisher/parallel_upload_test.go
@@ -10,7 +10,48 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 )
+
+// --- Per-file upload timeout -----------------------------------------------
+
+func TestUploadTimeoutFor(t *testing.T) {
+	t.Run("small files get the floor", func(t *testing.T) {
+		for _, size := range []int64{0, 1 << 20, 100 << 20} {
+			if got := uploadTimeoutFor(size); got != 10*time.Minute {
+				t.Errorf("size %d: timeout = %v, want %v", size, got, 10*time.Minute)
+			}
+		}
+	})
+
+	t.Run("large files scale with size at the 2 MiB/s floor throughput", func(t *testing.T) {
+		// 6 GiB at 2 MiB/s = 3072s of transfer + 5 min headroom.
+		got := uploadTimeoutFor(6 << 30)
+		want := 3072*time.Second + 5*time.Minute
+		if got != want {
+			t.Errorf("timeout = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("0.18.1 orin-nano recovery bundle gets well over the old shared budget", func(t *testing.T) {
+		// The 6.9 GB tegraflash bundle whose upload blew the shared 30-minute
+		// context in the 0.18.1 release build (run 30573040970 attempt 1).
+		if got := uploadTimeoutFor(6926039040); got < 45*time.Minute {
+			t.Errorf("timeout = %v, want >= 45m", got)
+		}
+	})
+
+	t.Run("never decreases as size grows", func(t *testing.T) {
+		prev := time.Duration(0)
+		for _, size := range []int64{0, 256 << 20, 1 << 30, 7 << 30, 64 << 30} {
+			got := uploadTimeoutFor(size)
+			if got < prev {
+				t.Errorf("size %d: timeout %v < previous %v", size, got, prev)
+			}
+			prev = got
+		}
+	})
+}
 
 // --- Part planning ---------------------------------------------------------
 

--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -1294,9 +1294,11 @@ func main() {
 		}
 	}
 
-	// Create context with timeout and storage client
-	// 30 minute timeout should be sufficient for most uploads
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	// Whole-run safety net so a wedged run cannot hang CI until the job-level
+	// timeout. Individual file uploads carry their own tighter, size-scaled
+	// deadlines (uploadTimeoutFor), so this must stay comfortably above the
+	// budget of the largest artifact we publish (~7 GB -> ~65 minutes).
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
 	defer cancel()
 
 	client, err := createStorageClientWithAuth(ctx, *accessToken)
@@ -1943,6 +1945,15 @@ func uploadFile(ctx context.Context, bucket *storage.BucketHandle, prefix, local
 	if err != nil {
 		return "", fmt.Errorf("failed to stat local file: %w", err)
 	}
+
+	// Each file gets its own size-scaled deadline. The parent context is only
+	// a coarse whole-run safety net; without a per-file budget, several multi-GB
+	// artifacts uploading concurrently on a degraded link drain the shared
+	// deadline and the last one to finish dies (0.18.1 orin-nano release).
+	timeout := uploadTimeoutFor(localInfo.Size())
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	obj := bucket.Object(destinationPath)
 	if existingAttrs, err := obj.Attrs(ctx); err == nil && existingAttrs.Size == localInfo.Size() {
 		log.WithField("path", destinationPath).Info("File already in GCS with matching size, skipping upload")
@@ -1958,6 +1969,9 @@ func uploadFile(ctx context.Context, bucket *storage.BucketHandle, prefix, local
 	if len(plan) > 1 {
 		logComposePlan(destinationPath, localInfo.Size(), plan)
 		if err := uploadFileComposite(ctx, bucketComposer{bucket: bucket}, uploadSem, localPath, destinationPath, contentType, localInfo.Size(), plan, partChunkSize); err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				err = fmt.Errorf("upload of %s (%d bytes) exceeded its %v budget: %w", filename, localInfo.Size(), timeout, err)
+			}
 			log.WithError(err).Error("Composite upload failed")
 			return "", err
 		}


### PR DESCRIPTION
## Why

The 0.18.1 release ([run 30573040970](https://github.com/wendylabsinc/WendyOS-Builder/actions/runs/30573040970), attempt 1) shipped without `jetson-orin-nano`: the publisher wraps **all** of a device's uploads in a single 30-minute context, and on a degraded runner link the Orin Nano's ~17.6 GB of artifacts drained it. The recovery bundle's last part finalize died with `context deadline exceeded`, the job failed after the image and OTA had already uploaded, and the device's manifest stayed on 0.17.0 while every other device advanced to 0.18.1 (fixed operationally by re-running the job).

This was not a one-device anomaly. Upload-step durations (minutes) across recent runs:

| Device | 4 nightlies | 0.18.1 attempt 1 | 0.18.1 attempt 2 |
|---|---|---|---|
| jetson-orin-nano (nvme sd) | 5.8 – 13.9 | **59.8 (failed at deadline)** | 9.7 |
| jetson-agx-orin (nvme emmc) | 5.2 – 9.9 | **28.8** | — |
| jetson-agx-thor (nvme) | 2.2 – 9.1 | 5.2 | — |
| generic-x86-64 (disk) | 1.2 – 1.8 | 6.6 | — |
| raspberry-pi-3/4/5 | 0.6 – 1.7 | 1.0 – 1.4 | — |

`jetson-agx-orin` came within ~1 minute of the same wall in the same run (its emmc-variant invocation spent ~19.6 of its 30 minutes on uploads alone). The composite uploader was designed around ~113 MB/s; that evening the runners saw ~4–7 MB/s per file. Same payload, next attempt: 9.7 minutes — the variance is network, not payload, so a fixed shared budget is the wrong shape.

## What

- Each file upload now gets its own deadline scaled to its size: transfer time at a 2 MiB/s floor throughput + 5 min headroom, never below 10 min. The 6.9 GB recovery bundle that died gets ~60 min to itself; small files keep tight bounds.
- The whole-run context becomes a coarse 2-hour safety net (it must exceed the largest single-file budget, since a child context cannot outlive its parent; still well under the 6 h job timeout).
- Deadline failures now name the file and the budget it exceeded instead of a bare `context deadline exceeded`.

## Testing

- `go test ./...` in `tools/publisher` (new `TestUploadTimeoutFor` covers the floor, the scaling formula, the incident's exact file size, and monotonicity).
- `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)