### PR TITLE
ci: warm only when a compile is needed, and build variants in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -583,6 +583,64 @@ jobs:
             echo "WENDYOS_AGENT_SHA256=$sha"
           } >> "$GITHUB_ENV"
 
+      # The paths filter only knows that a file under a heavy directory changed.
+      # A dry run lists the tasks a real build would execute without running or
+      # stamping any of them, so no compile task means the matrix restores from
+      # sstate unaided and the warm would rebuild what it already has.
+      - name: Probe whether a warm is needed
+        id: probe
+        timeout-minutes: 30
+        continue-on-error: true
+        working-directory: ${{ github.workspace }}/wendyos
+        env:
+          MAP: ${{ steps.vars.outputs.map }}
+        run: |
+          set -euo pipefail
+          TREE=$(. "$GITHUB_WORKSPACE/build/.wendyos-env"; echo "$WENDYOS_LAYER_TREE")
+          warm=false
+          probed=0
+          for token in $MAP; do
+            IFS='|' read -r _ board machine <<< "$token"
+            probed=$((probed + 1))
+            {
+              printf 'WENDYOS_LAYER_TREE = "%s"\n\n' "$TREE"
+              cat "conf/template/boards/$board/local.conf"
+            } > "$GITHUB_WORKSPACE/build/conf/local.conf"
+            LOG="$RUNNER_TEMP/probe-$machine.log"
+            # errexit does not apply inside a condition, so without these a
+            # failed setup would let bitbake probe an unconfigured tree.
+            if ! (
+              cd "$GITHUB_WORKSPACE" || exit 1
+              set +u
+              # shellcheck source=/dev/null
+              . ./build/.wendyos-env || exit 1
+              # shellcheck source=/dev/null
+              source "./repos/${WENDYOS_LAYER_TREE}/openembedded-core/oe-init-build-env" build || exit 1
+              BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE WENDYOS_AGENT_VERSION WENDYOS_AGENT_SHA256" \
+                MACHINE="$machine" bitbake -n wendyos-image
+            ) > "$LOG" 2>&1; then
+              echo "::warning::probe failed for $machine; warming"
+              tail -30 "$LOG" || true
+              warm=true; break
+            fi
+            # These rebuild on every run by construction — they embed the build
+            # commit or regenerate boot files — so their compile is noise, not
+            # work. Excluding them beats listing the heavy recipes instead: an
+            # unrecognised recipe still counts, so the gate errs toward warming.
+            noise='wendyos-identity|base-files|rpi-bootfiles|rpi-cmdline|tegra-bootcontrol-overlay'
+            compiles=$(grep -E '^NOTE: Running task .*:do_(compile|configure|compile_kernelmodules)\)$' "$LOG" \
+              | grep -vcE "/(${noise})[_.]" || true)
+            missed=$(sed -n 's/.*Sstate summary:.*Missed \([0-9]*\).*/\1/p' "$LOG" | tail -1)
+            echo "$machine: ${compiles:-?} significant compile task(s), ${missed:-?} sstate object(s) missing" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            if [[ -z "$missed" || "${compiles:-1}" -gt 0 ]]; then
+              warm=true; break
+            fi
+          done
+          # An empty MAP is no evidence either way, so do not claim a skip.
+          [[ "$probed" -gt 0 ]] || warm=true
+          echo "warm=$warm" >> "$GITHUB_OUTPUT"
+
       # Build every storage variant of this device, one after another, in the
       # single build tree bootstrapped above. Each variant only needs its own
       # DEVICE/STORAGE/MACHINE, which all live in the board local.conf; repos,
@@ -597,6 +655,8 @@ jobs:
       # share one TMPDIR safely — they run sequentially and deploy under
       # tmp/deploy/images/<machine>/.
       - name: Build image (all storage variants)
+        # Unset when the probe itself failed, which reads as warm.
+        if: steps.probe.outputs.warm != 'false'
         working-directory: ${{ github.workspace }}/wendyos
         env:
           MAP: ${{ steps.vars.outputs.map }}
@@ -661,6 +721,8 @@ jobs:
     # !cancelled() keeps the skipped-warm path alive, since a plain `needs`
     # on a skipped job would skip this job too. A FAILED warm build stops the
     # run here: the matrix would fail the same way, just eight times slower.
+    # A warm skipped by the probe compiled nothing, so that early-failure
+    # guarantee only covers builds the probe judged worth warming.
     if: ${{ !cancelled() && needs.detect-changes.outputs.devices != '' && (needs.warm-caches.result == 'success' || needs.warm-caches.result == 'skipped') }}
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,9 @@ jobs:
       warm-devices: ${{ steps.set.outputs.warm-devices }}
       version: ${{ steps.version.outputs.version }}
       is-release: ${{ steps.version.outputs.is-release }}
