### PR TITLE
image: ship frei0r so the agent can render thermal cameras

### DIFF
--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -140,6 +140,7 @@ IMAGE_INSTALL:append = " \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-ugly \
     gstreamer1.0-libav \
+    frei0r-plugins \
     "
 
 # python3-pip-jetson-config lives in meta-tegra-extensions, so it's Tegra-only.

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,3 +1,20 @@
 # vulkan is auto-included via DISTRO_FEATURES but vulkansink requires a windowing
 # system (x11 or wayland). WendyOS disables both, so meson hard-errors at configure.
 PACKAGECONFIG:remove = "vulkan"
+
+# frei0r gives GStreamer the frei0r-filter-* elements, of which the agent's
+# thermal render mode needs normalize0r: a per-frame contrast stretch.
+#
+# Thermal cameras (TOPDON TC001 / InfiRay family, deployed on wendy-box-theta
+# and ccr1) put a whole scene into ~16 of 256 grey levels, so an unprocessed
+# frame renders as a flat grey rectangle in the CLI viewer, the console and the
+# companion app. The stretch has to be per-frame: where that narrow band sits
+# drifts with ambient temperature, and a fixed brightness/contrast stretch was
+# measured clipping a real scene to a uniform field within minutes.
+#
+# `frei0r` is a PACKAGECONFIG on this recipe, so the wrapper plugin is built
+# only when it is enabled here. Installing frei0r-plugins alone is NOT enough —
+# without this the elements simply do not exist and the agent reports
+# FailedPrecondition. `:append` matches the convention used elsewhere in this
+# tree (see avahi_%.bbappend) so a weak default is not wiped.
+PACKAGECONFIG:append = " frei0r"


### PR DESCRIPTION
**Draft — not built or booted.** See the caveat at the end; a real build is needed before merging.

Companion to **WendyOS#1615**, which adds an opt-in thermal render mode to the agent's video service. That mode needs `frei0r-filter-normalize0r` for a per-frame contrast stretch, and the element does not exist on the image today — so the mode returns `FailedPrecondition` on every device.

### Why

Thermal cameras (TOPDON TC001 / InfiRay family, currently on `wendy-box-theta` and `ccr1`) put a whole scene into **~16 of 256 grey levels**. Measured, not estimated: `min=71 max=87` across a full frame. Unprocessed, that renders as a flat grey rectangle in the CLI viewer, the console, and the companion app — which is exactly what a user reported from their phone.

The stretch has to be **per-frame**. Where that narrow band sits drifts with ambient temperature, and a fixed brightness/contrast stretch was tried on a real captured frame: it clipped the scene to a uniform field with three specks. Adaptive is not a nicety here.

### Both changes are required

| change | why |
|---|---|
| `frei0r-plugins` in `IMAGE_INSTALL` | provides the filters |
| `PACKAGECONFIG:append = " frei0r"` on `gstreamer1.0-plugins-bad` | builds the **GStreamer wrapper** |

Installing the package alone is not enough — without the `PACKAGECONFIG`, the `frei0r-filter-*` elements are never registered and the agent still finds nothing. `:append` follows the convention already used in this tree (`avahi_%.bbappend`) so a weak default is not wiped.

`frei0r-plugins` comes from `meta-multimedia`, already in the layer set (`conf/template/include/bblayers/oe-common.inc`).

### Caveat — please verify on a build

The layer sources are not checked out on the machine this was written on, so **the recipe name and the `PACKAGECONFIG` key come from OpenEmbedded convention rather than being verified against the tree**. Both are standard, but worth confirming before merge — a wrong key fails silently by simply not enabling the feature.

`coloreffects`, the other element the render mode uses, is already present (verified on `wendy-box-theta`).

### Sequencing

Merging this alone changes nothing user-visible: the agent only builds the frei0r pipeline when a client explicitly requests `RENDER_MODE_THERMAL`, and the default stays `RAW` because rendering destroys the per-pixel temperature values analytic consumers need. Devices also need an image rebuild to pick this up — `wendy-box-theta` is on WendyOS 0.16.0 and cannot take OTA updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
