### PR TITLE
Swap Orin Nano Bluetooth to mainline btusb+btrtl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1036,6 +1036,30 @@ jobs:
             python3 scripts/check_game_controller_support.py --config "$CONFIG" --manifest "$MANIFEST"
           done
 
+      # Same evidence pattern for the Bluetooth stack: every image must meet
+      # the BlueZ floor, and machines under the mainline-transport contract
+      # (wendy-bluetooth.inc) must additionally show btusb+btrtl in the
+      # effective config, the rtl_bt firmware + modprobe blacklist packages
+      # present, and the vendor rtk_btusb packages absent. The evidence
+      # config exists only where the contract is enabled; the validator
+      # itself fails contract machines that are missing it.
+      - name: Validate Bluetooth stack
+        working-directory: ${{ github.workspace }}/wendyos
+        env:
+          MAP: ${{ steps.vars.outputs.map }}
+        run: |
+          set -euo pipefail
+          for token in $MAP; do
+            IFS='|' read -r storage board machine <<< "$token"
+            DEPLOY_DIR="$GITHUB_WORKSPACE/build/tmp/deploy/images/$machine"
+            CONFIG="$DEPLOY_DIR/wendyos-bluetooth-$machine.config"
+            MANIFEST=$(find "$DEPLOY_DIR" -maxdepth 1 -name 'wendyos-image-*.manifest' ! -type l -print -quit)
+            [[ -n "$MANIFEST" ]] || { echo "::error::missing image manifest in $DEPLOY_DIR"; exit 1; }
+            ARGS=(--machine "$machine" --manifest "$MANIFEST")
+            [[ -f "$CONFIG" ]] && ARGS+=(--config "$CONFIG")
+            python3 scripts/check_bluetooth_stack.py "${ARGS[@]}"
+          done
+
       # The persistent NVMe cache is written in place by the build (sstate,
       # downloads, repos are symlinked onto it) — no upload/save step needed.
 

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -11,6 +11,7 @@ on:
       - 'scripts/make-jetson-disk-img.py'
       - 'scripts/make_jetson_disk_img_test.py'
       - 'scripts/check_game_controller_support*'
+      - 'scripts/check_bluetooth_stack*'
       - 'recipes-core/wendyos-agent/files/*.sh'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
@@ -23,6 +24,7 @@ on:
       - 'scripts/make-jetson-disk-img.py'
       - 'scripts/make_jetson_disk_img_test.py'
       - 'scripts/check_game_controller_support*'
+      - 'scripts/check_bluetooth_stack*'
       - 'recipes-core/wendyos-agent/files/*.sh'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
@@ -67,3 +69,6 @@ jobs:
 
       - name: Run game-controller support validator tests
         run: python3 -m unittest scripts/check_game_controller_support_test.py
+
+      - name: Run Bluetooth stack validator tests
+        run: python3 -m unittest scripts/check_bluetooth_stack_test.py

--- a/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf
@@ -56,3 +56,24 @@ ROOTFSPART_SIZE_DEFAULT = "25769803776"
 
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "jetson-orin-nano"
+
+# Mainline Bluetooth (btusb+btrtl) replaces NVIDIA's out-of-tree rtk_btusb
+# for the devkit's RTL8822CE radio, which drops BLE HID links in a ~2 s
+# connect/drop loop (kernel side of the swap: wendy-bluetooth.inc via the
+# jp7 kernel bbappend; firmware + modprobe blacklist: tegra-packagegroup-base).
+# These hard assignments override upstream ?= defaults from devkit-wifi.inc
+# and nvidia-kernel-oot.inc; BAD_RECOMMENDATIONS is the catch-all for any
+# other RRECOMMENDS edge that would drag the vendor packages back in.
+# tegra-firmware-rtl8822 is the vendor-layout BT firmware (/lib/firmware
+# root); mainline btrtl loads from linux-firmware-rtl8822's rtl_bt/ instead.
+# Keep in sync with jetson-orin-nano-devkit-wendyos.conf.
+TEGRA_OOT_BLUETOOTH_DRIVERS = ""
+NVIDIA_WIFI = "kernel-module-rtl8822ce"
+LINUX_WIFI = "kernel-module-rtw88-8822ce"
+BAD_RECOMMENDATIONS:append = " \
+    kernel-module-rtk-btusb \
+    nv-kernel-module-rtk-btusb \
+    kernel-module-bluedroid-pm \
+    nv-kernel-module-bluedroid-pm \
+    tegra-firmware-rtl8822 \
+    "

--- a/conf/machine/jetson-orin-nano-devkit-wendyos.conf
+++ b/conf/machine/jetson-orin-nano-devkit-wendyos.conf
@@ -57,3 +57,24 @@ ROOTFSPART_SIZE_DEFAULT = "25769803776"
 
 # Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "jetson-orin-nano"
+
+# Mainline Bluetooth (btusb+btrtl) replaces NVIDIA's out-of-tree rtk_btusb
+# for the devkit's RTL8822CE radio, which drops BLE HID links in a ~2 s
+# connect/drop loop (kernel side of the swap: wendy-bluetooth.inc via the
+# jp7 kernel bbappend; firmware + modprobe blacklist: tegra-packagegroup-base).
+# These hard assignments override upstream ?= defaults from devkit-wifi.inc
+# and nvidia-kernel-oot.inc; BAD_RECOMMENDATIONS is the catch-all for any
+# other RRECOMMENDS edge that would drag the vendor packages back in.
+# tegra-firmware-rtl8822 is the vendor-layout BT firmware (/lib/firmware
+# root); mainline btrtl loads from linux-firmware-rtl8822's rtl_bt/ instead.
+# Keep in sync with jetson-orin-nano-devkit-nvme-wendyos.conf.
+TEGRA_OOT_BLUETOOTH_DRIVERS = ""
+NVIDIA_WIFI = "kernel-module-rtl8822ce"
+LINUX_WIFI = "kernel-module-rtw88-8822ce"
+BAD_RECOMMENDATIONS:append = " \
+    kernel-module-rtk-btusb \
+    nv-kernel-module-rtk-btusb \
+    kernel-module-bluedroid-pm \
+    nv-kernel-module-bluedroid-pm \
+    tegra-firmware-rtl8822 \
+    "

