### PR TITLE
Bump DISTRO_VERSION to 0.18.2

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -59,7 +59,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.18.1"
+DISTRO_VERSION = "0.18.2"
 # DISTRO_CODENAME is inherited from poky.conf (require'd above), which
 # sets it to the active oe-core series ("scarthgap", "wrynose", ...).
 # Don't override here or it gets stuck on a stale value across series.


### PR DESCRIPTION
One line: `DISTRO_VERSION` `0.18.1` → `0.18.2`.


## What 0.18.2 ships over 0.18.1

| PR | |
| --- | --- |
| #214 | `fix(systemd): enable PAM support so user@.service can start` |
| #213 | `fix(audio-config): wait for user D-Bus socket before systemctl --user` — the squash also absorbed #217's WirePlumber SPA-JSON rewrite and the `pipewire-user-setup.sh` socket-path fix, so #217 has no separate merge commit |
| #221 | `fix(bluetooth): keep pairing state across OTA updates` |
| #223 | `fix(wendyos-agent): skip GNU_HASH QA check for the now-dynamic agent binary` |

## Agent

The image resolves the agent from `wendylabsinc/WendyOS` `releases/latest` **at build time**, so a stable agent had to exist first. It now does:

```
GitHub releases/latest   2026.08.10-054004   prerelease=false
GCS agent manifest       2026.08.10-054004
```

Confirmed by ancestry to contain WendyOS#1594 (PipeWire audio stack, `ConnectProfile` A2DP direction fix, boot-time reconnection of trusted peripherals). The previous stable, `2026.08.07-174446`, predated it.

## Caveats worth knowing before promoting

- **The agent release did not pass the integration gate — it skipped it.** `wendy discover` returned `{"lanDevices":[]}`, so the matrix was empty, and `release`'s condition allows `needs.integration-tests.result == 'skipped'`. The same code did pass the full 26-test suite on the branch shortly beforehand, so there is evidence, just not from the release run itself.
- **AUR publishing failed** for `2026.08.10-054004` (`fatal: Could not read from remote repository` — SSH auth to AUR). Arch users are stale; GitHub, GCS, the install script, GCP Artifact Registry and Winget all published correctly. `Announce Release` was skipped downstream of the AUR failure, so no Discord announcement went out.
