### PR TITLE
publisher: drop the committed build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 *.py[cod]
 
 docs/superpowers
+
+# Go names the output after its directory; CI builds the publisher from source.
+/tools/publisher/publisher


### PR DESCRIPTION
A 23 MB macOS binary that CI never uses: every publish step builds its own from source. Ignored so a local `go build` in that directory cannot re-add it.