### PR TITLE
tegra: support Intel Wi-Fi M.2 cards (AX210) via iwlwifi + firmware

### DIFF
--- a/conf/distro/include/tegra-image.inc
+++ b/conf/distro/include/tegra-image.inc
@@ -30,6 +30,20 @@ IMAGE_INSTALL:append = " \
     v4l-utils \
     "
 
+# Firmware for third-party M.2 E-key Wi-Fi cards (e.g. Intel AX210NGW).
+# The stock devkit module's Realtek blobs arrive via meta-tegra's
+# devkit-wifi.inc (MACHINE_EXTRA_RRECOMMENDS -> tegra-firmware-rtl8822,
+# consumed through core-image's packagegroup-base-extended); Intel cards
+# need linux-firmware instead: iwlwifi-ty-*.{ucode,pnvm} live in
+# -iwlwifi-misc and the Bluetooth half's ibt-* in -ibt-misc. Targeted
+# subpackages, not the ~1 GiB full linux-firmware — the A/B rootfs slot
+# is size-pinned (wendyos-rootfs-size.inc). The matching kernel modules
+# are enabled by wifi-intel.cfg in the tegra kernel bbappends.
+IMAGE_INSTALL:append = " \
+    linux-firmware-iwlwifi-misc \
+    linux-firmware-ibt-misc \
+    "
+
 # Enable DeepStream SDK support (optional - adds ~1GB to image)
 # Tegra/NVIDIA hardware only - DeepStream requires NVIDIA GPUs
 # Also enables l4t-deepstream.csv which provides:

--- a/meta-tegra-extensions-jp6/recipes-kernel/linux/linux-jammy-nvidia-tegra/wifi-intel.cfg
+++ b/meta-tegra-extensions-jp6/recipes-kernel/linux/linux-jammy-nvidia-tegra/wifi-intel.cfg
@@ -1,0 +1,25 @@
+# Intel Wi-Fi (iwlwifi) + Intel USB Bluetooth for third-party M.2 E-key
+# cards such as the AX210NGW. The BSP only covers the devkit's stock
+# Realtek module (out-of-tree rtl8822ce/rtk-btusb via meta-tegra's
+# devkit-wifi.inc); nothing asserts the in-tree Intel stack, so do it
+# here. KCONFIG_MODE = "--alldefconfig" honors fragment symbols but does
+# not auto-select their dependencies, so the chain must be spelled out
+# (see meta-x86-extensions/recipes-kernel/linux/files/x86-nuc-drivers.cfg,
+# which this is a subset of — IWLMLD and BT_INTEL_PCIE are omitted because
+# they don't exist in this kernel, needing 6.15+/6.10+ respectively; the
+# AX210 is an IWLMVM part with USB Bluetooth).
+CONFIG_WLAN=y
+CONFIG_CFG80211=m
+CONFIG_MAC80211=m
+CONFIG_WLAN_VENDOR_INTEL=y
+CONFIG_IWLWIFI=m
+CONFIG_IWLMVM=m
+
+# The AX210's Bluetooth half is a USB function (8087:0032) driven by
+# btusb + btintel. The stock card's Bluetooth uses the out-of-tree
+# rtk-btusb instead, so the in-tree pair isn't guaranteed by the
+# defconfig. CONFIG_BT itself is deliberately not asserted: it is
+# already enabled (stock Bluetooth works) and repeating it =m here
+# would demote it if the defconfig has it =y.
+CONFIG_BT_HCIBTUSB=m
+CONFIG_BT_INTEL=m

--- a/meta-tegra-extensions-jp6/recipes-kernel/linux/linux-jammy-nvidia-tegra_%.bbappend
+++ b/meta-tegra-extensions-jp6/recipes-kernel/linux/linux-jammy-nvidia-tegra_%.bbappend
@@ -4,6 +4,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
     file://usb-gadget.cfg \
     file://usb-serial.cfg \