--- a/docs/bluetooth-support.md
+++ b/docs/bluetooth-support.md
@@ -30,9 +30,20 @@ by `rtk-btusb-blacklist` (modprobe policy), and replaced by mainline
 `btusb`+`btrtl` with firmware from `linux-firmware-rtl8822`
 (`rtl_bt/rtl8822cu_fw.bin` + `_config.bin`).
 
+Removing the vendor driver is still only half the swap: NVIDIA's kernel
+tree marks `0bda:c822` `BTUSB_IGNORE` in btusb's device tables so
+`rtk_btusb` could claim it, and with the vendor driver gone `btusb_probe()`
+returns `-ENODEV` for the radio with no dmesg trace — the board simply has
+no `hci0` (observed on the 0.18.1 devkit image). The kernel source patch
+`0001-Bluetooth-btusb-un-ignore-Realtek-RTL8822CE-0bda-c822.patch`
+(machine-gated in the jp7 tegra kernel bbappend, same override as the
+transport fragment) restores the mainline `BTUSB_REALTEK |
+BTUSB_WIDEBAND_SPEECH` entry for that ID.
+
 AGX Orin and Thor intentionally keep the vendor driver until each gets its
 own validated swap: enabling `btusb` while `rtk_btusb` is installed would be
-a probe race on the same USB ID.
+a probe race on the same USB ID — and their kernels keep NVIDIA's IGNORE
+entries, which the machine gating leaves untouched.
 
 ## On-device smoke test (Orin Nano)
 

