### PR TITLE
fix(tegra): re-enable the TCP metrics cache

### DIFF
--- a/meta-tegra-extensions/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
+++ b/meta-tegra-extensions/recipes-support/usb-network-tuning/files/99-usb-network-performance.conf
@@ -42,8 +42,12 @@ net.ipv4.tcp_timestamps = 1
 # Enable selective acknowledgments for better recovery from packet loss
 net.ipv4.tcp_sack = 1
 
-# Don't cache TCP metrics from previous connections
-net.ipv4.tcp_no_metrics_save = 1
+# Cache TCP metrics from previous connections (kernel default). The cache
+# carries learned path-MTU/MSS across connections to the same peer, which
+# matters on LTE/CGNAT uplinks where PMTU discovery is black-holed
+# (WDY-2443): with the cache disabled, every new connection rediscovers
+# the black hole from scratch.
+net.ipv4.tcp_no_metrics_save = 0
 
 # TCP memory allocation: min, pressure, max (in pages)
 net.ipv4.tcp_mem = 786432 1048576 26777216


### PR DESCRIPTION
## Summary

Part of [WDY-2443](https://linear.app/wendylabsinc/issue/WDY-2443), split out so it can be discussed independently of the outage fix (#234).

`net.ipv4.tcp_no_metrics_save=1` in the Tegra-only `99-usb-network-performance.conf` discards learned per-destination TCP metrics — including the discovered path MTU — after every connection. On LTE/CGNAT uplinks whose path black-holes full-size packets, that makes every new connection rediscover the black hole from scratch instead of reusing what the previous connection learned via `tcp_mtu_probing`. And Tegra is exactly the hardware deployed behind LTE.

This restores the kernel default (0), keeping the key explicit with a comment explaining why.

If the original setting was intentional for USB-gadget throughput benchmark repeatability, it should be applied ad hoc during benchmarks rather than shipped fleet-wide — happy to discuss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3p7ZahwwuHxZa5Q354r4G