### PR TITLE
publisher: authenticate with Application Default Credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1125,9 +1125,6 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -1305,7 +1302,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          TOKEN=$(gcloud auth print-access-token)
           # Build the publisher once, then invoke it per storage variant. Each
           # variant uploads to unique per-version/per-storage GCS paths and emits
           # its own manifest-entry JSON. Upload-only: ALL manifest writes stay
@@ -1384,7 +1380,6 @@ jobs:
               --device "$DEVICE"
               --version "$UPLOAD_VERSION"
               --file "$IMAGE_FILE"
-              --access-token "$TOKEN"
               --upload-only
               --metadata-out "$ENTRY_FILE"
             )
@@ -1528,9 +1523,6 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -1573,7 +1565,6 @@ jobs:
             exit 0
           fi
           echo "published=true" >> "$GITHUB_OUTPUT"
-          TOKEN=$(gcloud auth print-access-token)
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
           # Build once; up to 15 invocations follow across this step and the
           # master manifest step ($RUNNER_TEMP persists between steps).
@@ -1583,7 +1574,7 @@ jobs:
           for entry in "${entries[@]}"; do
             echo "::group::apply $(basename "$entry")"
             cat "$entry"
-            "$RUNNER_TEMP/publisher" --apply-metadata "$entry" --access-token "$TOKEN"
+            "$RUNNER_TEMP/publisher" --apply-metadata "$entry"
             echo "::endgroup::"
           done
 
@@ -1596,7 +1587,6 @@ jobs:
             echo "No manifest entries; skipping master manifest update."
             exit 0
           fi
-          TOKEN=$(gcloud auth print-access-token)
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
           # Reuse the binary from the previous step; rebuild only if missing
           # (e.g. this step re-run in isolation).
@@ -1615,7 +1605,6 @@ jobs:
               --device "$DEVICE"
               --version "$VERSION"
               --master-manifest-only
-              --access-token "$TOKEN"
             )
             if [[ "$NIGHTLY" == "true" ]]; then
               ARGS+=(--nightly)
@@ -1720,9 +1709,6 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -1750,13 +1736,12 @@ jobs:
             echo "::warning::No manifest entries found (did every build fail?); nothing to publish."
             exit 0
           fi
-          TOKEN=$(gcloud auth print-access-token)
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
           go build -o "$RUNNER_TEMP/publisher" .
           for entry in "${entries[@]}"; do
             echo "::group::apply $(basename "$entry")"
             cat "$entry"
-            "$RUNNER_TEMP/publisher" --apply-metadata "$entry" --access-token "$TOKEN"
+            "$RUNNER_TEMP/publisher" --apply-metadata "$entry"
             echo "::endgroup::"
           done
 
@@ -1771,12 +1756,11 @@ jobs:
             echo "No manifest entries; skipping PR master manifest update."
             exit 0
           fi
-          TOKEN=$(gcloud auth print-access-token)
           cd "$GITHUB_WORKSPACE/wendyos/tools/publisher"
           [[ -x "$RUNNER_TEMP/publisher" ]] || go build -o "$RUNNER_TEMP/publisher" .
           readarray -t rows < <(jq -sc '[.[] | {device, version}] | unique_by(.device) | .[]' "${entries[@]}")
           for row in "${rows[@]}"; do
             DEVICE=$(jq -r .device <<<"$row")
             VERSION=$(jq -r .version <<<"$row")
-            "$RUNNER_TEMP/publisher" --device "$DEVICE" --version "$VERSION" --pr "$PR_NUMBER" --master-manifest-only --nightly --access-token "$TOKEN" </dev/null
+            "$RUNNER_TEMP/publisher" --device "$DEVICE" --version "$VERSION" --pr "$PR_NUMBER" --master-manifest-only --nightly </dev/null
           done

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.py[cod]
 
 docs/superpowers