--- a/docs/bluetooth-support.md
+++ b/docs/bluetooth-support.md
@@ -1,0 +1,49 @@
+# Bluetooth stack support
+
+WendyOS owns Bluetooth with the mainline Linux stack: BlueZ in userspace
+(pairing, trust, reconnect, HID-over-GATT) over in-kernel transports. There
+is no Wendy Bluetooth daemon, and — on boards under the contract below — no
+vendor BT driver.
+
+Every shipping image is checked against a BlueZ floor (5.80) in build CI;
+the blacksail oe-core pin currently ships 5.86. The floor exists because
+BlueZ 5.72 and earlier destroy and recreate the UHID input device on every
+HID-over-GATT reconnect, which breaks controller hotplug expectations.
+
+## The mainline-transport contract
+
+`recipes-kernel/linux/wendy-bluetooth.inc` is an opt-in per-machine
+contract: it requests the mainline Bluetooth core (`bluetooth.cfg`) plus a
+per-BSP transport fragment, validates the post-Kconfig result, and deploys
+the effective config beside the image (`wendyos-bluetooth-<machine>.config`).
+`scripts/check_bluetooth_stack.py` then cross-checks that evidence with the
+image manifest in CI: every `=m` symbol needs its kernel-module package, the
+firmware and modprobe-blacklist packages must be present, and the vendor
+driver packages must be absent.
+
+First adopter: **Jetson Orin Nano devkit** (both storage machines). Its
+RTL8822CE radio (USB `0bda:c822`) is unusable for BLE HID under NVIDIA's
+out-of-tree `rtk_btusb` driver — the link drops in a ~2 s connect/drop loop
+— so that driver is removed at the package level
+(`conf/machine/jetson-orin-nano-devkit*-wendyos.conf`), blocked from loading
+by `rtk-btusb-blacklist` (modprobe policy), and replaced by mainline
+`btusb`+`btrtl` with firmware from `linux-firmware-rtl8822`
+(`rtl_bt/rtl8822cu_fw.bin` + `_config.bin`).
+
+AGX Orin and Thor intentionally keep the vendor driver until each gets its
+own validated swap: enabling `btusb` while `rtk_btusb` is installed would be
+a probe race on the same USB ID.
+
+## On-device smoke test (Orin Nano)
+
+```sh
+dmesg | grep -iE 'btusb|btrtl|rtk'   # expect btusb + RTL firmware lines, zero rtk_* lines
+lsmod | grep -E 'btusb|btrtl'
+bluetoothctl --version               # >= 5.80
+```
+
+Then pair a controller with `wendy device bluetooth connect <address>` and
+follow the game-controller smoke test in
+[game-controller-support.md](game-controller-support.md). For the BLE
+control channel, confirm the device still advertises the Wendy service UUID
+and accepts the L2CAP (PSM 128) mTLS connection from the CLI.

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/0001-Bluetooth-btusb-un-ignore-Realtek-RTL8822CE-0bda-c822.patch
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/0001-Bluetooth-btusb-un-ignore-Realtek-RTL8822CE-0bda-c822.patch
@@ -1,0 +1,51 @@
+From: Ethan <ebrogames@gmail.com>
+Subject: [PATCH] Bluetooth: btusb: un-ignore Realtek RTL8822CE (0bda:c822)
+
+NVIDIA's L4T kernel marks the RTL8822CE Bluetooth function BTUSB_IGNORE
+(in both btusb_table and quirks_table) so their out-of-tree rtk_btusb
+driver can claim the radio without racing btusb. WendyOS removes
+rtk_btusb on the Orin Nano devkit (it drops BLE HID links in a ~2 s
+connect/drop loop) and ships mainline btusb+btrtl instead — but with the
+IGNORE entries in place btusb_probe() returns -ENODEV for the radio and
+no hci device is ever created, silently: no dmesg line, no error,
+Bluetooth simply absent.
+
+Observed on-device (Orin Nano devkit, image 0.18.1, kernel
+6.8.12-l4t-r39.2.0): usb 0bda:c822 enumerates with textbook BT
+endpoints, /sys/class/bluetooth stays empty, and a manual sysfs bind
+fails with "No such device"; both table entries read driver_info=0x1
+(BTUSB_IGNORE) straight out of the shipped btusb.ko.
+
+Restore the mainline driver_info (BTUSB_REALTEK | BTUSB_WIDEBAND_SPEECH)
+for 0bda:c822 so btusb probes the radio and btrtl loads
+rtl_bt/rtl8822cu_fw.bin + rtl8822cu_config.bin, which
+linux-firmware-rtl8822 already ships. The rebranded 13d3:3549 entry is
+left ignored: it is not this board's hardware, and boards still on the
+vendor driver must not gain a probe race.
+
+Upstream-Status: Inappropriate [WendyOS reverts an NVIDIA L4T
+vendor-driver accommodation; mainline already carries these IDs]
+
+---
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -507,7 +507,8 @@
+ 	/* Realtek 8822CE Bluetooth devices */
+ 	{ USB_DEVICE(0x0bda, 0xb00c), .driver_info = BTUSB_REALTEK |
+ 						     BTUSB_WIDEBAND_SPEECH },
+-	{ USB_DEVICE(0x0bda, 0xc822), .driver_info = BTUSB_IGNORE },
++	{ USB_DEVICE(0x0bda, 0xc822), .driver_info = BTUSB_REALTEK |
++						     BTUSB_WIDEBAND_SPEECH },
+ 
+ 	/* Realtek 8822CU Bluetooth devices */
+ 	{ USB_DEVICE(0x13d3, 0x3549), .driver_info = BTUSB_IGNORE },
+@@ -795,7 +796,8 @@
+ 						     BTUSB_WIDEBAND_SPEECH },
+ 	{ USB_DEVICE(0x13d3, 0x3548), .driver_info = BTUSB_REALTEK |
+ 						     BTUSB_WIDEBAND_SPEECH },
+-	{ USB_DEVICE(0x0bda, 0xc822), .driver_info = BTUSB_IGNORE },
++	{ USB_DEVICE(0x0bda, 0xc822), .driver_info = BTUSB_REALTEK |
++						     BTUSB_WIDEBAND_SPEECH },
+ 	{ USB_DEVICE(0x13d3, 0x3549), .driver_info = BTUSB_IGNORE },
+ 	{ USB_DEVICE(0x13d3, 0x3553), .driver_info = BTUSB_REALTEK |
+ 						     BTUSB_WIDEBAND_SPEECH },

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/bluetooth-btusb-rtl.cfg
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/bluetooth-btusb-rtl.cfg
@@ -1,0 +1,12 @@
+# Mainline USB Bluetooth transport for the Orin Nano devkit's RTL8822CE
+# (USB 0bda:c822). btusb probes the radio and btrtl loads
+# rtl_bt/rtl8822cu_fw.bin + rtl8822cu_config.bin from linux-firmware-rtl8822.
+# The NVIDIA rtk_btusb driver for the same radio ships as an out-of-tree
+# module (nvidia-kernel-oot), so it is removed at the package level (see the
+# jetson-orin-nano machine confs), not via a Kconfig disable here. If a
+# future kernel bump brings an in-tree copy, add its symbol to
+# WENDYOS_BLUETOOTH_FORBIDDEN_SYMBOLS in the bbappend.
+
+CONFIG_BT_HCIBTUSB=m
+CONFIG_BT_HCIBTUSB_RTL=y
+CONFIG_BT_RTL=m

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
@@ -15,6 +15,23 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 require recipes-kernel/linux/wendy-game-controller.inc
+require recipes-kernel/linux/wendy-bluetooth.inc
+
+# Mainline Bluetooth transport, Orin Nano devkit only: its RTL8822CE radio is
+# unusable for BLE HID under the vendor rtk_btusb driver (~2 s connect/drop
+# loop), so that module is removed at the package level in the
+# jetson-orin-nano-devkit*-wendyos machine confs and btusb+btrtl take over.
+# AGX Orin / Thor keep the vendor driver until they get their own validated
+# swap — enabling btusb while rtk_btusb is still installed would be a probe
+# race on the same USB ID. The jetson-orin-nano-devkit override token covers
+# both storage machines (their -wendyos confs prepend it to MACHINEOVERRIDES).
+WENDYOS_BLUETOOTH_ENABLE:jetson-orin-nano-devkit = "1"
+SRC_URI:append:jetson-orin-nano-devkit = " file://bluetooth-btusb-rtl.cfg"
+WENDYOS_BLUETOOTH_EXTRA_SYMBOLS:jetson-orin-nano-devkit = " \
+    CONFIG_BT_HCIBTUSB \
+    CONFIG_BT_HCIBTUSB_RTL \
+    CONFIG_BT_RTL \
+    "
 
 SRC_URI += " \
     file://usb-gadget.cfg \

