### PR TITLE
fix(bluetooth): keep pairing state across OTA updates

### DIFF
--- a/recipes-core/systemd-mount-wendy/files/bluetooth-persist-state.conf
+++ b/recipes-core/systemd-mount-wendy/files/bluetooth-persist-state.conf
@@ -1,0 +1,11 @@
+[Unit]
+# bluetoothd loads /var/lib/bluetooth once, at startup. Without this it can
+# race the bind mount and come up against the empty rootfs directory, which
+# looks exactly like "nothing was ever paired" -- intermittently, and only on
+# some boots. RequiresMountsFor pulls in var-lib-bluetooth.mount and orders
+# after it, so the state is always in place before bluetoothd reads it.
+#
+# This is Requires=, not Wants=: a failed mount stops bluetoothd starting at all
+# rather than letting it come up silently amnesiac on the rootfs. Deliberate --
+# a forgotten pairing on an unattended appliance is worse than a failed unit.
+RequiresMountsFor=/var/lib/bluetooth

--- a/recipes-core/systemd-mount-wendy/files/var-lib-bluetooth.mount
+++ b/recipes-core/systemd-mount-wendy/files/var-lib-bluetooth.mount
@@ -1,0 +1,36 @@
+[Unit]
+Description=Bind mount /var/lib/bluetooth (Bluetooth pairing state) from data partition
+Documentation=man:systemd.mount(5)
+
+# BlueZ stores pairing state -- link keys, device names, the Trusted flag --
+# under /var/lib/bluetooth. By default that path is on the A/B rootfs, so every
+# OTA boots a slot with an empty directory and the device forgets every
+# peripheral it was paired with. Back it with /data/bluetooth (persists across
+# A/B switches), same pattern as /var/lib/wendy -> /data/wendy.
+
+# Ensure data partition is mounted and the directory has been created with the
+# restrictive mode link keys require.
+RequiresMountsFor=/data
+After=data.mount
+After=wendyos-bluetooth-state.service
+Requires=wendyos-bluetooth-state.service
+
+# Wait for the /data fs grow, same as var-lib-wendy.mount and
+# var-lib-containerd.mount. Board-specific, inert where absent.
+After=grow-data-fs-online.service
+
+# bluetoothd reads this directory once at startup, so mounting it afterwards
+# would leave it seeing an empty state and treating paired devices as unknown.
+# bluetooth.service carries a RequiresMountsFor drop-in for the same reason;
+# this ordering covers the case where it is started in the same transaction.
+Before=bluetooth.service
+DefaultDependencies=no
+
+[Mount]
+What=/data/bluetooth
+Where=/var/lib/bluetooth
+Type=none
+Options=bind,nosuid,nodev,noexec,x-systemd.mkdir
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-wendy/files/wendyos-bluetooth-state.service
+++ b/recipes-core/systemd-mount-wendy/files/wendyos-bluetooth-state.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Prepare persistent Bluetooth state directory on the data partition
+Documentation=man:systemd.mount(5)
+
+# The bind mount needs /data/bluetooth to already exist: x-systemd.mkdir creates
+# the mount point, never the source, so without this var-lib-bluetooth.mount
+# fails outright ("Failed to chase path"). Not optional hardening -- deleting
+# this unit takes Bluetooth down on any device whose /data lacks the directory.
+#
+# 0700 because /var/lib/bluetooth holds link keys: the info files are 0600, but
+# a listable directory still names every paired peripheral.
+RequiresMountsFor=/data
+After=data.mount
+Before=var-lib-bluetooth.mount
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/install -d -m 0700 -o root -g root /data/bluetooth
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
+++ b/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
@@ -1,7 +1,8 @@
-SUMMARY = "Systemd mount unit for persistent wendy volume storage"
-DESCRIPTION = "Bind mounts /var/lib/wendy from /data/wendy so persistent app volumes \
-(created under /var/lib/wendy/volumes by the agent) live on the /data partition instead \
-of the small A/B rootfs. Keeps volume data off the rootfs and surviving A/B OTA swaps."
+SUMMARY = "Systemd mount units for state that must survive an A/B OTA swap"
+DESCRIPTION = "Bind mounts state that must outlive an A/B OTA swap from the /data \
+partition instead of the small A/B rootfs: /var/lib/wendy for persistent app volumes \
+(created under /var/lib/wendy/volumes by the agent), and /var/lib/bluetooth for BlueZ \
+pairing state, which the device would otherwise forget on every update."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
@@ -9,17 +10,36 @@ inherit systemd
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI = "file://var-lib-wendy.mount"
+SRC_URI = " \
+    file://var-lib-wendy.mount \
+    file://var-lib-bluetooth.mount \
+    file://wendyos-bluetooth-state.service \
+    file://bluetooth-persist-state.conf \
+"
 S = "${UNPACKDIR}"
 