+tools/publisher/publisher

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -59,7 +59,7 @@ DISTRO = "wendyos"
 DISTROOVERRIDES = "poky"
 
 DISTRO_NAME = "WendyOS Linux platform"
-DISTRO_VERSION = "0.18.1"
+DISTRO_VERSION = "0.18.2"
 # DISTRO_CODENAME is inherited from poky.conf (require'd above), which
 # sets it to the active oe-core series ("scarthgap", "wrynose", ...).
 # Don't override here or it gets stuck on a stale value across series.

--- a/recipes-core/systemd-mount-wendy/files/bluetooth-persist-state.conf
+++ b/recipes-core/systemd-mount-wendy/files/bluetooth-persist-state.conf
@@ -1,0 +1,11 @@
+[Unit]
+# bluetoothd loads /var/lib/bluetooth once, at startup. Without this it can
+# race the bind mount and come up against the empty rootfs directory, which
+# looks exactly like "nothing was ever paired" -- intermittently, and only on
+# some boots. RequiresMountsFor pulls in var-lib-bluetooth.mount and orders
+# after it, so the state is always in place before bluetoothd reads it.
+#
+# This is Requires=, not Wants=: a failed mount stops bluetoothd starting at all
+# rather than letting it come up silently amnesiac on the rootfs. Deliberate --
+# a forgotten pairing on an unattended appliance is worse than a failed unit.
+RequiresMountsFor=/var/lib/bluetooth

--- a/recipes-core/systemd-mount-wendy/files/var-lib-bluetooth.mount
+++ b/recipes-core/systemd-mount-wendy/files/var-lib-bluetooth.mount
@@ -1,0 +1,36 @@
+[Unit]
+Description=Bind mount /var/lib/bluetooth (Bluetooth pairing state) from data partition
+Documentation=man:systemd.mount(5)
+
+# BlueZ stores pairing state -- link keys, device names, the Trusted flag --
+# under /var/lib/bluetooth. By default that path is on the A/B rootfs, so every
+# OTA boots a slot with an empty directory and the device forgets every
+# peripheral it was paired with. Back it with /data/bluetooth (persists across
+# A/B switches), same pattern as /var/lib/wendy -> /data/wendy.
+
+# Ensure data partition is mounted and the directory has been created with the
+# restrictive mode link keys require.
+RequiresMountsFor=/data
+After=data.mount
+After=wendyos-bluetooth-state.service
+Requires=wendyos-bluetooth-state.service
+
+# Wait for the /data fs grow, same as var-lib-wendy.mount and
+# var-lib-containerd.mount. Board-specific, inert where absent.
+After=grow-data-fs-online.service
+
+# bluetoothd reads this directory once at startup, so mounting it afterwards
+# would leave it seeing an empty state and treating paired devices as unknown.
+# bluetooth.service carries a RequiresMountsFor drop-in for the same reason;
+# this ordering covers the case where it is started in the same transaction.
+Before=bluetooth.service
+DefaultDependencies=no
+
+[Mount]
+What=/data/bluetooth
+Where=/var/lib/bluetooth
+Type=none
+Options=bind,nosuid,nodev,noexec,x-systemd.mkdir
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-wendy/files/wendyos-bluetooth-state.service
+++ b/recipes-core/systemd-mount-wendy/files/wendyos-bluetooth-state.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Prepare persistent Bluetooth state directory on the data partition
+Documentation=man:systemd.mount(5)
+
+# The bind mount needs /data/bluetooth to already exist: x-systemd.mkdir creates
+# the mount point, never the source, so without this var-lib-bluetooth.mount
+# fails outright ("Failed to chase path"). Not optional hardening -- deleting
+# this unit takes Bluetooth down on any device whose /data lacks the directory.
+#
+# 0700 because /var/lib/bluetooth holds link keys: the info files are 0600, but
+# a listable directory still names every paired peripheral.
+RequiresMountsFor=/data
+After=data.mount
+Before=var-lib-bluetooth.mount
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/install -d -m 0700 -o root -g root /data/bluetooth
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
+++ b/recipes-core/systemd-mount-wendy/systemd-mount-wendy_1.0.bb
@@ -1,7 +1,8 @@
-SUMMARY = "Systemd mount unit for persistent wendy volume storage"
-DESCRIPTION = "Bind mounts /var/lib/wendy from /data/wendy so persistent app volumes \
-(created under /var/lib/wendy/volumes by the agent) live on the /data partition instead \
-of the small A/B rootfs. Keeps volume data off the rootfs and surviving A/B OTA swaps."
+SUMMARY = "Systemd mount units for state that must survive an A/B OTA swap"
+DESCRIPTION = "Bind mounts state that must outlive an A/B OTA swap from the /data \
+partition instead of the small A/B rootfs: /var/lib/wendy for persistent app volumes \
+(created under /var/lib/wendy/volumes by the agent), and /var/lib/bluetooth for BlueZ \
+pairing state, which the device would otherwise forget on every update."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
@@ -9,17 +10,36 @@ inherit systemd
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI = "file://var-lib-wendy.mount"
+SRC_URI = " \
+    file://var-lib-wendy.mount \
+    file://var-lib-bluetooth.mount \
+    file://wendyos-bluetooth-state.service \
+    file://bluetooth-persist-state.conf \
+"
 S = "${UNPACKDIR}"
 
