### PR TITLE
Persist systemd-timesyncd's clock across A/B slots (WDY-1877)

### DIFF
--- a/recipes-core/systemd-mount-wendy/files/timesyncd-persist-clock.conf
+++ b/recipes-core/systemd-mount-wendy/files/timesyncd-persist-clock.conf
@@ -1,14 +1,12 @@
 [Unit]
-# timesyncd reads /var/lib/systemd/timesync/clock once, at startup, and it is
-# Before=sysinit.target with no ordering against local-fs.target — so without
-# this it can start before the bind mount and read the rootfs copy instead of the
-# persisted one.
+# timesyncd reads /var/lib/systemd/timesync/clock once, at startup, and is
+# Before=sysinit.target with no ordering against local-fs.target — so without this
+# it can start before the bind mount and read the rootfs copy.
 #
-# Wants=, NOT RequiresMountsFor= — the opposite choice to
-# bluetooth-persist-state.conf, deliberately. There, a failed mount should stop
-# bluetoothd rather than let it come up amnesiac. Here, blocking timesyncd on a
-# failed mount would leave the clock unsynced, which is the exact failure this
-# change exists to prevent. Failing open costs one boot on the rootfs copy —
-# i.e. the behaviour before this change — instead of no time sync at all.
+# Wants=, not RequiresMountsFor= — the opposite choice to
+# bluetooth-persist-state.conf. There a failed mount should stop bluetoothd rather
+# than let it come up amnesiac; here blocking timesyncd would leave the clock
+# unsynced, the failure this change exists to prevent. Failing open costs one boot
+# on the rootfs copy, which is the behaviour before this change.
 Wants=var-lib-systemd-timesync.mount
 After=var-lib-systemd-timesync.mount

--- a/recipes-core/systemd-mount-wendy/files/timesyncd-persist-clock.conf
+++ b/recipes-core/systemd-mount-wendy/files/timesyncd-persist-clock.conf
@@ -1,0 +1,14 @@
+[Unit]
+# timesyncd reads /var/lib/systemd/timesync/clock once, at startup, and it is
+# Before=sysinit.target with no ordering against local-fs.target — so without
+# this it can start before the bind mount and read the rootfs copy instead of the
+# persisted one.
+#
+# Wants=, NOT RequiresMountsFor= — the opposite choice to
+# bluetooth-persist-state.conf, deliberately. There, a failed mount should stop
+# bluetoothd rather than let it come up amnesiac. Here, blocking timesyncd on a
+# failed mount would leave the clock unsynced, which is the exact failure this
+# change exists to prevent. Failing open costs one boot on the rootfs copy —
+# i.e. the behaviour before this change — instead of no time sync at all.
+Wants=var-lib-systemd-timesync.mount
+After=var-lib-systemd-timesync.mount