+      agent-version: ${{ steps.agent.outputs.version }}
+      agent-sha-arm64: ${{ steps.agent.outputs.sha-arm64 }}
+      agent-sha-amd64: ${{ steps.agent.outputs.sha-amd64 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -141,6 +144,38 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Build version: $VERSION"
+
+      # Resolved once for the whole run: a release landing mid-run would
+      # otherwise pin different agent versions to different devices.
+      - id: agent
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_json="$(curl -sSfL --retry 3 --retry-all-errors --retry-delay 5 \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/wendylabsinc/WendyOS/releases/latest")"
+          # Shape-checked because the consuming steps interpolate these.
+          version="$(jq -r '.tag_name' <<<"$release_json")"
+          if [[ ! "$version" =~ ^[A-Za-z0-9._-]+$ || "$version" == "null" ]]; then
+            echo "unusable agent tag: '$version'" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          # A missing arch stays empty rather than fatal, so only the jobs
+          # that need that arch fail.
+          for arch in arm64 amd64; do
+            sha="$(jq -r --arg a "$arch" '.assets[]
+              | select(.name | test("^wendy-agent-linux-\($a)-.*\\.tar\\.gz$"))
+              | .digest' <<<"$release_json" | sed 's/^sha256://')"
+            [[ "$sha" =~ ^[0-9a-f]{64}$ ]] || {
+              echo "::warning::no $arch digest for wendyos-agent $version"
+              sha=""
+            }
+            echo "sha-$arch=$sha" >> "$GITHUB_OUTPUT"
+          done
+          echo "Resolved wendyos-agent $version for the whole run"
 
       - id: set
         env:
@@ -553,34 +588,22 @@ jobs:
       # passing the arm64 sha to an amd64 build fails do_fetch on checksum.
       - name: Resolve latest wendyos-agent version
         env:
-          GH_TOKEN: ${{ github.token }}
           DEVICE: ${{ matrix.device }}
+          VERSION: ${{ needs.detect-changes.outputs.agent-version }}
+          SHA_ARM64: ${{ needs.detect-changes.outputs.agent-sha-arm64 }}
+          SHA_AMD64: ${{ needs.detect-changes.outputs.agent-sha-amd64 }}
         run: |
           set -euo pipefail
           case "$DEVICE" in
-            generic-x86-64) ARCH=amd64 ;;
-            *)              ARCH=arm64 ;;
+            generic-x86-64) ARCH=amd64; SHA="$SHA_AMD64" ;;
+            *)              ARCH=arm64; SHA="$SHA_ARM64" ;;
           esac
-
-          release_json="$(curl -sSfL \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/wendylabsinc/WendyOS/releases/latest")"
-
-          version="$(jq -r '.tag_name' <<<"$release_json")"
-          sha="$(jq -r --arg arch "$ARCH" '.assets[]
-            | select(.name | test("^wendy-agent-linux-\($arch)-.*\\.tar\\.gz$"))
-            | .digest' <<<"$release_json" | sed 's/^sha256://')"
-
-          if [[ -z "$version" || "$version" == "null" || -z "$sha" || "$sha" == "null" ]]; then
-            echo "Failed to resolve wendyos-agent version/sha for arch '$ARCH' (version='$version' sha='$sha')" >&2
-            exit 1
-          fi
-
-          echo "Resolved wendyos-agent $version for $ARCH (sha256=$sha)"
+          [[ -n "$VERSION" && -n "$SHA" ]] \
+            || { echo "no wendyos-agent $ARCH asset resolved for this run" >&2; exit 1; }
+          echo "Resolved wendyos-agent $VERSION for $ARCH (sha256=$SHA)"
           {
-            echo "WENDYOS_AGENT_VERSION=$version"
-            echo "WENDYOS_AGENT_SHA256=$sha"
+            echo "WENDYOS_AGENT_VERSION=$VERSION"
+            echo "WENDYOS_AGENT_SHA256=$SHA"
           } >> "$GITHUB_ENV"
 
       # The paths filter only knows that a file under a heavy directory changed.
@@ -1006,34 +1029,22 @@ jobs:
       # passing the arm64 sha to an amd64 build fails do_fetch on checksum.
       - name: Resolve latest wendyos-agent version
         env:
-          GH_TOKEN: ${{ github.token }}
           DEVICE: ${{ matrix.device }}
+          VERSION: ${{ needs.detect-changes.outputs.agent-version }}
+          SHA_ARM64: ${{ needs.detect-changes.outputs.agent-sha-arm64 }}
+          SHA_AMD64: ${{ needs.detect-changes.outputs.agent-sha-amd64 }}
         run: |
           set -euo pipefail
           case "$DEVICE" in