-SYSTEMD_SERVICE:${PN} = "var-lib-wendy.mount"
+SYSTEMD_SERVICE:${PN} = "var-lib-wendy.mount var-lib-bluetooth.mount wendyos-bluetooth-state.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
 do_install() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/var-lib-wendy.mount ${D}${systemd_system_unitdir}/var-lib-wendy.mount
+    install -m 0644 ${UNPACKDIR}/var-lib-bluetooth.mount ${D}${systemd_system_unitdir}/var-lib-bluetooth.mount
+    install -m 0644 ${UNPACKDIR}/wendyos-bluetooth-state.service \
+        ${D}${systemd_system_unitdir}/wendyos-bluetooth-state.service
+
+    # Drop-in rather than a bbappend on bluez5: the ordering requirement comes
+    # from this recipe's mount unit, so it belongs with it.
+    install -d ${D}${systemd_system_unitdir}/bluetooth.service.d
+    install -m 0644 ${UNPACKDIR}/bluetooth-persist-state.conf \
+        ${D}${systemd_system_unitdir}/bluetooth.service.d/persist-state.conf
 }
 
-FILES:${PN} += "${systemd_system_unitdir}/var-lib-wendy.mount"
+FILES:${PN} += " \
+    ${systemd_system_unitdir}/var-lib-wendy.mount \
+    ${systemd_system_unitdir}/var-lib-bluetooth.mount \
+    ${systemd_system_unitdir}/wendyos-bluetooth-state.service \
+    ${systemd_system_unitdir}/bluetooth.service.d/persist-state.conf \
+"
 
 RDEPENDS:${PN} = "systemd"


### PR DESCRIPTION
Hardware-validated on a Raspberry Pi 4 (see **Validation** below). Joannis raised the same issue independently.

## Problem

BlueZ stores its pairing state — link keys, device names, the `Trusted` flag — under `/var/lib/bluetooth`, which sits on the A/B rootfs. Every OTA boots the *other* slot, whose copy is empty, so the device forgets every peripheral it has ever paired with. On a product designed to run unattended, that means someone has to physically put a speaker back into pairing mode after each update.

Confirmed on a Raspberry Pi 4: `/var/lib/bluetooth` is plain rootfs, covered by no mount, and a paired speaker is gone after an update.

## Fix

Bind `/data/bluetooth` → `/var/lib/bluetooth`, the pattern already used for `/var/lib/wendy` and `/var/lib/containerd`. `var-lib-wendy.mount`'s own comment describes the identical failure for app volumes.

Three details the obvious version gets wrong:

**The source directory must be created explicitly.** `x-systemd.mkdir` creates the *mount point*, never the bind source, so without a preparatory step the mount fails outright. Verified directly:

```
systemd-mount --options=bind,x-systemd.mkdir --type=none /tmp/bmsrc /tmp/bmdst
→ Failed to chase path '/tmp/bmsrc': No such file or directory   (nothing created, nothing mounted)
```

A oneshot creates `/data/bluetooth` before the mount. This is load-bearing, not hardening — deleting it takes Bluetooth down on any device whose `/data` lacks the directory.

**Permissions.** The same oneshot creates the directory `0700`. The `info` files are `0600`, so link keys would not be exposed, but a listable directory names the address of every paired peripheral.

