### PR TITLE
fix(audio-config): two more bugs between a paired speaker and sound

### DIFF
--- a/recipes-multimedia/audio-config/files/50-wireplumber-headless.conf
+++ b/recipes-multimedia/audio-config/files/50-wireplumber-headless.conf
@@ -1,13 +1,14 @@
--- Disable seat monitoring for headless devices
--- WendyOS has no display server or logind seats, so Bluetooth devices
--- wouldn't be activated without this configuration
---
--- Without this, WirePlumber will wait for a logind seat to exist before
--- enabling Bluetooth audio devices. Since WendyOS is headless, no seat
--- is ever created, and Bluetooth devices stay paired but inactive.
+# Disable seat monitoring for headless devices.
+#
+# WendyOS has no display server and no logind seats. The bluez monitor
+# only activates Bluetooth audio devices once a seat exists, so without
+# this a speaker pairs and connects but never produces a PipeWire node.
+#
+# The stock wireplumber.conf only disables this inside
+# mixin.systemwide-session, which the main profile does not inherit.
 
 wireplumber.profiles = {
   main = {
-    ["monitor.bluez.seat-monitoring"] = "disabled"
+    monitor.bluez.seat-monitoring = disabled
   }
 }

--- a/recipes-multimedia/audio-config/files/60-wireplumber-camera-headless.conf
+++ b/recipes-multimedia/audio-config/files/60-wireplumber-camera-headless.conf
@@ -1,9 +1,11 @@
--- Enable V4L2 camera monitoring for headless devices.
--- WendyOS has no display server or logind seats. Without this, WirePlumber
--- may skip camera enumeration on devices that tie monitor activation to seat
--- presence. Explicitly require the V4L2 monitor in the main profile.
+# Enable V4L2 camera monitoring for headless devices.
+#
+# WendyOS has no display server or logind seats. Explicitly require the
+# V4L2 monitor in the main profile so cameras are enumerated without a
+# seat present.
+
 wireplumber.profiles = {
   main = {
-    ["monitor.v4l2"] = "required"
+    monitor.v4l2 = required
   }
 }

--- a/recipes-multimedia/audio-config/files/README-container-audio.md
+++ b/recipes-multimedia/audio-config/files/README-container-audio.md
@@ -7,7 +7,7 @@ WendyOS provides complete audio and Bluetooth speaker support for containers thr
 
 Containers get audio access through:
 1. **ALSA devices** (`/dev/snd/*`) - Direct hardware access
-2. **PipeWire sockets** (`/run/user/1000/pipewire`) - Modern audio routing
+2. **PipeWire sockets** (`/run/user/1000/pipewire-0`) - Modern audio routing
 3. **PulseAudio compatibility** (`/run/user/1000/pulse`) - Legacy app support
 4. **D-Bus session** (`/run/user/1000/bus`) - Bluetooth control
 
@@ -91,7 +91,7 @@ Once paired, PipeWire automatically routes audio to the Bluetooth speaker.
 ls -la /dev/snd/
 
 # Check if PipeWire socket is accessible