--- a/recipes-core/systemd-mount-wendy/files/var-lib-systemd-timesync.mount
+++ b/recipes-core/systemd-mount-wendy/files/var-lib-systemd-timesync.mount
@@ -1,0 +1,38 @@
+[Unit]
+Description=Bind mount /var/lib/systemd/timesync (last-known-good clock) from data partition
+Documentation=man:systemd.mount(5)
+
+# systemd-timesyncd stamps /var/lib/systemd/timesync/clock on every sync and, at
+# startup, bumps the system clock up to that file's mtime. On hardware with no
+# RTC (Raspberry Pi) that file IS the clock across a reboot. By default it lives
+# on the A/B rootfs, so an OTA boots a slot whose copy came from the image and
+# the device comes up at the Yocto build epoch instead of near real time —
+# months in the past. Back it with /data so it survives the slot switch, same
+# pattern as /var/lib/wendy -> /data/wendy (WDY-1877).
+
+RequiresMountsFor=/data
+After=data.mount
+
+# Deliberately NOT ordered after grow-data-fs-online.service, unlike
+# var-lib-wendy.mount and var-lib-bluetooth.mount. That unit is
+# WantedBy=multi-user.target, so ordering after it while also ordering before a
+# Before=sysinit.target consumer (timesyncd, below) forms a cycle that systemd
+# would break by silently dropping an edge. Safe to skip here: the clock file is
+# zero bytes, so it cannot hit ENOSPC on a not-yet-grown filesystem — the reason
+# the other mounts wait.
+
+# systemd-timesyncd reads the clock file once at startup, so mounting after it
+# would leave it looking at the rootfs copy. It is Before=sysinit.target and
+# does not wait for local-fs.target, hence the explicit ordering plus the
+# Wants=/After= drop-in on the service itself.
+Before=systemd-timesyncd.service
+DefaultDependencies=no
+
+[Mount]
+What=/data/systemd-timesync
+Where=/var/lib/systemd/timesync
+Type=none
+Options=bind,nosuid,nodev,noexec,x-systemd.mkdir
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-wendy/files/var-lib-systemd-timesync.mount
+++ b/recipes-core/systemd-mount-wendy/files/var-lib-systemd-timesync.mount
@@ -2,29 +2,29 @@
 Description=Bind mount /var/lib/systemd/timesync (last-known-good clock) from data partition
 Documentation=man:systemd.mount(5)
 
-# systemd-timesyncd stamps /var/lib/systemd/timesync/clock on every sync and, at
-# startup, bumps the system clock up to that file's mtime. On hardware with no
-# RTC (Raspberry Pi) that file IS the clock across a reboot. By default it lives
-# on the A/B rootfs, so an OTA boots a slot whose copy came from the image and
-# the device comes up at the Yocto build epoch instead of near real time —
-# months in the past. Back it with /data so it survives the slot switch, same
-# pattern as /var/lib/wendy -> /data/wendy (WDY-1877).
+# systemd-timesyncd stamps /var/lib/systemd/timesync/clock on every sync and bumps
+# the system clock up to that file's mtime at startup. On hardware with no RTC
+# (Raspberry Pi) that file is the clock across a reboot, and on the A/B rootfs it
+# does not survive an OTA. Backed by /data it does (WDY-1877).
 
 RequiresMountsFor=/data
 After=data.mount
 
-# Deliberately NOT ordered after grow-data-fs-online.service, unlike
-# var-lib-wendy.mount and var-lib-bluetooth.mount. That unit is
-# WantedBy=multi-user.target, so ordering after it while also ordering before a
-# Before=sysinit.target consumer (timesyncd, below) forms a cycle that systemd
-# would break by silently dropping an edge. Safe to skip here: the clock file is
-# zero bytes, so it cannot hit ENOSPC on a not-yet-grown filesystem — the reason
-# the other mounts wait.
+# The source directory, with the ownership timesyncd needs. Requires=, not just
+# After=: a timesyncd restart pulls this mount in on its own, and nothing else
+# would then pull in the unit that creates the source.
+After=wendyos-timesync-state.service
+Requires=wendyos-timesync-state.service
 
-# systemd-timesyncd reads the clock file once at startup, so mounting after it
-# would leave it looking at the rootfs copy. It is Before=sysinit.target and
-# does not wait for local-fs.target, hence the explicit ordering plus the
-# Wants=/After= drop-in on the service itself.
+# Not ordered after grow-data-fs-online.service, unlike var-lib-wendy.mount and
+# var-lib-bluetooth.mount: that unit is WantedBy=multi-user.target, so ordering
+# after it and before a Before=sysinit.target consumer forms a cycle that systemd
+# breaks by dropping an edge. The clock file is zero bytes and cannot hit ENOSPC
+# on a not-yet-grown filesystem, which is why those mounts wait.
+
+# timesyncd reads the clock file once at startup, so mounting after it would leave
+# it on the rootfs copy. It is Before=sysinit.target and does not wait for
+# local-fs.target, hence this ordering plus the drop-in on the service itself.
 Before=systemd-timesyncd.service
 DefaultDependencies=no
 