**Ordering.** `bluetoothd` reads `/var/lib/bluetooth` once at startup. A mount landing after it leaves bluetoothd looking at the empty rootfs directory, which presents as "nothing was ever paired" — intermittently, depending on how the units happen to order on a given boot. `bluetooth.service` therefore gets a `RequiresMountsFor=/var/lib/bluetooth` drop-in, which makes systemd pull in the mount and order after it, rather than relying on `Before=` alone.

That drop-in is a hard `Requires=`, so a failed mount stops bluetoothd starting rather than letting it come up silently amnesiac on the rootfs. Deliberate, and documented in the unit. The sibling bind mounts (`wendy`, `containerd`, `tee`) order their consumers without requiring them; `wendyos-user-setup.service` is the precedent for hard-requiring a `/data`-backed bind mount.

## Known limitation

The update that introduces this **still loses existing pairings, once** — confirmed in validation. The state lives on the slot being replaced, which is not mounted while the new slot boots, so there is nothing to migrate from. Every update after this one preserves them. Not worth the complexity of mounting the outgoing rootfs to rescue a single transition.

## Why it matters beyond the annoyance

WendyOS#1594 adds boot-time reconnection of trusted audio peripherals, since nothing else restores them after a reboot. Without this change that feature does nothing after the most common unattended reboot — an update — because there is no trusted device left to reconnect to.

## Validation

Raspberry Pi 4 (`wendyos-tom-rpi4`), Bose Revolve II SoundLink `78:2B:64:76:F3:CE`, adapter `E4:5F:01:0D:81:46`. Branch rebased onto `main` first, so the image also carries the audio-config fixes from #213/#217 — the pre-rebase branch predated them and had Bluetooth audio dead.

Two OTAs of the PR image, since the transition needs #221 present in *both* slots:

| step | result |
| --- | --- |
| Baseline, 0.18.1 | `/var/lib/bluetooth` not a mountpoint; Bose paired on the rootfs |
| OTA #1 | pairing gone — the documented one-time loss |
| Re-pair | `LinkKey` + `Trusted=true` written under `/data/bluetooth` |
| **OTA #2** | boot slot **1 → 0**, pairing **intact** on a slot that had never seen the speaker |

Per-checkbox evidence after the swap:

```
findmnt /var/lib/bluetooth
  /dev/mmcblk0p5[/bluetooth]  ext4  rw,nosuid,nodev,noexec,noatime

stat -c '%a %U:%G' /data/bluetooth /var/lib/bluetooth
  700 root:root
  700 root:root

stat -c %i /data/bluetooth /var/lib/bluetooth
  786437
  786437

systemctl show -p After -p Requires bluetooth.service
  After=var-lib-bluetooth.mount
  Requires=var-lib-bluetooth.mount

grep -E '^Name|^Trusted' .../78:2B:64:76:F3:CE/info
  Name=Bose Revolve II SoundLink
  Trusted=true
```

No failed units on either boot beyond the pre-existing `systemd-networkd-wait-online` on this wlan0-only board.

The persisted key was then shown to be *usable*, not merely present: after the swap the speaker was power-cycled and reconnected with no re-pairing, authenticating against a link key that came off `/data` on a slot which had never seen it.

## Testing

- [x] Pair a speaker, `wendy os update`, confirm the pairing survives
- [x] Confirm `/data/bluetooth` is `0700` and `/var/lib/bluetooth` shows the same inode
- [x] Confirm `bluetooth.service` orders after `var-lib-bluetooth.mount`

After the swap BlueZ still reports the speaker `Paired: true`, `Trusted: true` — which is what this PR is responsible for. Acting on that (reconnecting at boot) is WendyOS#1594's behaviour, validated in that PR and not re-tested here.

## Unrelated issue found while validating

`wendy os update --pr N` reports a false rollback on every run:

```
✗ OS version unchanged after update; the device likely rolled back
```

Both updates had fully succeeded. PR and nightly images keep `DISTRO_VERSION` from `conf/distro/wendyos.conf`, so `/etc/os-release` reports `0.18.1` while the manifest version is `pr-221`; those can never match. Anyone validating a PR image will read it as a failure. CLI-side, tracked separately.