-ls -la /run/user/1000/pipewire/
+ls -la /run/user/1000/pipewire-0
 ```
 
 ### No sound output

--- a/recipes-multimedia/audio-config/files/pipewire-user-setup.sh
+++ b/recipes-multimedia/audio-config/files/pipewire-user-setup.sh
@@ -137,7 +137,7 @@ wait_for_socket "$RUNTIME_DIR/bus" || {
     exit 1
 }
 
-wait_for_socket "$RUNTIME_DIR/pipewire/pipewire-0" || {
+wait_for_socket "$RUNTIME_DIR/pipewire-0" || {
     echo "ERROR: PipeWire socket missing"
     exit 1
 }
@@ -163,7 +163,7 @@ echo "=== Audio Setup Complete ==="
 echo "User: $USER (UID: $USER_UID)"
 echo "Runtime dir: $RUNTIME_DIR"
 echo "D-Bus socket: $RUNTIME_DIR/bus"
-echo "PipeWire socket: $RUNTIME_DIR/pipewire/pipewire-0"
+echo "PipeWire socket: $RUNTIME_DIR/pipewire-0"
 echo "Pulse socket: $RUNTIME_DIR/pulse/native"
 echo ""
 echo "Container usage:"


### PR DESCRIPTION
Stacked on #213. Hardware-verified on a Raspberry Pi 4 (`raspberry-pi-4`, SD) with a Bose Revolve II SoundLink.

## Why

#214 and #213 are both correct and both necessary, but they are the first two links in a longer chain. With just those two, a Raspberry Pi 4 running the #213 image gets a healthy user session — `user@1000.service` active, PipeWire and WirePlumber running, `/run/user/1000/{bus,pipewire-0,pulse}` all present — and still cannot play a note to a Bluetooth speaker.

Two more bugs sit between that and audible sound. Each commit is independent and separately verified.

## 1. `verify the PipeWire socket at its real path`

`pipewire-user-setup.service` failed at every boot even once the session was healthy:

```
ERROR: Socket /run/user/1000/pipewire/pipewire-0 not ready after 10s
ERROR: PipeWire socket missing
```

The socket is `$XDG_RUNTIME_DIR/pipewire-0`; there is no `pipewire/` subdirectory. Only the unit's own verification step was failing, so audio was up while systemd reported the service dead — a false negative that hides the real state, and it also aborts the script before its final `chmod` of the runtime directory. Introduced in f26ec6c (2026-02-03). Same wrong path in the closing summary and in `README-container-audio.md`.

## 2. `write WirePlumber drop-ins as SPA-JSON, not Lua`

This is the one that blocks Bluetooth.

`50-wireplumber-headless.conf` and `60-wireplumber-camera-headless.conf` use Lua syntax — `--` comments and `["key"] = "value"` tables — but WirePlumber 0.5.14 parses `wireplumber.conf.d/*.conf` as SPA-JSON. Both files are rejected whole, at every boot:

```
wp-conf: failed to open '/etc/wireplumber/wireplumber.conf.d/50-wireplumber-headless.conf':
         section 'wireplumber.profiles' has no value
```

So `monitor.bluez.seat-monitoring = disabled` never applies. That matters because the stock `wireplumber.conf` only disables seat monitoring inside `mixin.systemwide-session`, which the `main` profile does **not** inherit — so on a headless board the bluez monitor waits forever for a logind seat that never appears. Exactly the failure the file's own comment warns about.

A/B tested on hardware, twice in each direction:

| `wireplumber.conf.d` contents | `libspa-bluez5` in `/proc/<wireplumber>/maps` |
| --- | --- |
| Lua (as shipped) | **absent** — monitor never loads |
| SPA-JSON (this commit) | **loaded** — speaker enumerates |

These files have been untouched since ddcd91c (2026-01-26) and have never been valid: the `wireplumber.conf.d/*.conf` layout is 0.5-only, while the syntax is 0.4-era, so 0.5 rejects them and 0.4 would have ignored them.

## Verified on a real build

Verified on a freshly flashed `raspberry-pi-4` card written from this PR's own image (`wendy os install --pr 217`) — no hand-applied `/etc` edits anywhere. Both changes are present as built, and on first boot:

```
user@1000.service            active
pipewire-user-setup.service  active   ("Finished Enable PipeWire Audio for wendy User")
libspa-bluez5                loaded into wireplumber
PipeWire socket              /run/user/1000/pipewire-0
```

A Bose Revolve II paired with `wendy device bluetooth connect` — CLI only, no `device shell` — enumerated as a PipeWire **Sink**, and audio played from a container holding only the `audio` entitlement, audible from the speaker.

Bluetooth headset microphones also work on this build: opening a capture stream auto-switches the card to `headset-head-unit`, real audio is captured, and it reverts to `a2dp-sink` on release.

Note on test methodology: `aplay`, `speaker-test` and `wendy device audio list` all go through raw ALSA and pass on a completely dead PipeWire, so they cannot verify any of this. Neither can `busctl --system tree org.bluez` — registered endpoints are exported client-side by WirePlumber and never appear under `org.bluez`, so that tree reads identically on working and broken systems.

## Agent-side fixes are also required

This PR gets the host audio stack working. Two things still need agent changes, tracked in WendyOS#1594:

- **Container audio.** `applyAudio()` prefers `/run/pipewire/pipewire-0` (the system-wide instance, which has no WirePlumber and therefore an empty graph) over the user-session socket, so apps with the `audio` entitlement fall through to raw ALSA and cannot reach Bluetooth at all.
- **Connect-time profile selection.** `Device1.Connect()` connects every profile a device supports, which lets a speaker that also implements A2DP Source claim our sink endpoint — the card then lands on `audio-gateway` with no sink node. Selecting the profile explicitly at connect time is deterministic (6/6 vs 0/6 on hardware) and needs no configuration change here.