--- a/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
+++ b/meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
@@ -26,7 +26,16 @@ require recipes-kernel/linux/wendy-bluetooth.inc
 # race on the same USB ID. The jetson-orin-nano-devkit override token covers
 # both storage machines (their -wendyos confs prepend it to MACHINEOVERRIDES).
 WENDYOS_BLUETOOTH_ENABLE:jetson-orin-nano-devkit = "1"
-SRC_URI:append:jetson-orin-nano-devkit = " file://bluetooth-btusb-rtl.cfg"
+# The config fragment alone is not enough: NVIDIA's kernel tree marks the
+# devkit radio's USB ID (0bda:c822) BTUSB_IGNORE in btusb's device tables so
+# rtk_btusb can claim it, which makes btusb_probe() return -ENODEV with no
+# dmesg trace once the vendor driver is gone. The source patch restores the
+# mainline driver_info for that ID; it is gated to the same machines as the
+# fragment so vendor-driver boards keep NVIDIA's tables untouched.
+SRC_URI:append:jetson-orin-nano-devkit = " \
+    file://bluetooth-btusb-rtl.cfg \
+    file://0001-Bluetooth-btusb-un-ignore-Realtek-RTL8822CE-0bda-c822.patch \
+    "
 WENDYOS_BLUETOOTH_EXTRA_SYMBOLS:jetson-orin-nano-devkit = " \
     CONFIG_BT_HCIBTUSB \
     CONFIG_BT_HCIBTUSB_RTL \

--- a/meta-tegra-extensions/recipes-kernel/rtk-btusb-blacklist/rtk-btusb-blacklist/rtk-btusb-blacklist.conf
+++ b/meta-tegra-extensions/recipes-kernel/rtk-btusb-blacklist/rtk-btusb-blacklist/rtk-btusb-blacklist.conf
@@ -1,0 +1,10 @@
+# Keep the NVIDIA out-of-tree Realtek BT driver off the RTL8822CE so only
+# mainline btusb binds the radio. blacklist stops the udev modalias autoload;
+# the install override also stops any explicit or dependency-driven load,
+# which blacklist alone does not.
+blacklist rtk_btusb
+install rtk_btusb /bin/false
+# btcoex ships inside the vendor driver source; harmless if no such module
+# exists, decisive if a future package splits it out.
+blacklist rtk_btcoex
+install rtk_btcoex /bin/false

--- a/meta-tegra-extensions/recipes-kernel/rtk-btusb-blacklist/rtk-btusb-blacklist_1.0.bb
+++ b/meta-tegra-extensions/recipes-kernel/rtk-btusb-blacklist/rtk-btusb-blacklist_1.0.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Keep NVIDIA's out-of-tree rtk_btusb off the Realtek BT radio"
+DESCRIPTION = "Jetson Orin Nano devkits use mainline btusb+btrtl for the \
+RTL8822CE Bluetooth radio; the vendor rtk_btusb driver drops BLE HID links \
+in a ~2 s connect/drop loop. Its packages are removed from the image, and \
+this modprobe policy guarantees a stray copy (stale OTA overlay, future \
+packaging regression) can never bind the radio first."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI = "file://rtk-btusb-blacklist.conf"
+
+S = "${UNPACKDIR}"
+
+do_install() {
+    install -d ${D}${sysconfdir}/modprobe.d
+    install -m 0644 ${UNPACKDIR}/rtk-btusb-blacklist.conf ${D}${sysconfdir}/modprobe.d/
+}

--- a/recipes-core/packagegroups/packagegroup-wendyos-kernel.bb
+++ b/recipes-core/packagegroups/packagegroup-wendyos-kernel.bb
@@ -29,3 +29,20 @@ WENDYOS_GAME_CONTROLLER_MODULE_PACKAGES = " \
     "
 
 RRECOMMENDS:${PN}:append = "${@' ' + d.getVar('WENDYOS_GAME_CONTROLLER_MODULE_PACKAGES') if d.getVar('WENDYOS_GAME_CONTROLLER_ENABLE') == '1' else ''}"
+
+# Mainline Bluetooth contract (wendy-bluetooth.inc): same RRECOMMENDS
+# rationale as above — a package exists only where the effective config
+# resolved =m, and CI cross-checks the outcome. Opt-in per machine, matching
+# the kernel-side WENDYOS_BLUETOOTH_ENABLE gating; first adopter is the Orin
+# Nano devkit (both storage machines share the jetson-orin-nano-devkit
+# override).
+WENDYOS_BLUETOOTH_ENABLE ?= "0"
+WENDYOS_BLUETOOTH_ENABLE:jetson-orin-nano-devkit = "1"
+WENDYOS_BLUETOOTH_MODULE_PACKAGES = " \
+    kernel-module-bluetooth \
+    kernel-module-btusb \
+    kernel-module-btrtl \
+    kernel-module-rfcomm \
+    "
+
+RRECOMMENDS:${PN}:append = "${@' ' + d.getVar('WENDYOS_BLUETOOTH_MODULE_PACKAGES') if d.getVar('WENDYOS_BLUETOOTH_ENABLE') == '1' else ''}"

--- a/recipes-core/packagegroups/tegra-packagegroup-base.inc
+++ b/recipes-core/packagegroups/tegra-packagegroup-base.inc
@@ -39,3 +39,14 @@ RDEPENDS:${PN}:append = " optee-os"
 # The mount itself self-gates on /data via RequiresMountsFor=/data, so it is
 # inert on any Tegra config that lacks a /data partition.
 RDEPENDS:${PN}:append = " systemd-mount-tee"