-SYSTEMD_SERVICE:${PN} = "var-lib-wendy.mount"
+SYSTEMD_SERVICE:${PN} = "var-lib-wendy.mount var-lib-bluetooth.mount wendyos-bluetooth-state.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
 do_install() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/var-lib-wendy.mount ${D}${systemd_system_unitdir}/var-lib-wendy.mount
+    install -m 0644 ${UNPACKDIR}/var-lib-bluetooth.mount ${D}${systemd_system_unitdir}/var-lib-bluetooth.mount
+    install -m 0644 ${UNPACKDIR}/wendyos-bluetooth-state.service \
+        ${D}${systemd_system_unitdir}/wendyos-bluetooth-state.service
+
+    # Drop-in rather than a bbappend on bluez5: the ordering requirement comes
+    # from this recipe's mount unit, so it belongs with it.
+    install -d ${D}${systemd_system_unitdir}/bluetooth.service.d
+    install -m 0644 ${UNPACKDIR}/bluetooth-persist-state.conf \
+        ${D}${systemd_system_unitdir}/bluetooth.service.d/persist-state.conf
 }
 
-FILES:${PN} += "${systemd_system_unitdir}/var-lib-wendy.mount"
+FILES:${PN} += " \
+    ${systemd_system_unitdir}/var-lib-wendy.mount \
+    ${systemd_system_unitdir}/var-lib-bluetooth.mount \
+    ${systemd_system_unitdir}/wendyos-bluetooth-state.service \
+    ${systemd_system_unitdir}/bluetooth.service.d/persist-state.conf \
+"
 
 RDEPENDS:${PN} = "systemd"

--- a/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
+++ b/recipes-core/wendyos-agent/wendyos-agent_1.0.bb
@@ -118,7 +118,19 @@ FILES:${PN} = "/usr/local/bin/wendy-agent \
 #                      debug metadata on-device. Proper fix is upstream
 #                      building the agent with `go build -trimpath`; drop this
 #                      skip once releases ship trimmed binaries.
-INSANE_SKIP:${PN} += "already-stripped buildpaths"
+#   ldflags          - Go's internal linker emits only a SysV .hash table, never
+#                      a .gnu.hash, so the GNU_HASH check fails on any
+#                      dynamically linked Go binary. This started firing with
+#                      release 2026.08.07-174446, where the agent switched from
+#                      a static CGO_ENABLED=0 build to a cgo-enabled dynamic one
+#                      (NEEDED: libc.so.6 libdl.so.2 libpthread.so.0) -- the
+#                      check silently skips static binaries, which is why earlier
+#                      releases passed. GNU_HASH is a symbol-lookup speed
+#                      optimization; the SysV table is functional, the binary
+#                      declares no versioned glibc symbols, and we do not compile
+#                      it, so there are no LDFLAGS of ours to pass. Drop this
+#                      skip if upstream returns to static linking.
+INSANE_SKIP:${PN} += "already-stripped buildpaths ldflags"
 
 # Runtime dependencies
 # curl/wget needed for auto-updater, tar for extraction