-            generic-x86-64) ARCH=amd64 ;;
-            *)              ARCH=arm64 ;;
+            generic-x86-64) ARCH=amd64; SHA="$SHA_AMD64" ;;
+            *)              ARCH=arm64; SHA="$SHA_ARM64" ;;
           esac
-
-          release_json="$(curl -sSfL \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/wendylabsinc/WendyOS/releases/latest")"
-
-          version="$(jq -r '.tag_name' <<<"$release_json")"
-          sha="$(jq -r --arg arch "$ARCH" '.assets[]
-            | select(.name | test("^wendy-agent-linux-\($arch)-.*\\.tar\\.gz$"))
-            | .digest' <<<"$release_json" | sed 's/^sha256://')"
-
-          if [[ -z "$version" || "$version" == "null" || -z "$sha" || "$sha" == "null" ]]; then
-            echo "Failed to resolve wendyos-agent version/sha for arch '$ARCH' (version='$version' sha='$sha')" >&2
-            exit 1
-          fi
-
-          echo "Resolved wendyos-agent $version for $ARCH (sha256=$sha)"
+          [[ -n "$VERSION" && -n "$SHA" ]] \
+            || { echo "no wendyos-agent $ARCH asset resolved for this run" >&2; exit 1; }
+          echo "Resolved wendyos-agent $VERSION for $ARCH (sha256=$SHA)"
           {
-            echo "WENDYOS_AGENT_VERSION=$version"
-            echo "WENDYOS_AGENT_SHA256=$sha"
+            echo "WENDYOS_AGENT_VERSION=$VERSION"
+            echo "WENDYOS_AGENT_SHA256=$SHA"
           } >> "$GITHUB_ENV"
 
       # Build every storage variant of this device, one after another, in the

--- a/conf/template/include/local/common.inc
+++ b/conf/template/include/local/common.inc
@@ -2,17 +2,19 @@
 
 DL_DIR = "${TOPDIR}/../downloads"
 
-# RPi kernel source mirror. The self-hosted runner image bakes a bitbake mirror
-# tarball of the 5+ GB raspberrypi/linux kernel tree at /opt/source-mirror
-# (wendylabsinc/ci, seed-kernel-source-mirror.sh). Without this, the
-# linux-raspberrypi do_fetch cold-clones that tree from GitHub at job time,
-# which intermittently stalls / exits 128 and fails the RPi builds. Point
-# PREMIRRORS at the baked tarball so the fetch is a local extract instead.
+# RPi kernel source mirror. The self-hosted runner image bakes bitbake mirror
+# tarballs at /opt/source-mirror (wendylabsinc/ci, seed-kernel-source-mirror.sh).
+# Without these, linux-raspberrypi's do_fetch cold-clones at job time, which
+# intermittently stalls / exits 128 and fails the RPi builds. Point PREMIRRORS at
+# the baked tarballs so the fetch is a local extract instead.
 #
 # Guarded on the directory existing, so local and dev builds (no mirror) are
-# unaffected; if the tarball is ever absent, this is a PREMIRRORS (not
+# unaffected; if a tarball is ever absent, this is a PREMIRRORS (not
 # BB_FETCH_PREMIRRORONLY), so bitbake still falls back to the upstream SRC_URI.
 PREMIRRORS:prepend = "${@'git://github.com/raspberrypi/linux.* file:///opt/source-mirror/ \n' if os.path.isdir('/opt/source-mirror') else ''}"
+# The kernel recipe fetches a second git source, the kmeta, which the pattern
+# above does not match.
+PREMIRRORS:prepend = "${@'git://git.yoctoproject.org/yocto-kernel-cache.* file:///opt/source-mirror/ \n' if os.path.isdir('/opt/source-mirror') else ''}"
 # sstate-cache is partitioned per layer tree so cross-series builds (e.g.
 # scarthgap Orin and wrynose Thor on the same workspace) don't share
 # signatures or accidentally collide. Downloads stay shared — source


### PR DESCRIPTION
`bitbake -n` now runs first. It executes nothing and writes no stamps, but lists the tasks a real build would run. If none of them compiles, the warm is skipped and the matrix restores from sstate as it already would have. Any probe failure warms, so the fallback is today's behaviour.

One job per variant again, so they queue independently instead of running sequentially inside one job. The warm matrix stays merged, so the MACHINE-independent bulk is still compiled once per device, not once per disk.

`warm-caches` is dispatched by a paths filter, but whether a warm is needed depends on task hashes. A one-line edit to `conf/distro/wendyos.conf` trips the `global` filter and warms all 7 devices.

`publish` now holds a device back until every one of its variants has an entry (previously a failed SD build could bump the device's `latest` to a version with no SD image), and the agent version is resolved once per run instead of once per job, so two variants of one board can't pin different agents under one version.