### PR TITLE
fix: s5cmd checksums asset URL in install-build-deps.sh

### DIFF
--- a/scripts/install-build-deps.sh
+++ b/scripts/install-build-deps.sh
@@ -82,8 +82,13 @@ tmp_s5=$(mktemp -d)
 wget -qO "${tmp_s5}/s5cmd.tar.gz" \
     "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-${s5cmd_arch}.tar.gz"
 # Verify the download against the release's published checksums (finding H9).
+# NOTE: the checksums asset itself is NOT version-prefixed (unlike every other
+# release asset) — it's published as the literal name "s5cmd_checksums.txt"
+# regardless of release version (verified against the v2.2.2 release's actual
+# asset list via the GitHub releases API). The per-file entries *inside* it
+# still are version-prefixed, which is what the awk lookup below matches on.
 wget -qO "${tmp_s5}/checksums.txt" \
-    "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_checksums.txt"
+    "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_checksums.txt"
 s5cmd_sha="$(awk -v f="s5cmd_${S5CMD_VERSION}_Linux-${s5cmd_arch}.tar.gz" '$2 == f {print $1}' "${tmp_s5}/checksums.txt")"
 [[ -n "${s5cmd_sha}" ]] || { echo "no checksum for s5cmd_${S5CMD_VERSION}_Linux-${s5cmd_arch}.tar.gz" >&2; exit 1; }
 echo "${s5cmd_sha}  ${tmp_s5}/s5cmd.tar.gz" | sha256sum -c -


### PR DESCRIPTION
Cherry-pick of a fix discovered while build-verifying the WDY-2430 v4l2loopback branch — filed separately because it unblocks `make setup` for **every** board, not just that feature.

The s5cmd v2.2.2 GitHub release publishes its checksums file **unversioned** (`s5cmd_checksums.txt`); the script requested a version-prefixed name and 404'd, so bootstrap failed on any fresh machine (bug present on `main` since `b04163a`). The per-file entries inside the checksums file are version-prefixed, so the existing `awk` lookup is unchanged.

Verified against the live GitHub release assets, and exercised end-to-end by the (previously impossible) `make setup` + `bitbake v4l2loopback` run on the feature branch.

Recommend merging this before the `wdy-2430-v4l2loopback-module` PR (which carries the same commit; it will dedupe on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3p7ZahwwuHxZa5Q354r4G