--- a/recipes-core/systemd-mount-wendy/files/wendyos-timesync-state.service
+++ b/recipes-core/systemd-mount-wendy/files/wendyos-timesync-state.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Prepare persistent systemd-timesyncd state directory on the data partition
+Documentation=man:systemd.mount(5)
+
+# The bind mount needs /data/systemd-timesync to already exist: x-systemd.mkdir
+# creates the mount point, never the source, so without this
+# var-lib-systemd-timesync.mount fails outright ("Failed to chase path").
+#
+# Ownership matches what StateDirectory=systemd/timesync would create
+# (systemd-timesync:systemd-timesync, 0755). systemd-timesyncd would chown the
+# directory itself on start, but setting it here keeps the on-disk state correct
+# even on a boot where timesyncd never runs.
+RequiresMountsFor=/data
+After=data.mount
+# The systemd-timesync user is created by sysusers; without this the install
+# below can lose the race and fail on -o.
+After=systemd-sysusers.service
+Before=var-lib-systemd-timesync.mount
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/install -d -m 0755 -o systemd-timesync -g systemd-timesync /data/systemd-timesync
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-wendy/files/wendyos-timesync-state.service
+++ b/recipes-core/systemd-mount-wendy/files/wendyos-timesync-state.service
@@ -11,9 +11,9 @@ Documentation=man:systemd.mount(5)
 # directory itself on start, but setting it here keeps the on-disk state correct
 # even on a boot where timesyncd never runs.
 #
-# The recursive chown is load-bearing, not tidying. Yocto allocates system UIDs
-# dynamically, so systemd-timesync has a DIFFERENT numeric UID in each slot's
-# image — measured 991 in one and 993 in the other on the same device. /data is
+# The recursive chown is required for correctness, not tidiness. Yocto allocates
+# system UIDs dynamically, so systemd-timesync has a DIFFERENT numeric UID in
+# each slot's image — measured 991 in one and 993 in the other. /data is
 # shared between slots, so after an A/B switch the clock file carries the other
 # slot's UID, timesyncd cannot write it ("Permission denied"), and it silently
 # declines to restore the clock: the device comes up at the Yocto build epoch

--- a/recipes-core/systemd-mount-wendy/files/wendyos-timesync-state.service
+++ b/recipes-core/systemd-mount-wendy/files/wendyos-timesync-state.service
@@ -10,6 +10,21 @@ Documentation=man:systemd.mount(5)
 # (systemd-timesync:systemd-timesync, 0755). systemd-timesyncd would chown the
 # directory itself on start, but setting it here keeps the on-disk state correct
 # even on a boot where timesyncd never runs.
+#
+# The recursive chown is load-bearing, not tidying. Yocto allocates system UIDs
+# dynamically, so systemd-timesync has a DIFFERENT numeric UID in each slot's
+# image — measured 991 in one and 993 in the other on the same device. /data is
+# shared between slots, so after an A/B switch the clock file carries the other
+# slot's UID, timesyncd cannot write it ("Permission denied"), and it silently
+# declines to restore the clock: the device comes up at the Yocto build epoch
+# exactly as if this mount did not exist. Verified on hardware — before the
+# chown the agent had to jump the clock 146 days from the build epoch; after it,
+# the boot clock was already correct.
+#
+# Left failing loudly rather than prefixed with '-': if the chown does not
+# happen the restore silently does not happen either, and a failed unit is the
+# only signal. (/data/bluetooth avoids all of this by being root-owned, UID 0
+# being the one UID that cannot drift.)
 RequiresMountsFor=/data
 After=data.mount
 # The systemd-timesync user is created by sysusers; without this the install