+
+# Mainline Bluetooth for the Orin Nano devkit's RTL8822CE: btrtl loads its
+# firmware from linux-firmware-rtl8822 (rtl_bt/ layout), and the modprobe
+# blacklist keeps the removed vendor rtk_btusb driver from ever binding the
+# radio first. Hard RDEPENDS on purpose: these are the runtime halves of the
+# wendy-bluetooth.inc kernel contract, and CI's check_bluetooth_stack.py
+# fails the build if either goes missing from the image manifest.
+RDEPENDS:${PN}:append:jetson-orin-nano-devkit = " \
+    linux-firmware-rtl8822 \
+    rtk-btusb-blacklist \
+    "

--- a/recipes-kernel/linux/files/bluetooth.cfg
+++ b/recipes-kernel/linux/files/bluetooth.cfg
@@ -1,0 +1,13 @@
+# Mainline Bluetooth core for boards on the WendyOS bluetooth contract.
+#
+# Core stack and the protocol layers WendyOS relies on: BLE + BR/EDR dual
+# mode, RFCOMM for serial-profile peripherals, HIDP for classic HID. The
+# board-specific transport driver (e.g. btusb+btrtl) comes from a separate
+# per-BSP fragment so this one stays hardware-neutral.
+
+CONFIG_BT=m
+CONFIG_BT_BREDR=y
+CONFIG_BT_LE=y
+CONFIG_BT_RFCOMM=m
+CONFIG_BT_RFCOMM_TTY=y
+CONFIG_BT_HIDP=m

--- a/recipes-kernel/linux/wendy-bluetooth.inc
+++ b/recipes-kernel/linux/wendy-bluetooth.inc
@@ -1,0 +1,58 @@
+# Shared WendyOS Bluetooth-transport kernel contract.
+#
+# Unlike the game-controller contract, this one is opt-in per machine: it
+# exists to pin a board to the mainline Bluetooth stack (btusb and friends)
+# where a BSP would otherwise ship a vendor driver for the same radio. A
+# vendor and a mainline driver both claiming one USB ID is a probe race, so
+# a board must only enable this once its vendor driver is actually removed.
+#
+# First adopter: Jetson Orin Nano (RTL8822CE on USB 0bda:c822), whose NVIDIA
+# out-of-tree rtk_btusb driver drops BLE HID links in a ~2 s connect/drop
+# loop. The mainline btusb+btrtl pair replaces it.
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+WENDYOS_BLUETOOTH_ENABLE ?= "0"
+SRC_URI:append = "${@' file://bluetooth.cfg' if d.getVar('WENDYOS_BLUETOOTH_ENABLE') == '1' else ''}"
+
+WENDYOS_BLUETOOTH_SYMBOLS = " \
+    CONFIG_BT \
+    CONFIG_BT_RFCOMM \
+    CONFIG_BT_HIDP \
+    ${WENDYOS_BLUETOOTH_EXTRA_SYMBOLS} \
+    "
+# Transport symbols the adopting BSP appends (e.g. CONFIG_BT_HCIBTUSB).
+WENDYOS_BLUETOOTH_EXTRA_SYMBOLS ?= ""
+
+# Symbols that must NOT resolve =y or =m — an in-tree vendor driver that
+# would race the mainline stack for the same hardware. Package-level vendor
+# drivers are excluded by the image validator instead (they never appear in
+# the kernel config).
+WENDYOS_BLUETOOTH_FORBIDDEN_SYMBOLS ?= ""
+
+# Validate the effective config after Kconfig has resolved all BSP
+# dependencies, same rationale as wendy-game-controller.inc: a fragment is a
+# request, not a guarantee.
+do_configure:append() {
+    [ "${WENDYOS_BLUETOOTH_ENABLE}" = "1" ] || return 0
+    config="${B}/.config"
+    [ -f "$config" ] || bbfatal "bluetooth: effective kernel config not found at $config"
+
+    for symbol in ${WENDYOS_BLUETOOTH_SYMBOLS}; do
+        if ! grep -Eq "^${symbol}=(y|m)$" "$config"; then
+            bbfatal "bluetooth: ${symbol} is neither built-in nor modular in $config"
+        fi
+    done
+    for symbol in ${WENDYOS_BLUETOOTH_FORBIDDEN_SYMBOLS}; do
+        if grep -Eq "^${symbol}=(y|m)$" "$config"; then
+            bbfatal "bluetooth: vendor driver symbol ${symbol} is still enabled in $config"
+        fi
+    done
+}
+
+# Publish the exact config checked above beside the image artifacts; CI
+# cross-checks it against the image manifest (=m needs its kernel-module
+# package present, vendor packages must be absent).
+do_deploy:append() {
+    [ "${WENDYOS_BLUETOOTH_ENABLE}" = "1" ] || return 0
+    install -m 0644 "${B}/.config" "${DEPLOYDIR}/wendyos-bluetooth-${MACHINE}.config"
+}

