### PR TITLE
fix(wendyos-agent): skip GNU_HASH QA check for the now-dynamic agent binary

### DIFF
--- a/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
+++ b/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
@@ -118,7 +118,19 @@ FILES:${PN} = "/usr/local/bin/wendy-agent \
 #                      debug metadata on-device. Proper fix is upstream
 #                      building the agent with `go build -trimpath`; drop this
 #                      skip once releases ship trimmed binaries.
-INSANE_SKIP:${PN} += "already-stripped buildpaths"
+#   ldflags          - Go's internal linker emits only a SysV .hash table, never
+#                      a .gnu.hash, so the GNU_HASH check fails on any
+#                      dynamically linked Go binary. This started firing with
+#                      release 2026.08.07-174446, where the agent switched from
+#                      a static CGO_ENABLED=0 build to a cgo-enabled dynamic one
+#                      (NEEDED: libc.so.6 libdl.so.2 libpthread.so.0) -- the
+#                      check silently skips static binaries, which is why earlier
+#                      releases passed. GNU_HASH is a symbol-lookup speed
+#                      optimization; the SysV table is functional, the binary
+#                      declares no versioned glibc symbols, and we do not compile
+#                      it, so there are no LDFLAGS of ours to pass. Drop this
+#                      skip if upstream returns to static linking.
+INSANE_SKIP:${PN} += "already-stripped buildpaths ldflags"
 
 # Runtime dependencies
 # curl/wget needed for auto-updater, tar for extraction


### PR DESCRIPTION
## Problem

Every board build on `main` has failed since agent release `2026.08.07-174446` was promoted to Latest ([run 31210481318](https://github.com/wendylabsinc/WendyOS-Builder/actions/runs/31210481318)):

```
ERROR: wendyos-agent-2026.08.07.174446-r0 do_package_qa: QA Issue:
  File /usr/local/bin/wendy-agent in package wendyos-agent doesn't have GNU_HASH (didn't pass LDFLAGS?) [ldflags]
```

Not a fetch/checksum problem — the tarball downloads and verifies fine. It is `do_package_qa`.

## Root cause

Diffing the ELF headers of the previous stable release against the current one:

| | `2026.07.27-003050` | `2026.08.07-174446` |
|---|---|---|
| linkage | static `ET_EXEC`, no `.dynamic` | dynamic, `.interp = /lib/ld-linux-aarch64.so.1` |
| hash section | — | `.hash` only, **no `.gnu.hash`** |
| `NEEDED` | — | `libc.so.6`, `libdl.so.2`, `libpthread.so.0` |

Upstream's agent build flipped from static `CGO_ENABLED=0` to cgo-enabled. Yocto's `ldflags` check skips static binaries entirely, which is why every earlier release sailed through; now that the binary is dynamic the check applies, and Go's internal linker only ever emits a SysV `.hash` table, never a `.gnu.hash`.

Timing lines up exactly: `2026.08.07-174446` became Latest at 17:58 UTC on Aug 7, the first failing build is 19:12 that evening, and all seven boards fail identically (not blacksail-specific).

## Why skipping is the right call, not a workaround

- GNU_HASH is a symbol-lookup speed optimization; the SysV `.hash` table is functional.
- We do not compile this binary, so there are no LDFLAGS of ours to pass — the check's premise doesn't apply.
- `.gnu.version_r` is empty (21 unversioned cgo-runtime symbols), so no glibc-version floor is introduced on-device.
- Matches how the repo already handles prebuilt vendor binaries — `cusparselt` and `nvidia-userspace` both carry an `ldflags` skip.

The comment in the recipe says to drop this skip if upstream returns to static linking.

## Worth a separate look

The linkage change is real, not just a QA annoyance. The agent is no longer self-contained: it now needs glibc present at runtime. The image ships it and Yocto's shlib scanning adds the dependency automatically, but this also applies to binaries `wendyos-agent-updater.sh` pulls at runtime, which bypass packaging entirely. If static linking was a deliberate property of the agent, the better fix is upstream restoring `CGO_ENABLED=0` and reverting this.

## Testing

Not verified locally — bitbake cannot run on the machine this was authored on. CI on this PR is the check. The ELF analysis above was done directly against both downloaded release tarballs.

Note: `main` currently has a second, unrelated breakage (`Nothing RPROVIDES 'frei0r-plugins'`), which is #222's territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4rsVUsMtCXbFdBnTcwhF