@@ -22,6 +37,7 @@ DefaultDependencies=no
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/install -d -m 0755 -o systemd-timesync -g systemd-timesync /data/systemd-timesync
+ExecStart=/usr/bin/chown -R systemd-timesync:systemd-timesync /data/systemd-timesync
 
 [Install]
 WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-wendy/files/wendyos-timesync-state.service
+++ b/recipes-core/systemd-mount-wendy/files/wendyos-timesync-state.service
@@ -2,33 +2,27 @@
 Description=Prepare persistent systemd-timesyncd state directory on the data partition
 Documentation=man:systemd.mount(5)
 
-# The bind mount needs /data/systemd-timesync to already exist: x-systemd.mkdir
-# creates the mount point, never the source, so without this
-# var-lib-systemd-timesync.mount fails outright ("Failed to chase path").
+# Without this the mount still succeeds — x-systemd.mkdir creates the bind source
+# as well as the mount point — but creates it root:root, and timesyncd cannot then
+# write the clock file. It fails silently: the mount reads as active either way.
 #
-# Ownership matches what StateDirectory=systemd/timesync would create
-# (systemd-timesync:systemd-timesync, 0755). systemd-timesyncd would chown the
-# directory itself on start, but setting it here keeps the on-disk state correct
-# even on a boot where timesyncd never runs.
+# Ownership matches what StateDirectory=systemd/timesync would create. timesyncd
+# chowns the directory itself on start, so the recursive chown is the part that
+# matters: it reaches the clock file inside. Yocto allocates system UIDs
+# dynamically, so systemd-timesync has a different numeric UID in each slot's
+# image, and after an A/B switch the file carries the other slot's UID; timesyncd
+# cannot write it, silently declines to restore the clock, and the device boots at
+# the image epoch exactly as if this mount did not exist. (/data/bluetooth
+# sidesteps all of this by being root-owned, UID 0 being the one that cannot
+# drift.)
 #
-# The recursive chown is required for correctness, not tidiness. Yocto allocates
-# system UIDs dynamically, so systemd-timesync has a DIFFERENT numeric UID in
-# each slot's image — measured 991 in one and 993 in the other. /data is
-# shared between slots, so after an A/B switch the clock file carries the other
-# slot's UID, timesyncd cannot write it ("Permission denied"), and it silently
-# declines to restore the clock: the device comes up at the Yocto build epoch
-# exactly as if this mount did not exist. Verified on hardware — before the
-# chown the agent had to jump the clock 146 days from the build epoch; after it,
-# the boot clock was already correct.
-#
-# Left failing loudly rather than prefixed with '-': if the chown does not
-# happen the restore silently does not happen either, and a failed unit is the
-# only signal. (/data/bluetooth avoids all of this by being root-owned, UID 0
-# being the one UID that cannot drift.)
+# Not prefixed with '-': a failed chown means the restore silently does not
+# happen, and a failed unit is the only signal.
+ConditionPathExists=/usr/lib/systemd/systemd-timesyncd
 RequiresMountsFor=/data
 After=data.mount
-# The systemd-timesync user is created by sysusers; without this the install
-# below can lose the race and fail on -o.
+# systemd-timesync is created by sysusers; without this the -o below can lose the
+# race and fail.
 After=systemd-sysusers.service
 Before=var-lib-systemd-timesync.mount
 DefaultDependencies=no

--- a/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
+++ b/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
@@ -1,8 +1,10 @@
 SUMMARY = "Systemd mount units for state that must survive an A/B OTA swap"
 DESCRIPTION = "Bind mounts state that must outlive an A/B OTA swap from the /data \
 partition instead of the small A/B rootfs: /var/lib/wendy for persistent app volumes \
-(created under /var/lib/wendy/volumes by the agent), and /var/lib/bluetooth for BlueZ \
-pairing state, which the device would otherwise forget on every update."
+(created under /var/lib/wendy/volumes by the agent), /var/lib/bluetooth for BlueZ \
+pairing state, which the device would otherwise forget on every update, and \
+/var/lib/systemd/timesync for systemd-timesyncd's last-known-good clock, without which \
+an RTC-less board comes up months in the past after every OTA."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
@@ -15,10 +17,14 @@ SRC_URI = " \
     file://var-lib-bluetooth.mount \
     file://wendyos-bluetooth-state.service \
     file://bluetooth-persist-state.conf \
+    file://var-lib-systemd-timesync.mount \
+    file://wendyos-timesync-state.service \
+    file://timesyncd-persist-clock.conf \
 "
 S = "${UNPACKDIR}"
 
