### PR TITLE
base-files: enable TCP MTU probing so a carrier uplink cannot black-hole the agent

### DIFF
--- a/docs/jetson-troubleshooting.md
+++ b/docs/jetson-troubleshooting.md
@@ -121,3 +121,81 @@ slot: 1,    retry_count: 0,    status: normal
   OTA cycle, it is safe to delete: `rm /data/mender/tegra-bl-version-before`
 
 ---
+
+## Device is invisible to Wendy Cloud on an LTE / carrier uplink
+
+### Symptom
+
+The device vanishes from `wendy cloud discover` and `wendy cloud device shell`
+fails — but it is **not** offline. `wendyos-agent` is running, the link is up,
+DHCP has a lease, ping and traceroute succeed, and other software on the box
+keeps using the network normally. The agent retries every 90s forever:
+
+```
+broker connection failed, reconnecting  ... authentication handshake failed: EOF  backoff:90
+cloud flusher: flush failed             ... authentication handshake failed: EOF
+mesh roster sync failed                 ... DeadlineExceeded
+```
+
+It does **not** take an LTE-only site to hit this. `99-interface-metrics.conf`
+gives ethernet metric 100 against WiFi's 300, so plugging an LTE modem into
+`eth0` moves cloud egress onto it even with WiFi up and healthy — LAN/mDNS
+management keeps working, which is why the device looks fine to anyone on site
+and dead to everyone else.
+
+### Cause
+
+The carrier path's MTU is below 1500 and it drops the ICMP "fragmentation
+needed" replies Path MTU Discovery depends on. PMTUD fails silently: small
+packets pass, large ones are black-holed with no error.
+
+TCP connects fine. The first *large* packet is a TLS ClientHello — ~1556 bytes,
+since a TLS 1.3 post-quantum key share is over 1.2 KB by itself — and it is
+never delivered, so every TLS connection hangs until it times out.
+
+### Fix
+
+Shipped since this was found: `/etc/sysctl.d/99-wendyos-pmtu.conf` sets
+`net.ipv4.tcp_mtu_probing = 1`, so the kernel searches for a working MSS when it
+detects a black hole. On an image that predates it, apply by hand:
+
+```bash
+printf 'net.ipv4.tcp_mtu_probing = 1\n' > /etc/sysctl.d/99-wendy-pmtu.conf
+sysctl -p /etc/sysctl.d/99-wendy-pmtu.conf
+```
+
+That drop-in lives on the running A/B slot and is **lost on the next OS update** —
+which is why the real fix ships in the image. For UDP/QUIC, which probing does
+not cover, clamp the connection on sites known to be behind a carrier link:
+
+```bash
+nmcli connection modify "<profile>" 802-3-ethernet.mtu 1400
+nmcli connection down "<profile>" && nmcli connection up "<profile>"
+```
+
+### Verify
+
+```bash
+sysctl net.ipv4.tcp_mtu_probing          # expect 1
+curl -sS --interface eth0 --max-time 20 -o /dev/null -w '%{http_code}\n' https://api.ipify.org
+```
+
+The device rejoins `wendy cloud discover` on its own next retry — no agent
+restart needed.
+
+### Notes
+
+- **`ping -M do` cannot be used to measure PMTU here.** BusyBox `ping` has no
+  `-M` flag, so every rung returns "invalid option" and reads as a failure —
+  including over a perfectly healthy link, which looks like a catastrophic MTU
+  problem and sends you the wrong way. Probe with `curl --interface <iface>`
+  while stepping the link MTU (`ip link set eth0 mtu N`) instead.
+- `nc -z` also misreports on this image; it failed against endpoints `curl`
+  reached over the same interface.
+- Measured on a Jetson Orin Nano on a TELUS LTE modem (2026-08-13, WDY-2443):
+  usable path MTU 1430, link at 1500, HTTPS dead at 1440+ and fine at 1430. With
+  probing enabled, HTTPS succeeds at MTU 1500 in ~4s.
+- Small packets succeeding is the tell. If ping works and TLS hangs, suspect
+  this before suspecting the agent.
+
+---

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI += " \
     file://issue \
     file://issue.net \
     file://sysctl.d/99-quiet-console.conf \
+    file://sysctl.d/99-wendyos-pmtu.conf \
     "
 
 do_install:append() {
@@ -24,6 +25,17 @@ do_install:append() {
     # Install sysctl config to quiet console (reduce kernel/audit messages)
     install -d ${D}${sysconfdir}/sysctl.d
     install -m 0644 ${UNPACKDIR}/sysctl.d/99-quiet-console.conf ${D}${sysconfdir}/sysctl.d/
+
+    # Keep TCP alive on uplinks that black-hole large packets (LTE/CGNAT).
+    # Ships in the image on purpose: /etc/sysctl.d belongs to the running A/B
+    # slot, so a drop-in applied by hand is lost on the next OS update.
+    #
+    # Only TCP is covered. The UDP/QUIC half would need an MTU clamp, and that
+    # is deliberately NOT done fleet-wide here: the safe carrier value (~1400)
+    # would also shrink every packet on the gigabit LANs where nothing is
+    # wrong. Clamp per-connection on sites known to be behind a carrier link:
+    #   nmcli connection modify "<profile>" 802-3-ethernet.mtu 1400
+    install -m 0644 ${UNPACKDIR}/sysctl.d/99-wendyos-pmtu.conf ${D}${sysconfdir}/sysctl.d/
 
     # Suppress the upstream Poky /etc/motd disclaimer.
     # Dynamic MOTD comes from update-motd via /etc/profile.d/motd.sh

--- a/recipes-core/base-files/files/sysctl.d/99-wendyos-pmtu.conf
+++ b/recipes-core/base-files/files/sysctl.d/99-wendyos-pmtu.conf
@@ -1,0 +1,32 @@
+# Survive a path that black-holes large packets (carrier / LTE / CGNAT uplinks).
+#
+# Path MTU Discovery works by sending full-size packets and trusting the network
+# to answer "fragmentation needed" when one is too big. Plenty of carrier paths
+# drop those ICMP replies. PMTUD then fails *silently*: small packets pass, every
+# large packet vanishes, and nothing reports an error.
+#
+# What that looks like on a device: ping, DNS and traceroute all succeed, the link
+# is up, DHCP is fine — and every TLS connection hangs, because a ClientHello is
+# the first large packet anything sends. The agent's is ~1556 bytes (a TLS 1.3
+# post-quantum key share is over 1.2 KB on its own), so the device is cut off from
+# Wendy Cloud while looking completely healthy to anyone standing next to it.
+#
+# Measured on a Jetson on a TELUS LTE modem, 2026-08-13 (WDY-2443): usable path
+# MTU 1430, link at 1500, HTTPS dead at 1440+ and fine at 1430. With probing on,
+# HTTPS succeeds at MTU 1500 in ~4s.
+#
+# 1 = enable packetization-layer PMTUD only after a black hole is detected. The
+#     kernel then searches for a working MSS instead of retransmitting into the
+#     void forever. This costs one stalled connection on such a path and nothing
+#     at all on a healthy one, which is why it is safe as a fleet-wide default.
+#     (2 would probe from the start; it also lowers the initial MSS on every
+#     link, including the LANs where nothing is wrong.)
+#
+# Deliberately shipped in the image rather than written to /etc on a device: on
+# an A/B OS update the running slot's /etc/sysctl.d is replaced by the new slot's,
+# so a hand-applied drop-in is lost exactly when nobody is watching.
+#
+# Covers TCP only, on both IPv4 and IPv6. UDP/QUIC still relies on the
+# application doing its own PMTU discovery — see the recipe comment for why a
+# fleet-wide MTU clamp is not the answer for that.
+net.ipv4.tcp_mtu_probing = 1


### PR DESCRIPTION
Fixes the root cause in [WDY-2443](https://linear.app/wendylabsinc/issue/WDY-2443/wendyos-pmtu-black-hole-on-lte-uplinks-silently-kills-the-agents-wendy).

## The failure

A device whose default route is an LTE modem **goes dark to Wendy Cloud while still having working internet**. It vanishes from `wendy cloud discover`, `wendy cloud device shell` fails, cameras stop reaching the relay — yet `wendyos-agent` is running, the link is up, DHCP has a lease, and ping/DNS/traceroute all succeed.

The carrier path's MTU is under 1500 and it drops the ICMP "fragmentation needed" replies PMTUD depends on, so PMTUD fails **silently**: small packets pass, large ones vanish, nothing errors.

TCP connects fine. The first large packet is a TLS ClientHello — ~1556 bytes, because a TLS 1.3 post-quantum key share is over 1.2 KB on its own — and it is never delivered:

```
* Trying 104.26.12.205:443...
* socket successfully bound to interface 'eth0'    <- TCP handshake SUCCEEDS
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
} [1556 bytes data]                                 <- first LARGE packet
* Connection timed out after 15005 milliseconds
```

Everything the agent does to reach the cloud is TLS, so all of it fails, in a 90s retry loop that never converges.

**It does not take an LTE-only site to hit this.** `99-interface-metrics.conf` gives ethernet metric 100 against WiFi's 300, so plugging an LTE modem into `eth0` moves cloud egress onto it *even with WiFi up and healthy*. LAN/mDNS management keeps working, so the device looks fine to anyone on site and dead to everyone else. The whole failure was reproduced with WiFi connected throughout.

## The change

One shipped sysctl: `net.ipv4.tcp_mtu_probing = 1`.

The kernel falls back to packetization-layer PMTUD when it detects a black hole and searches for a working MSS, instead of retransmitting into the void. It **adapts to whatever the carrier's number is** rather than hardcoding one that goes stale on a different SIM, APN or site.

Why `1` and not `2`: `1` engages only after a black hole is detected — one stalled connection on a broken path, and **nothing at all on a healthy link**, which is what makes it safe fleet-wide. `2` probes from the start and lowers the initial MSS on every link, including the LANs where nothing is wrong.

**Why it ships in the image rather than being applied to devices:** `/etc/sysctl.d` belongs to the running A/B slot, so a hand-applied drop-in survives a reboot but is lost on the next OS update — exactly when nobody is watching. Baking it in means every slot has it.

**Scope — TCP only.** The UDP/QUIC half would need an MTU clamp, deliberately *not* done fleet-wide: the safe carrier value (~1400) would also shrink every packet on the gigabit LANs where nothing is wrong. The recipe comment and the troubleshooting entry give the per-connection `nmcli` clamp for sites known to be behind a carrier link.

## Evidence

Measured on a Jetson Orin Nano on a TELUS LTE modem, stepping the link MTU and probing with a real HTTPS request:

| eth0 link MTU | 1500 | 1480 | 1460 | 1440 | 1434 | 1430 | 1428 | 1420 | 1400 | 1280 |
|---|---|---|---|---|---|---|---|---|---|---|
| HTTPS over eth0 | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ |

**Usable path MTU 1430–1433.** With `tcp_mtu_probing=1`, HTTPS succeeds at MTU **1500** in ~4s, three attempts of three.

Clamping the MTU by hand brought the device back into `wendy cloud discover` **within one poll and with no agent restart** — it self-heals on its own retry the moment packets get through. The agent was never at fault.

## Verification

I can't run a Yocto build here, so I verified the delivery mechanism on a live WendyOS 0.18.1 device (ccr1) instead:

```
/etc/sysctl.d/  →  99-quiet-console.conf, 99-usb-network-performance.conf
kernel.printk   =  3 4 1 3      ← the shipped drop-in IS applied at runtime
net.ipv4.tcp_mtu_probing = 0    ← currently off, confirming the gap
```

So a `base-files` drop-in reaches `/etc/sysctl.d` and is applied by `systemd-sysctl` on this image. This change follows `99-quiet-console.conf` exactly — same recipe, same install pattern. `base-files` rather than `meta-tegra-extensions` because the problem is board-agnostic: any device on a carrier uplink hits it. Nothing else in the repo sets `tcp_mtu_probing`, so there's no conflict.

**What still needs a real build/boot:** that the file lands in the image and reads back as `1`. Worth confirming on the first image, plus the `nmcli radio wifi off` A/B and reboot survival on the affected device.

## Also included

A troubleshooting entry (`docs/jetson-troubleshooting.md`) with symptom → cause → fix → verify, because this failure is nearly undiagnosable from the device's own vantage point. It records two traps that each cost real time:

- **`ping -M do` cannot measure PMTU on this image.** BusyBox `ping` has no `-M` flag, so every rung returns "invalid option" and reads as a failure — *including over a healthy link*, which looks like a catastrophic MTU problem and sends you the wrong way. Probe with `curl --interface <iface>` while stepping the link MTU.
- `nc -z` misreports here too; it failed against endpoints `curl` reached over the same interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)