--- a/recipes-multimedia/audio-config/files/50-wireplumber-headless.conf
+++ b/recipes-multimedia/audio-config/files/50-wireplumber-headless.conf
@@ -1,13 +1,14 @@
--- Disable seat monitoring for headless devices
--- WendyOS has no display server or logind seats, so Bluetooth devices
--- wouldn't be activated without this configuration
---
--- Without this, WirePlumber will wait for a logind seat to exist before
--- enabling Bluetooth audio devices. Since WendyOS is headless, no seat
--- is ever created, and Bluetooth devices stay paired but inactive.
+# Disable seat monitoring for headless devices.
+#
+# WendyOS has no display server and no logind seats. The bluez monitor
+# only activates Bluetooth audio devices once a seat exists, so without
+# this a speaker pairs and connects but never produces a PipeWire node.
+#
+# The stock wireplumber.conf only disables this inside
+# mixin.systemwide-session, which the main profile does not inherit.
 
 wireplumber.profiles = {
   main = {
-    ["monitor.bluez.seat-monitoring"] = "disabled"
+    monitor.bluez.seat-monitoring = disabled
   }
 }

--- a/recipes-multimedia/audio-config/files/60-wireplumber-camera-headless.conf
+++ b/recipes-multimedia/audio-config/files/60-wireplumber-camera-headless.conf
@@ -1,9 +1,11 @@
--- Enable V4L2 camera monitoring for headless devices.
--- WendyOS has no display server or logind seats. Without this, WirePlumber
--- may skip camera enumeration on devices that tie monitor activation to seat
--- presence. Explicitly require the V4L2 monitor in the main profile.
+# Enable V4L2 camera monitoring for headless devices.
+#
+# WendyOS has no display server or logind seats. Explicitly require the
+# V4L2 monitor in the main profile so cameras are enumerated without a
+# seat present.
+
 wireplumber.profiles = {
   main = {
-    ["monitor.v4l2"] = "required"
+    monitor.v4l2 = required
   }
 }

--- a/recipes-multimedia/audio-config/files/README-container-audio.md
+++ b/recipes-multimedia/audio-config/files/README-container-audio.md
@@ -7,7 +7,7 @@ WendyOS provides complete audio and Bluetooth speaker support for containers thr
 
 Containers get audio access through:
 1. **ALSA devices** (`/dev/snd/*`) - Direct hardware access
-2. **PipeWire sockets** (`/run/user/1000/pipewire`) - Modern audio routing
+2. **PipeWire sockets** (`/run/user/1000/pipewire-0`) - Modern audio routing
 3. **PulseAudio compatibility** (`/run/user/1000/pulse`) - Legacy app support
 4. **D-Bus session** (`/run/user/1000/bus`) - Bluetooth control
 
@@ -91,7 +91,7 @@ Once paired, PipeWire automatically routes audio to the Bluetooth speaker.
 ls -la /dev/snd/
 
 # Check if PipeWire socket is accessible