-SYSTEMD_SERVICE:${PN} = "var-lib-wendy.mount var-lib-bluetooth.mount wendyos-bluetooth-state.service"
+SYSTEMD_SERVICE:${PN} = "var-lib-wendy.mount var-lib-bluetooth.mount wendyos-bluetooth-state.service \
+                         var-lib-systemd-timesync.mount wendyos-timesync-state.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
 do_install() {
@@ -30,9 +36,19 @@ do_install() {
 
     # Drop-in rather than a bbappend on bluez5: the ordering requirement comes
     # from this recipe's mount unit, so it belongs with it.
+    install -m 0644 ${UNPACKDIR}/var-lib-systemd-timesync.mount \
+        ${D}${systemd_system_unitdir}/var-lib-systemd-timesync.mount
+    install -m 0644 ${UNPACKDIR}/wendyos-timesync-state.service \
+        ${D}${systemd_system_unitdir}/wendyos-timesync-state.service
+
     install -d ${D}${systemd_system_unitdir}/bluetooth.service.d
     install -m 0644 ${UNPACKDIR}/bluetooth-persist-state.conf \
         ${D}${systemd_system_unitdir}/bluetooth.service.d/persist-state.conf
+
+    # Same reasoning: timesyncd must be ordered after this recipe's mount unit.
+    install -d ${D}${systemd_system_unitdir}/systemd-timesyncd.service.d
+    install -m 0644 ${UNPACKDIR}/timesyncd-persist-clock.conf \
+        ${D}${systemd_system_unitdir}/systemd-timesyncd.service.d/persist-clock.conf
 }
 
 FILES:${PN} += " \
@@ -40,6 +56,9 @@ FILES:${PN} += " \
     ${systemd_system_unitdir}/var-lib-bluetooth.mount \
     ${systemd_system_unitdir}/wendyos-bluetooth-state.service \
     ${systemd_system_unitdir}/bluetooth.service.d/persist-state.conf \
+    ${systemd_system_unitdir}/var-lib-systemd-timesync.mount \
+    ${systemd_system_unitdir}/wendyos-timesync-state.service \
+    ${systemd_system_unitdir}/systemd-timesyncd.service.d/persist-clock.conf \
 "
 
 RDEPENDS:${PN} = "systemd"

--- a/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
+++ b/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
@@ -34,18 +34,17 @@ do_install() {
     install -m 0644 ${UNPACKDIR}/wendyos-bluetooth-state.service \
         ${D}${systemd_system_unitdir}/wendyos-bluetooth-state.service
 
-    # Drop-in rather than a bbappend on bluez5: the ordering requirement comes
-    # from this recipe's mount unit, so it belongs with it.
     install -m 0644 ${UNPACKDIR}/var-lib-systemd-timesync.mount \
         ${D}${systemd_system_unitdir}/var-lib-systemd-timesync.mount
     install -m 0644 ${UNPACKDIR}/wendyos-timesync-state.service \
         ${D}${systemd_system_unitdir}/wendyos-timesync-state.service
 
+    # Drop-ins rather than bbappends on bluez5 and systemd: the ordering
+    # requirement comes from this recipe's mount units, so it belongs with them.
     install -d ${D}${systemd_system_unitdir}/bluetooth.service.d
     install -m 0644 ${UNPACKDIR}/bluetooth-persist-state.conf \
         ${D}${systemd_system_unitdir}/bluetooth.service.d/persist-state.conf
 
-    # Same reasoning: timesyncd must be ordered after this recipe's mount unit.
     install -d ${D}${systemd_system_unitdir}/systemd-timesyncd.service.d
     install -m 0644 ${UNPACKDIR}/timesyncd-persist-clock.conf \
         ${D}${systemd_system_unitdir}/systemd-timesyncd.service.d/persist-clock.conf


### PR DESCRIPTION
Closes WDY-1877.
Closes WDY-2197.
Pairs with [WendyOS#1683](https://github.com/wendylabsinc/WendyOS/pull/1683).

## What breaks for the user

An owner updates a Pi, or reboots it after a power cut. It comes back believing it is months in the past — the date the image was built. Log timestamps and update records are wrong, and if the owner has logged in to the CLI at any point since that date, the device rejects their credential as "not yet valid" and they are locked out of every channel until it reaches a time server. A Pi has no RTC, so this is every boot that starts without a network.

## What we have to work with

`systemd-timesyncd` already stamps `/var/lib/systemd/timesync/clock` on every sync and, at startup, advances the system clock to that file's mtime. That is exactly the "write the time down every time the device learns it" floor the ticket asks for, ticking continuously and needing no new code — but it lives on the A/B rootfs, so every OTA boots a slot whose copy came from the image and the value resets to the build date.

`/data` survives slot switches and already backs `/var/lib/wendy` and `/var/lib/bluetooth`. systemd's own fallback floor, `/usr/lib/clock-epoch`, is stamped 2011 (Yocto's `SOURCE_DATE_EPOCH`), so it is no help.

## Changes

- Bind-mount `/var/lib/systemd/timesync` from `/data/systemd-timesync`, ordered before `systemd-timesyncd` — it reads the file once at startup and is `Before=sysinit.target`, so a later mount would leave it on the rootfs copy.
- A prep unit creates the source with the ownership timesyncd needs and chowns it recursively. Yocto allocates system UIDs per image, so after a slot switch the clock file can carry the other slot's UID, leaving timesyncd unable to write it. The mount `Requires=` that unit.
- Drop-in ordering timesyncd after the mount, `Wants=` rather than `RequiresMountsFor=`: a failed mount should cost one boot on the rootfs copy, not disable time sync entirely.

This supersedes the ticket's proposal that the agent rewrite `/config/clock_floor` after each sync. The OS already maintains a ticking floor; making it survive an A/B switch is less code than duplicating it in the agent, and it applies before the agent starts, which is what WDY-2197's pre-NTP window needed.

## Validation (Pi 4, `wendyos-tom-rpi4`)

OTA from this PR's image on `p3` into `p4`, a real A/B switch:

```
System clock time advanced to recorded timestamp: Tue 2026-08-11 06:31:33 UTC
timesync: clock advanced ... offset 72.845s
```

72 seconds of residual drift against the 146-day jump measured before the change. All three units come up `active` from the shipped image.

The recursive chown was validated directly, since UID allocation happened to match across these two builds and cannot be forced from outside: a clock file planted at UID 991 with the units stopped was chowned and became writable as `systemd-timesync` once `Requires=` pulled the prep unit in. Without `Requires=`, a `systemctl restart systemd-timesyncd` brings the mount up with a `root:root` source and no chown — `x-systemd.mkdir` creates the bind source, not just the mount point — and the mount reads `active` either way, so it fails silently.

First boot is unchanged: the image ships `/var/lib/systemd/timesync/` empty (confirmed by mounting the rootfs underneath the bind mount), so there is no rootfs clock file being hidden and no seed value available.

## Not in this PR

WDY-1877 also floats triggering an immediate Roughtime re-query on network-up instead of the fixed backoff, which would shorten the stuck-clock window after a WiFi flap. Untouched here.

Seeding the persisted clock from a real build timestamp would give a permanently-offline RTC-less device a usable floor instead of 2011. Worth its own issue.