+    file://wifi-intel.cfg \
     file://0001-crypto-scatterwalk-Backport-memcpy_sglist.patch \
     file://0002-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch \
     file://0003-crypto-algif_aead-Revert-to-operating-out-of-place-CVE-2026-31431.patch \

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/wifi-intel.cfg
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/wifi-intel.cfg
@@ -1,0 +1,25 @@
+# Intel Wi-Fi (iwlwifi) + Intel USB Bluetooth for third-party M.2 E-key
+# cards such as the AX210NGW. The BSP only covers the devkit's stock
+# Realtek module (out-of-tree rtl8822ce/rtk-btusb via meta-tegra's
+# devkit-wifi.inc); nothing asserts the in-tree Intel stack, so do it
+# here. KCONFIG_MODE = "--alldefconfig" honors fragment symbols but does
+# not auto-select their dependencies, so the chain must be spelled out
+# (see meta-x86-extensions/recipes-kernel/linux/files/x86-nuc-drivers.cfg,
+# which this is a subset of — IWLMLD and BT_INTEL_PCIE are omitted because
+# they don't exist in this kernel, needing 6.15+/6.10+ respectively; the
+# AX210 is an IWLMVM part with USB Bluetooth).
+CONFIG_WLAN=y
+CONFIG_CFG80211=m
+CONFIG_MAC80211=m
+CONFIG_WLAN_VENDOR_INTEL=y
+CONFIG_IWLWIFI=m
+CONFIG_IWLMVM=m
+
+# The AX210's Bluetooth half is a USB function (8087:0032) driven by
+# btusb + btintel. The stock card's Bluetooth uses the out-of-tree
+# rtk-btusb instead, so the in-tree pair isn't guaranteed by the
+# defconfig. CONFIG_BT itself is deliberately not asserted: it is
+# already enabled (stock Bluetooth works) and repeating it =m here
+# would demote it if the defconfig has it =y.
+CONFIG_BT_HCIBTUSB=m
+CONFIG_BT_INTEL=m

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
@@ -18,6 +18,7 @@ SRC_URI += " \
     file://usb-gadget.cfg \
     file://usb-gadget-builtin.cfg \
     file://usb-serial.cfg \
+    file://wifi-intel.cfg \
     file://0001-crypto-scatterwalk-Backport-memcpy_sglist.patch \
     file://0002-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch \
     file://0003-crypto-algif_aead-Revert-to-operating-out-of-place-CVE-2026-31431.patch \


### PR DESCRIPTION
## Problem

On a Jetson Orin Nano with an Intel AX210NGW M.2 card, `wendy device wifi connect` fails with "No Wi-Fi device found" (NetworkManager's error relayed by the agent). The kernel never creates a wlan netdev: Jetson images only carry the devkit's stock Realtek module support (out-of-tree `rtl8822ce`/`rtk-btusb` + `tegra-firmware-rtl8822` via meta-tegra's `devkit-wifi.inc`), and neither the in-tree Intel iwlwifi driver nor Intel firmware blobs are anywhere in the Tegra build.

Verified against two devices on the same WendyOS-0.18.1 / JP7.2 image: a stock-chip Orin Nano has a working `wlan0`, the AX210 one has no wireless interface at all.

## Changes

- **`wifi-intel.cfg`** (new, wired into both the JP7 `linux-noble-nvidia-tegra` and JP6 `linux-jammy-nvidia-tegra` bbappends): enables `CFG80211`/`MAC80211`, `IWLWIFI`/`IWLMVM`, and `BT_HCIBTUSB`/`BT_INTEL` for the card's USB Bluetooth half. Subset of `meta-x86-extensions`' `x86-nuc-drivers.cfg` — `IWLMLD` / `BT_INTEL_PCIE` omitted (need 6.15+/6.10+; AX210 is an IWLMVM part). `CONFIG_BT` itself is deliberately not asserted to avoid demoting a possible `=y`. Modules ship automatically via the `kernel-modules` meta-package (`usb-gadget-modules` RDEPENDS).
- **`tegra-image.inc`**: installs `linux-firmware-iwlwifi-misc` (AX210 `iwlwifi-ty-*.ucode`/`.pnvm`) and `linux-firmware-ibt-misc` (`ibt-*` BT firmware). Targeted subpackages rather than full `linux-firmware` (~1 GiB) to respect the size-pinned A/B rootfs slot; license packages are auto-pulled via RDEPENDS.

No userspace changes needed: the Wi-Fi userspace (NM wifi plugin, wpa-supplicant, `wireless-regdb-static`) already ships on Tegra via the default `wifi` DISTRO_FEATURE → `packagegroup-base-wifi` (consumed through `core-image`'s `packagegroup-base-extended`). WendyAgent is chip-agnostic (everything goes through nmcli), so no agent changes either.

## Testing

- [ ] Image builds for `jetson-orin-nano-devkit-nvme-wendyos` (not yet run — draft)
- [ ] AX210 device: `nmcli device status` shows a `wifi` row; `wendy device wifi connect` works
- [ ] Stock Realtek devkit card still works (regression check)
- [ ] Bluetooth: `8087:0032` enumerates and pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)