-ls -la /run/user/1000/pipewire/
+ls -la /run/user/1000/pipewire-0
 ```
 
 ### No sound output

--- a/recipes-multimedia/audio-config/files/pipewire-user-setup.sh
+++ b/recipes-multimedia/audio-config/files/pipewire-user-setup.sh
@@ -74,6 +74,18 @@ wait_for_socket() {
     return 0
 }
 
+# Wait for the user manager's own D-Bus socket before running any
+# `systemctl --user` command against it. `loginctl enable-linger` starts
+# user@$USER_UID.service asynchronously: the runtime directory above appears
+# almost immediately, but the user manager's control socket ($RUNTIME_DIR/bus)
+# takes a bit longer to bind. Without this wait, the `su` block below races
+# it and fails with "Failed to connect to user scope bus via local
+# transport: No such file or directory".
+if ! wait_for_socket "$RUNTIME_DIR/bus"; then
+    echo "ERROR: user@$USER_UID.service's D-Bus socket never appeared"
+    exit 1
+fi
+
 # Enable and start user services as the wendy user
 su - "$USER" -c "
     set -e
@@ -125,7 +137,7 @@ wait_for_socket "$RUNTIME_DIR/bus" || {
     exit 1
 }
 
-wait_for_socket "$RUNTIME_DIR/pipewire/pipewire-0" || {
+wait_for_socket "$RUNTIME_DIR/pipewire-0" || {
     echo "ERROR: PipeWire socket missing"
     exit 1
 }
@@ -151,7 +163,7 @@ echo "=== Audio Setup Complete ==="
 echo "User: $USER (UID: $USER_UID)"
 echo "Runtime dir: $RUNTIME_DIR"
 echo "D-Bus socket: $RUNTIME_DIR/bus"
-echo "PipeWire socket: $RUNTIME_DIR/pipewire/pipewire-0"
+echo "PipeWire socket: $RUNTIME_DIR/pipewire-0"
 echo "Pulse socket: $RUNTIME_DIR/pulse/native"
 echo ""
 echo "Container usage:"

--- a/tools/publisher/README.md
+++ b/tools/publisher/README.md
@@ -29,7 +29,7 @@ The WendyOS Publisher maintains a structured manifest system in GCS for distribu
 - 🔐 **SHA256 Checksums** - Automatic integrity verification
 - 🚀 **Nightly Promotion** - Convert tested nightly builds to stable releases
 - 📊 **Device Stability Levels** - Mark devices as stable, experimental, or deprecated
-- 🔑 **Auto Authentication** - Automatic gcloud authentication if credentials missing
+- 🔑 **Auto Authentication** - Offers a gcloud login when no credentials are found and a terminal is attached
 
 ## Installation
 
@@ -55,7 +55,7 @@ By default, the tool uses the `wendyos-images-public` bucket. Override with:
 ```
 
 ### Authentication
-The tool automatically triggers `gcloud auth application-default login` if credentials are not found.
+The tool uses Application Default Credentials. When none are found and stdin is a terminal, it triggers `gcloud auth application-default login`. Without a terminal — CI, cron, a container — it reports the credential error instead, so it never waits on a prompt nobody can answer. In CI, ADC comes from the workload-identity credentials file that `google-github-actions/auth` exports. See RUNBOOK.md for the full picture.
 
 ## Usage
 