--- a/scripts/check_bluetooth_stack.py
+++ b/scripts/check_bluetooth_stack.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate the WendyOS Bluetooth stack: BlueZ floor and, on machines under
+the mainline-transport contract, effective kernel config plus the presence
+of the mainline driver/firmware packages and the absence of the vendor
+driver packages they replace."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+# Every shipping image must carry at least this BlueZ. The blacksail oe-core
+# pin ships 5.86; the floor guards against a pin rollback past the HoG/uhid
+# reconnect fixes (uhid persistence landed in 5.73, stabilized by 5.7x).
+BLUEZ_PACKAGE = "bluez5"
+BLUEZ_MIN_VERSION = (5, 80)
+
+# Machines under the full mainline-Bluetooth contract (wendy-bluetooth.inc).
+# Matched as a prefix so both storage variants of a devkit are covered.
+FULL_PROFILE_MACHINE_PREFIXES = ("jetson-orin-nano-devkit",)
+
+# Symbols the contract requires as y|m; =m additionally requires the module
+# package in this exact image.
+MODULE_PACKAGES = {
+    "CONFIG_BT": "kernel-module-bluetooth",
+    "CONFIG_BT_RFCOMM": "kernel-module-rfcomm",
+    "CONFIG_BT_HCIBTUSB": "kernel-module-btusb",
+    "CONFIG_BT_RTL": "kernel-module-btrtl",
+}
+
+# Bool symbols that must resolve =y (they gate behavior inside their parent
+# module rather than producing one of their own).
+BUILTIN_SYMBOLS = ("CONFIG_BT_BREDR", "CONFIG_BT_LE", "CONFIG_BT_HCIBTUSB_RTL")
+
+REQUIRED_PACKAGES = ("linux-firmware-rtl8822", "rtk-btusb-blacklist")
+
+# The vendor driver this contract replaces. Any of these in the manifest
+# means the removal regressed and the vendor module could race btusb for
+# the radio. Prefixed and un-prefixed module package names both count
+# (KERNEL_MODULE_PACKAGE_PREFIX aliases via RPROVIDES).
+FORBIDDEN_PACKAGE_PATTERNS = (
+    r"(nv-)?kernel-module-rtk-btusb",
+    r"tegra-firmware-rtl8822",
+)
+
+
+def read_config(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = re.fullmatch(r"(CONFIG_[A-Z0-9_]+)=(y|m)", line.strip())
+        if match:
+            values[match.group(1)] = match.group(2)
+    return values
+
+
+def read_manifest(path: Path) -> dict[str, str]:
+    """Map package name -> version ('' when the manifest line has none)."""
+
+    packages: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        fields = line.split()
+        if fields:
+            packages[fields[0]] = fields[2] if len(fields) >= 3 else ""
+    return packages
+
+
+def manifest_has(packages: dict[str, str], expected: str) -> bool:
+    """Accept Yocto's exact RPROVIDE or version-suffixed package name."""
+
+    versioned = re.compile(rf"^{re.escape(expected)}-[0-9].*$")
+    return expected in packages or any(versioned.fullmatch(package) for package in packages)
+
+
+def parse_version(version: str) -> tuple[int, ...]:
+    numbers = re.match(r"(\d+(?:\.\d+)*)", version)
+    if not numbers:
+        return ()
+    return tuple(int(part) for part in numbers.group(1).split("."))
+
+
+def validate_bluez(packages: dict[str, str]) -> list[str]:
+    if not manifest_has(packages, BLUEZ_PACKAGE):
+        return [f"{BLUEZ_PACKAGE} is absent from the image manifest"]
+    version = packages.get(BLUEZ_PACKAGE, "")
+    parsed = parse_version(version)
+    if not parsed:
+        return [f"{BLUEZ_PACKAGE} version {version!r} is unparseable"]
+    if parsed < BLUEZ_MIN_VERSION:
+        floor = ".".join(str(part) for part in BLUEZ_MIN_VERSION)
+        return [f"{BLUEZ_PACKAGE} {version} is older than the {floor} floor"]
+    return []
+
+
+def validate_full_profile(config: dict[str, str], packages: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    for symbol, module_package in MODULE_PACKAGES.items():
+        state = config.get(symbol)
+        if state not in {"y", "m"}:
+            errors.append(f"{symbol} is not enabled (effective value: {state or 'unset'})")
+        elif state == "m" and not manifest_has(packages, module_package):
+            errors.append(f"{symbol}=m but {module_package} is absent from the image manifest")
+    for symbol in BUILTIN_SYMBOLS:
+        if config.get(symbol) != "y":
+            errors.append(f"{symbol} must resolve =y (effective value: {config.get(symbol) or 'unset'})")
+    for package in REQUIRED_PACKAGES:
+        if not manifest_has(packages, package):
+            errors.append(f"required package {package} is absent from the image manifest")
+    for pattern in FORBIDDEN_PACKAGE_PATTERNS:
+        forbidden = re.compile(rf"^{pattern}(-[0-9].*)?$")
+        for package in sorted(packages):
+            if forbidden.fullmatch(package):
+                errors.append(f"vendor package {package} must not be in the image manifest")
+    return errors
+
+
+def machine_has_full_profile(machine: str) -> bool:
+    return machine.startswith(FULL_PROFILE_MACHINE_PREFIXES)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--machine", required=True, help="Yocto MACHINE the manifest belongs to")
+    parser.add_argument("--manifest", required=True, type=Path, help="wendyos-image package manifest")
+    parser.add_argument("--config", type=Path, help="effective kernel .config (required for contract machines)")
+    args = parser.parse_args(argv)
+
+    packages = read_manifest(args.manifest)
+    errors = validate_bluez(packages)
+
+    if machine_has_full_profile(args.machine):
+        if args.config is None:
+            errors.append(
+                f"machine {args.machine} is under the Bluetooth contract but no "
+                "--config was provided (wendyos-bluetooth-<machine>.config missing?)"
+            )
+        else:
+            errors.extend(validate_full_profile(read_config(args.config), packages))
+
+    if errors:
+        for error in errors:
+            print(f"bluetooth stack error: {error}", file=sys.stderr)
+        return 1
+
+    scope = "full contract" if machine_has_full_profile(args.machine) else "bluez floor"
+    print(f"bluetooth stack OK ({scope}): {args.machine} + {args.manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_bluetooth_stack_test.py
+++ b/scripts/check_bluetooth_stack_test.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import tempfile
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_bluetooth_stack as checker  # noqa: E402
+
+
+def full_config(**overrides: str) -> dict[str, str]:
+    config = {symbol: "m" for symbol in checker.MODULE_PACKAGES}
+    config.update({symbol: "y" for symbol in checker.BUILTIN_SYMBOLS})
+    config.update(overrides)
+    return config
+
+
+def full_packages(**overrides: str) -> dict[str, str]:
+    packages = {checker.BLUEZ_PACKAGE: "5.86"}
+    packages.update({package: "6.8.12" for package in checker.MODULE_PACKAGES.values()})
+    packages.update({package: "1.0" for package in checker.REQUIRED_PACKAGES})
+    packages.update(overrides)
+    return packages
+
+
+class BluezFloorTests(unittest.TestCase):
+    def test_current_pin_passes(self):
+        self.assertEqual(checker.validate_bluez({"bluez5": "5.86"}), [])
+
+    def test_scarthgap_bluez_fails_the_floor(self):
+        errors = checker.validate_bluez({"bluez5": "5.72"})
+        self.assertTrue(any("older than" in error for error in errors))
+
+    def test_missing_and_unparseable_bluez_are_reported(self):
+        self.assertTrue(any("absent" in e for e in checker.validate_bluez({})))
+        self.assertTrue(any("unparseable" in e for e in checker.validate_bluez({"bluez5": "git"})))
+
+
+class FullProfileTests(unittest.TestCase):
+    def test_clean_contract_image_passes(self):
+        self.assertEqual(checker.validate_full_profile(full_config(), full_packages()), [])
+
+    def test_builtin_symbols_need_no_module_packages(self):
+        config = full_config(**{symbol: "y" for symbol in checker.MODULE_PACKAGES})
+        packages = full_packages()
+        for module_package in checker.MODULE_PACKAGES.values():
+            packages.pop(module_package)
+        self.assertEqual(checker.validate_full_profile(config, packages), [])
+
+    def test_modular_symbol_without_package_is_reported(self):
+        packages = full_packages()
+        packages.pop("kernel-module-btusb")
+        errors = checker.validate_full_profile(full_config(), packages)
+        self.assertTrue(any("kernel-module-btusb" in error for error in errors))
+
+    def test_bool_symbols_must_be_builtin(self):
+        errors = checker.validate_full_profile(
+            full_config(CONFIG_BT_HCIBTUSB_RTL="m"), full_packages()
+        )
+        self.assertTrue(any("CONFIG_BT_HCIBTUSB_RTL must resolve =y" in error for error in errors))
+
+    def test_missing_firmware_or_blacklist_is_reported(self):
+        for required in checker.REQUIRED_PACKAGES:
+            packages = full_packages()
+            packages.pop(required)
+            errors = checker.validate_full_profile(full_config(), packages)
+            self.assertTrue(any(required in error for error in errors), required)
+
+    def test_vendor_packages_are_forbidden_in_any_spelling(self):
+        for vendor in (
+            "kernel-module-rtk-btusb",
+            "nv-kernel-module-rtk-btusb",
+            "nv-kernel-module-rtk-btusb-6.8.12-wendy",
+            "tegra-firmware-rtl8822",
+        ):
+            errors = checker.validate_full_profile(full_config(), full_packages(**{vendor: "1.0"}))
+            self.assertTrue(any(vendor in error for error in errors), vendor)
+
+
+class MachineScopeTests(unittest.TestCase):
+    def test_only_orin_nano_devkits_carry_the_full_profile(self):
+        self.assertTrue(checker.machine_has_full_profile("jetson-orin-nano-devkit-nvme-wendyos"))
+        self.assertTrue(checker.machine_has_full_profile("jetson-orin-nano-devkit-wendyos"))
+        self.assertFalse(checker.machine_has_full_profile("jetson-agx-orin-devkit-wendyos"))
+        self.assertFalse(checker.machine_has_full_profile("rpi5-wendyos"))
+
+    def test_cli_floor_only_for_non_contract_machine(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "wendyos-image.manifest"
+            manifest.write_text("bluez5 aarch64 5.86\n", encoding="utf-8")
+            self.assertEqual(
+                checker.main(["--machine", "rpi5-wendyos", "--manifest", str(manifest)]), 0
+            )
+
+    def test_cli_contract_machine_requires_config(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "wendyos-image.manifest"
+            manifest.write_text("bluez5 aarch64 5.86\n", encoding="utf-8")
+            self.assertEqual(
+                checker.main(
+                    ["--machine", "jetson-orin-nano-devkit-nvme-wendyos", "--manifest", str(manifest)]
+                ),
+                1,
+            )
+
+    def test_cli_parses_real_file_shapes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = root / ".config"
+            manifest = root / "wendyos-image.manifest"
+            config.write_text(
+                "\n".join(f"{symbol}={state}" for symbol, state in full_config().items()) + "\n",
+                encoding="utf-8",
+            )
+            manifest.write_text(
+                "\n".join(f"{package} aarch64 {version}" for package, version in full_packages().items())
+                + "\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                checker.main(
+                    [
+                        "--machine",
+                        "jetson-orin-nano-devkit-nvme-wendyos",
+                        "--manifest",
+                        str(manifest),
+                        "--config",
+                        str(config),
+                    ]
+                ),
+                0,
+            )
+
+
+class BluetoothLayerWiringTests(unittest.TestCase):
+    def test_jp7_kernel_append_wires_the_contract(self):
+        append = (
+            REPO_ROOT
+            / "meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend"
+        ).read_text(encoding="utf-8")
+        self.assertIn("require recipes-kernel/linux/wendy-bluetooth.inc", append)
+        self.assertIn('WENDYOS_BLUETOOTH_ENABLE:jetson-orin-nano-devkit = "1"', append)
+        self.assertIn("file://bluetooth-btusb-rtl.cfg", append)
+
+    def test_fragments_cover_the_validator_symbols(self):
+        core = (REPO_ROOT / "recipes-kernel/linux/files/bluetooth.cfg").read_text(encoding="utf-8")
+        transport = (
+            REPO_ROOT
+            / "meta-tegra-extensions-jp7/recipes-kernel/linux/linux-noble-nvidia-tegra/bluetooth-btusb-rtl.cfg"
+        ).read_text(encoding="utf-8")
+        fragment_symbols = {
+            line.split("=", 1)[0]
+            for text in (core, transport)
+            for line in text.splitlines()
+            if line.startswith("CONFIG_") and "=" in line
+        }
+        self.assertTrue(set(checker.MODULE_PACKAGES).issubset(fragment_symbols))
+        self.assertTrue(set(checker.BUILTIN_SYMBOLS).issubset(fragment_symbols))
+
+    def test_machine_confs_remove_the_vendor_driver(self):
+        for conf in (
+            "conf/machine/jetson-orin-nano-devkit-nvme-wendyos.conf",
+            "conf/machine/jetson-orin-nano-devkit-wendyos.conf",
+        ):
+            with self.subTest(conf=conf):
+                text = (REPO_ROOT / conf).read_text(encoding="utf-8")
+                self.assertIn('TEGRA_OOT_BLUETOOTH_DRIVERS = ""', text)
+                self.assertIn("kernel-module-rtk-btusb", text)
+                self.assertIn("tegra-firmware-rtl8822", text)
+
+    def test_packagegroups_carry_runtime_halves(self):
+        kernel_group = (
+            REPO_ROOT / "recipes-core/packagegroups/packagegroup-wendyos-kernel.bb"
+        ).read_text(encoding="utf-8")
+        base_group = (
+            REPO_ROOT / "recipes-core/packagegroups/tegra-packagegroup-base.inc"
+        ).read_text(encoding="utf-8")
+        self.assertIn('WENDYOS_BLUETOOTH_ENABLE:jetson-orin-nano-devkit = "1"', kernel_group)
+        self.assertIn("kernel-module-btrtl", kernel_group)
+        self.assertIn("linux-firmware-rtl8822", base_group)
+        self.assertIn("rtk-btusb-blacklist", base_group)
+
+    def test_blacklist_recipe_blocks_both_vendor_modules(self):
+        conf = (
+            REPO_ROOT
+            / "meta-tegra-extensions/recipes-kernel/rtk-btusb-blacklist/rtk-btusb-blacklist/rtk-btusb-blacklist.conf"
+        ).read_text(encoding="utf-8")
+        for module in ("rtk_btusb", "rtk_btcoex"):
+            self.assertIn(f"blacklist {module}", conf)
+            self.assertIn(f"install {module} /bin/false", conf)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an opt-in per-machine Bluetooth kernel contract (`wendy-bluetooth.inc`, same shape as the game-controller contract from #218) with required and forbidden symbol validation and a deployed evidence config
- enable it for both Jetson Orin Nano devkit machines with a btusb+btrtl transport fragment
- remove the NVIDIA out-of-tree `rtk_btusb` driver at the package level (machine-conf overrides + `BAD_RECOMMENDATIONS`) and guarantee it can never bind first via a modprobe blacklist recipe
- ship `linux-firmware-rtl8822` (the `rtl_bt/` layout mainline btrtl loads) through tegra-packagegroup-base, and recommend the =m Bluetooth module packages through packagegroup-wendyos-kernel
- validate in CI with `scripts/check_bluetooth_stack.py`: a BlueZ ≥5.80 floor on every image (the blacksail pin ships 5.86), and on contract machines the effective kernel config, required packages, and the absence of the vendor packages

## Why

The devkit's RTL8822CE radio (USB 0bda:c822) drops BLE HID links in a metronomic ~2 s connect/drop loop under `rtk_btusb`: observed on the Rosmaster car as 62 uhid create/destroy cycles in 122 s, with one kernel "Bad flag" line per cycle and the ring buffer wrapped by `rtk_btcoex` debug spam. The same hardware+driver combo is broken on stock JetPack with no known fix (NVIDIA forum 274090). Wired USB proves everything above the transport is healthy, and the image already runs BlueZ 5.86 — the vendor transport is the remaining lever.

AGX Orin and Thor intentionally keep the vendor driver until each gets its own validated swap: enabling btusb while rtk_btusb is installed would race probes on the same USB ID.

## Dependencies and rollout

Stacked on #218 (`agent/native-gamepad-kernel`) — merges after it. The companion agent-side pairing-flow fix is wendylabsinc/WendyOS#1595.

## Validation

- `python3 -m unittest scripts/check_bluetooth_stack_test.py` — 18 tests
- `python3 -m unittest scripts/check_game_controller_support_test.py` still green
- both workflow files parse
- `git diff --check`

## Hardware acceptance still required

- flash the Orin Nano car; dmesg shows btusb probing 0bda:c822 and `RTL: firmware rtl_bt/rtl8822cu_fw.bin`, zero rtk_* lines
- `wendy device bluetooth` scan/connect/forget; BLE discovery advert + L2CAP mTLS channel; A2DP via wireplumber; a bluetooth-entitled app through the D-Bus proxy
- Xbox controller fresh pair, evdev arrival, 30-minute soak with concurrent wlan0 iperf3 (coex watch), controller power-cycle auto-reconnect
- warm reboots and an A/B OTA from a vendor-driver build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