@@ -419,7 +419,7 @@ for version, metadata := range manifest.Versions {
 
 The tool exits with non-zero status on errors:
 
-- **Authentication errors**: Triggers gcloud auth flow
+- **Authentication errors**: Triggers the gcloud auth flow when a terminal is attached; otherwise reported
 - **Validation errors**: Invalid device names, versions, or file paths
 - **GCS errors**: Network issues, permission problems
 - **Swap errors**: Version doesn't exist, category mismatch

--- a/tools/publisher/RUNBOOK.md
+++ b/tools/publisher/RUNBOOK.md
@@ -11,17 +11,16 @@ Operational guide for publishing OS images using the WendyOS publisher (`tools/p
 
 ### Authentication
 
-The tool auto-triggers `gcloud auth application-default login` if your credentials are missing or expired. Just follow the browser prompt when it pops up.
+The tool uses Application Default Credentials. On a developer machine it auto-triggers `gcloud auth application-default login` when no credentials are found at all — just follow the browser prompt when it pops up.
 
-You can also pass a token directly with `--access-token` (useful in CI):
-```bash
-go run . --access-token "$(gcloud auth print-access-token)" [other flags]
-```
-
-If you need to manually re-auth:
+Credentials that exist but are expired or revoked do not trigger the prompt: they load lazily, so the tool starts normally and the first GCS call fails with `invalid_grant`. Re-auth manually when you see that:
 ```bash
 gcloud auth application-default login
 ```
+
+In CI, `google-github-actions/auth` exports a workload-identity credentials file as `GOOGLE_APPLICATION_CREDENTIALS` and the tool picks it up. No token is passed on the command line: the auth library exchanges that file for tokens and refreshes them against their real expiries, so an upload that outlives a single token keeps working. That holds while the GitHub runtime token embedded in the credentials file stays valid — for a job long enough to outlive it, re-run the auth action before the publish step.
+
+Without a terminal on stdin the tool never offers the interactive login — it reports the credential error instead of blocking on a prompt nobody can answer.
 
 ## Running the Tool
 
@@ -268,7 +267,6 @@ gs://wendyos-images-public/
 | `--update-only` | No | Update manifests without uploading files |
 | `--list` | No | List all images in the bucket |
 | `--notify-discord <bool>` | No | Send Discord notification (default: `true`) |
-| `--access-token <token>` | No | GCS access token (for CI or manual override) |
 | `--debug` | No | Enable verbose debug logging |
 | `--help` | No | Show help message |
 
@@ -279,7 +277,7 @@ At least one of `--file`, `--ota-update`, or `--recovery-file` is required for u
 ## Troubleshooting
 
 ### "authentication error" on first run
-The tool will auto-open a browser for Google auth. Complete the login flow and the upload will retry. Alternatively, pass `--access-token` directly.
+The tool will auto-open a browser for Google auth. Complete the login flow and the upload will retry. If you see the error without a prompt, stdin is not a terminal — run `gcloud auth application-default login` yourself first.
 
 ### "version does not exist" on swap
 The `--swap` flag requires an existing version. Check you're using the exact version string (including `-nightly` suffix if applicable).

--- a/tools/publisher/go.mod
+++ b/tools/publisher/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/SaveTheRbtz/zstd-seekable-format-go/pkg v0.10.0
 	github.com/klauspost/compress v1.18.6
 	github.com/sirupsen/logrus v1.9.3
-	golang.org/x/oauth2 v0.13.0
+	golang.org/x/term v0.13.0
 	google.golang.org/api v0.150.0
 )
 
@@ -26,6 +26,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/tools/publisher/go.sum
+++ b/tools/publisher/go.sum
@@ -112,6 +112,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
+golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/tools/publisher/upload_and_manifest.go
+++ b/tools/publisher/upload_and_manifest.go
@@ -24,10 +24,9 @@ import (
 	seekable "github.com/SaveTheRbtz/zstd-seekable-format-go/pkg"
 	"github.com/klauspost/compress/zstd"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/oauth2"
+	"golang.org/x/term"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 )
 
 var log = logrus.New()
@@ -52,33 +51,6 @@ func masterManifestPath(prefix string) string {
 // pr/<N>/ prefix the same way imageObjectPath does.
 func imageDirPrefix(prefix, deviceType string) string {
 	return fmt.Sprintf("%simages/%s/", prefix, deviceType)
-}
-
-// gcloudTokenSource implements oauth2.TokenSource. It seeds with the caller's
-// initial access token and refreshes by running "gcloud auth print-access-token"
-// once the token is within 10 seconds of expiry (the oauth2 package's Valid()
-// check applies a 10-second buffer).
-type gcloudTokenSource struct {
-	mu    sync.Mutex
-	token *oauth2.Token
-}
-
-func (s *gcloudTokenSource) Token() (*oauth2.Token, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.token != nil && s.token.Valid() {
-		return s.token, nil
-	}
-	out, err := exec.Command("gcloud", "auth", "print-access-token").Output()
-	if err != nil {
-		return nil, fmt.Errorf("gcloud token refresh failed: %w", err)
-	}
-	s.token = &oauth2.Token{
-		AccessToken: strings.TrimSpace(string(out)),
-		TokenType:   "Bearer",
-		Expiry:      time.Now().Add(55 * time.Minute),
-	}
-	return s.token, nil
 }
 
 // manifestCacheControl is set on every manifest write. Manifests are mutable
@@ -995,60 +967,56 @@ func sendDiscordNotification(webhookURL string, deviceType, version string, isNi
 	return nil
 }
 
-// createStorageClientWithAuth creates a storage client and triggers authentication if needed
-func createStorageClientWithAuth(ctx context.Context, accessToken string) (*storage.Client, error) {
-	// If an access token is provided, seed the refreshing token source with it.
-	// GCP access tokens expire after 1 hour; gcloudTokenSource re-runs
-	// "gcloud auth print-access-token" when the token is near expiry so that
-	// long-running retry loops (412 backoff) don't hit 401 mid-flight.
-	if accessToken != "" {
-		log.Info("Using provided access token for authentication")
-		ts := &gcloudTokenSource{
-			token: &oauth2.Token{
-				AccessToken: accessToken,
-				TokenType:   "Bearer",
-				Expiry:      time.Now().Add(55 * time.Minute),
-			},
-		}
-		client, err := storage.NewClient(ctx, option.WithTokenSource(ts))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create storage client with access token: %w", err)
-		}
+// missingCredentials reports whether err is the auth library saying it found no
+// Application Default Credentials at all. A malformed credentials file, a denied
+// permission or a network failure must not match: those are reported as-is
+// rather than answered with a login prompt.
+func missingCredentials(err error) bool {
+	return strings.Contains(err.Error(), "could not find default credentials")
+}
+
+// interactiveTerminal reports whether stdin is a terminal, i.e. whether a human
+// is present to complete a browser login. CI must never reach the interactive
+// path: it would wait on a prompt nobody can answer until the job timeout fires.
+// This is a real tty check, not a character-device check — CI redirects stdin
+// from /dev/null, which is itself a character device.
+func interactiveTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// createStorageClientWithAuth creates a storage client from Application Default
+// Credentials. CI supplies ADC through the workload-identity credentials file
+// that google-github-actions/auth exports as GOOGLE_APPLICATION_CREDENTIALS: the
+// auth library exchanges it for tokens itself and refreshes against each token's
+// real expiry, for as long as the GitHub runtime token embedded in that file
+// stays valid. On a developer machine ADC comes from "gcloud auth
+// application-default login", which is offered here when none is found.
+//
+// The credentials only load lazily, so an expired or revoked ADC file creates a
+// client without error and fails at the first GCS call instead of here.
+func createStorageClientWithAuth(ctx context.Context) (*storage.Client, error) {
+	client, err := storage.NewClient(ctx)
+	if err == nil {
 		return client, nil
 	}
-
-	// Try to create the client with default credentials
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// Check if this is an authentication error
-		errMsg := err.Error()
-		if strings.Contains(errMsg, "could not find default credentials") ||
-			strings.Contains(errMsg, "application default credentials") ||
-			strings.Contains(errMsg, "credential") {
-			log.Warn("Authentication credentials not found. Triggering gcloud auth...")
-
-			// Run gcloud auth application-default login
-			cmd := exec.Command("gcloud", "auth", "application-default", "login")
-			cmd.Stdin = os.Stdin
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-
-			if err := cmd.Run(); err != nil {
-				return nil, fmt.Errorf("authentication failed: %w", err)
-			}
-
-			log.Info("Authentication successful. Retrying storage client creation...")
-
-			// Retry creating the client
-			client, err = storage.NewClient(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create storage client after authentication: %w", err)
-			}
-		} else {
-			return nil, err
-		}
+	if !missingCredentials(err) || !interactiveTerminal() {
+		return nil, err
 	}
 
+	log.Warn("Authentication credentials not found. Triggering gcloud auth...")
+	cmd := exec.CommandContext(ctx, "gcloud", "auth", "application-default", "login")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("authentication failed: %w", err)
+	}
+
+	log.Info("Authentication successful. Retrying storage client creation...")
+	client, err = storage.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage client after authentication: %w", err)
+	}
 	return client, nil
 }
 
@@ -1082,7 +1050,6 @@ func main() {
 	stability := flag.String("stability", "stable", "Device stability level: stable, experimental, deprecated")
 	notifyDiscord := flag.Bool("notify-discord", true, "Send Discord notification after successful publish")
 	notifyOnly := flag.Bool("notify-only", false, "Send Discord notification for an already-published release (reads sizes from manifest)")
-	accessToken := flag.String("access-token", "", "GCS access token (from gcloud auth print-access-token)")
 	debug := flag.Bool("debug", false, "Enable debug logging")
 	promote := flag.Bool("promote", false, "Promote nightly to stable by removing 'nightly' from version name")
 	swap := flag.Bool("swap", false, "Replace existing version's image file while preserving metadata")
@@ -1301,7 +1268,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
 	defer cancel()
 
-	client, err := createStorageClientWithAuth(ctx, *accessToken)
+	client, err := createStorageClientWithAuth(ctx)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to create storage client")
 	}


### PR DESCRIPTION
Stacked on #215. Replaces the hand-rolled token handling in the publisher with Application Default Credentials.

## Why

The publisher accepted `--access-token` and wrapped it in a token source that stamped a fabricated 55-minute expiry on it, measured from process start. Two problems follow.

The build job mints one token before its per-storage-variant loop, so the second variant starts with a token that is already part used. In [run 30573040970](https://github.com/wendylabsinc/WendyOS-Builder/actions/runs/30573040970) the token was minted at 19:22:57 and the second publisher started at 19:52:43 — about 30 minutes into a 60-minute token, while believing it had 55 minutes left.

The refresh runs on that invented clock and never in response to a rejection. It re-mints with `gcloud auth print-access-token`, which returns a cached token unless it is within 3 min 45 s of expiry, so the replacement can also be near death and is stamped as good for another 55 minutes.

Neither has caused a failure because the 30-minute whole-run context always expired before the fabricated clock fired: the refresh path has never run in CI. #215 raises that ceiling to 2 hours and makes both reachable.

## What

The client uses ADC. In CI that is the workload-identity credentials file `google-github-actions/auth` exports as `GOOGLE_APPLICATION_CREDENTIALS`. The auth library does the token exchange and refreshes against real expiries, so how long a publisher process runs no longer depends on when the job minted a token.

The interactive `gcloud auth application-default login` fallback runs only when stdin is a terminal and no credentials are found at all. It also honours the run context.

No step calls the gcloud CLI any more, so the three Cloud SDK setup steps are removed.

The second commit deletes `tools/publisher/publisher`, a 23 MB arm64 binary committed by accident in #161. Nothing reads it — every CI invocation builds from source into `RUNNER_TEMP` — and a bare `go build ./...` in that directory writes over it.

## Merge order

wendylabsinc/wendy-lite#33 must merge first. That repo checks this publisher out with no `ref` and still passes `--access-token`.

## Testing

Given a credentials file shaped like the auth action's, with the OIDC endpoint pointed at a dead port, the client parses the external account config and fetches the subject token from that URL before the STS exchange. This confirms the url-sourced credential source is handled by the pinned library versions.

With no credentials and stdin not a terminal, the publisher reports the error instead of launching a browser login. A malformed or unreadable `GOOGLE_APPLICATION_CREDENTIALS` also reports its own error rather than triggering a login that cannot fix it.

Scopes differ: the Go client asks for `devstorage.full_control` and `cloud-platform`, a superset of what the gcloud token carried. This only proves out on the first real publish.