### PR TITLE
Ship BuildKit, so a build host survives an OS update

### DIFF
--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -125,6 +125,21 @@ WENDYOS_UPDATE_BOOTLOADER ?= "1"
 # set to "0" in a machine conf to opt out.
 WENDYOS_CONTAINER_RUNTIME ?= "1"
 
+# Build host support (BuildKit). Lets `wendy run --build-host <device>` build
+# container images on this device instead of a developer's laptop, which matters
+# when the developer is remote: an edge image push measured ~67 KB/s over a home
+# link, versus minutes on the office network.
+#
+# Off by default, and for two separate reasons. BuildKit is ~85 MB of binaries
+# that most devices will never use, and running builds for other people is a
+# thing a device should opt into rather than acquire by being reachable -- the
+# agent enforces the second half separately, gating BuildImage on its own
+# marker file, so this flag is about whether the daemon is on the image at all.
+#
+# Opt in on boards that are actually meant to build: the Sparks and the AGX
+# Thors, not a camera box.
+WENDYOS_BUILD_HOST ?= "0"
+
 # Driver add-ons (systemd-sysext). Adds the kernel prerequisites for merging a driver
 # image at runtime, plus module signing. Off by default; opted into per machine so a
 # board only takes the kernel delta once it is actually shipping driver support.

--- a/recipes-containers/buildkit/buildkit_0.32.2.bb
+++ b/recipes-containers/buildkit/buildkit_0.32.2.bb
@@ -1,0 +1,91 @@
+SUMMARY = "BuildKit daemon, for devices acting as a wendy build host"
+DESCRIPTION = "buildkitd + buildctl, so `wendy run --build-host <device>` can \
+build container images on this device instead of a developer's laptop."
+HOMEPAGE = "https://github.com/moby/buildkit"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+# Upstream's own release binaries, pinned by version AND checksum for the same
+# reason wendyos-agent pins both: the version is part of SRC_URI and the checksum
+# is part of the do_fetch signature, so a bump re-runs the fetch instead of
+# serving a stale cached tarball.
+#
+# 0.32.2 is the version verified end to end on a Jetson AGX Thor and a DGX Spark
+# acting as build hosts. Bump version and BOTH checksums together.
+BUILDKIT_VERSION = "0.32.2"
+BUILDKIT_RELEASE_ARCH = "arm64"
+BUILDKIT_RELEASE_ARCH:x86-wendyos = "amd64"
+
+SRC_URI = "https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/buildkit-v${BUILDKIT_VERSION}.linux-${BUILDKIT_RELEASE_ARCH}.tar.gz;name=buildkit \
+           file://buildkit.service \
+           file://buildkitd.toml"
+
+SRC_URI[buildkit.sha256sum] = "${@d.getVar('BUILDKIT_SHA256_' + d.getVar('BUILDKIT_RELEASE_ARCH'))}"
+BUILDKIT_SHA256_arm64 = "9e8f46bf309ec0ab262967be5538a4dbe06be756a82621f98253933bac5dcf92"
+BUILDKIT_SHA256_amd64 = "2975d0f651ad96ba8b80b9992ae1f9a964f4408569af5b6dc36544165c3926af"
+
+S = "${UNPACKDIR}"
+
+inherit systemd
+
+# NOT auto-enabled. Running other people's builds is something a device opts
+# into: the agent gates it on its own marker file (build-host-enabled, set by
+# `wendy cloud device build-host enable`), and starting the daemon on every
+# device would spend memory on hosts that will never build. The unit is
+# installed and left disabled; enabling the role starts it.
+SYSTEMD_SERVICE:${PN} = "buildkit.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"
+
+COMPATIBLE_MACHINE = "^(?!qemuall).*$"
+
+do_install() {
+    # /opt, not /usr/local: a merged sysext driver add-on turns /usr into an
+    # ephemeral overlay, so anything installed under it is discarded on the next
+    # reboot (same reason wendyos-agent lives in /opt/wendyos/bin).
+    install -d ${D}/opt/buildkit/bin
+
+    # The tarball unpacks to bin/. Install every shipped binary rather than a
+    # hand-listed subset: buildkitd needs its runc and CNI helpers, and the
+    # buildkit-qemu-* binaries are what a future emulated-platform build would
+    # use. Find them rather than globbing a hard-coded path so an upstream
+    # layout change fails loudly here instead of silently shipping nothing.
+    BINDIR=$(find ${S} -type d -name bin | head -1)
+    if [ -z "${BINDIR}" ]; then
+        bbfatal "no bin/ directory in the unpacked buildkit release archive"
+    fi
+    for f in "${BINDIR}"/*; do
+        install -m 0755 "$f" ${D}/opt/buildkit/bin/
+    done
+    test -x ${D}/opt/buildkit/bin/buildkitd || bbfatal "buildkitd missing from the release archive"
+    test -x ${D}/opt/buildkit/bin/buildctl  || bbfatal "buildctl missing from the release archive"
+
+    # The agent execs a bare "buildctl" (build_service.go), so it must be on
+    # PATH. Symlinks only -- the binaries themselves stay in /opt.
+    install -d ${D}${bindir}
+    ln -sf /opt/buildkit/bin/buildctl  ${D}${bindir}/buildctl
+    ln -sf /opt/buildkit/bin/buildkitd ${D}${bindir}/buildkitd
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/buildkit.service ${D}${systemd_system_unitdir}/
+
+    # Config, which is where the state directory is set. See buildkitd.toml.
+    install -d ${D}${sysconfdir}/buildkit
+    install -m 0644 ${UNPACKDIR}/buildkitd.toml ${D}${sysconfdir}/buildkit/
+}
+
+FILES:${PN} = "/opt/buildkit/bin/* \
+               ${bindir}/buildctl \
+               ${bindir}/buildkitd \
+               ${sysconfdir}/buildkit/buildkitd.toml \
+               ${systemd_system_unitdir}/* \
+               "
+
+# Prebuilt upstream binaries: no source to strip or split, and they are already
+# built for the target arch.
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+EXCLUDE_FROM_SHLIBS = "1"
+SKIP_FILEDEPS:${PN} = "1"
+
+RDEPENDS:${PN} += "ca-certificates"

--- a/recipes-containers/buildkit/files/buildkit.service
+++ b/recipes-containers/buildkit/files/buildkit.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=BuildKit daemon
+Documentation=https://github.com/moby/buildkit
+# Ordered after /data is available: the state directory set in buildkitd.toml
+# lives there, and a daemon that starts first would create it on the root
+# filesystem instead -- the exact failure this configuration exists to avoid.
+After=network-online.target local-fs.target
+Wants=network-online.target
+RequiresMountsFor=/data
+
+[Service]
+Type=simple
+# Config path is buildkitd's own default (/etc/buildkit/buildkitd.toml), so the
+# state directory comes from the file rather than from flags. Anyone reading
+# `ps` sees no --root and might assume the default; the config is the one place
+# it is written down.
+ExecStart=/opt/buildkit/bin/buildkitd --addr unix:///run/buildkit/buildkitd.sock
+Restart=always
+RestartSec=2
+# BuildKit's runc executor manages its own cgroup subtree for build steps.
+Delegate=yes
+KillMode=process
+# A build is best-effort work on a device whose real job is running apps. Prefer
+# killing a build over the agent or an app if the device runs out of memory.
+OOMScoreAdjust=500
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-containers/buildkit/files/buildkitd.toml
+++ b/recipes-containers/buildkit/files/buildkitd.toml
@@ -1,0 +1,30 @@
+# BuildKit state directory and cache policy for a WendyOS build host.
+#
+# WHY root IS SET HERE
+#
+# buildkitd's default --root is /var/lib/buildkit, which on WendyOS is the A/B
+# root filesystem. Measured on a Jetson AGX Thor: 12 GB with 4.6 GB free, beside
+# a /data partition with 862 GB. A build cache grows by design, and an edge image
+# that compiles a TensorRT engine writes gigabytes -- so the default does not
+# produce a failed build, it fills the partition the device boots from.
+#
+# /data is also the partition that survives an OS update, so a cache here is not
+# thrown away every time the device is updated.
+root = "/data/buildkit"
+
+[worker.oci]
+  enabled = true
+  # Bound the cache regardless of where it lives. Unbounded growth is harmless on
+  # a 900 GB partition and fatal on a 12 GB one, and this file is the only thing
+  # standing between the two if root is ever changed.
+  gc = true
+  [[worker.oci.gcpolicy]]
+    keepBytes = "40GB"
+    keepDuration = "336h"
+
+[worker.containerd]
+  # Off deliberately. containerd on this device belongs to the agent, which runs
+  # the apps: a second client sharing its content store and namespaces means two
+  # writers to state the agent believes it owns. The OCI worker above is
+  # self-contained.
+  enabled = false

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -169,6 +169,18 @@ IMAGE_INSTALL:append = " \
     ${@oe.utils.ifelse(d.getVar('WENDYOS_CONTAINER_RUNTIME') == '1', ' packagegroup-wendyos-container', '')} \
     "
 
+# Build host support (BuildKit). Off unless a machine opts in with
+# WENDYOS_BUILD_HOST = "1" -- see wendyos.conf for why it is not the default.
+#
+# Shipping it in the image is the point: installed by hand it lands on the A/B
+# root filesystem, so the next OS update boots a slot without it and the device
+# silently stops being a build host. The agent still reports the role as enabled
+# (its marker lives on /data), which is a state nobody can explain from the
+# outside.
+IMAGE_INSTALL:append = " \
+    ${@oe.utils.ifelse(d.getVar('WENDYOS_BUILD_HOST') == '1', ' buildkit', '')} \
+    "
+
 # Note: gadget-network-config (standalone dnsmasq) removed.
 # USB gadget IPv4 mode is controlled by WENDYOS_USB_NET_MODE (see wendyos.conf).
 


### PR DESCRIPTION
**Draft: never been through bitbake.** See "What is unverified" — this needs an image build before it can be trusted.

Pairs with WendyOS #1767, which makes the same hazards visible from the CLI.

## The problem

`wendy run --build-host <device>` needs buildkitd on the device, and nothing provides it. Installing it by hand works — until the next OS update.

Verified on `joannis-agx-thor`:

| path | on | survives an OS update? |
|---|---|---|
| `/usr/local/bin` | `/` (A/B rootfs slot) | **no** |
| `/etc/systemd/system` | `/` (A/B rootfs slot) | **no** |
| `/data` | `nvme0n1p17`, 912 GB | yes |

So an update boots a slot with neither the daemon nor its unit. **And the failure is quiet:** the agent's opt-in marker lives at `/data/etc/wendy-agent/build-host-enabled` and *does* survive, so the device keeps reporting the builder role as enabled while having nothing to build with — a state nobody can explain from the outside.

## Second problem, same cause: where the cache goes

`buildkitd`'s default `--root` is `/var/lib/buildkit`, which on that Thor is a **12 GB filesystem with 4.6 GB free**, beside 862 GB of `/data`. A build cache grows by design, and an edge image that compiles a TensorRT engine writes gigabytes — so the default does not produce a failed build, it fills the partition the device boots from. theta already sits at 97% on `/`.

`buildkitd.toml` therefore sets `root = "/data/buildkit"`, plus a GC policy — because that file is all that stands between the two outcomes if `root` is ever changed.

## Deliberate choices

**Off by default** (`WENDYOS_BUILD_HOST = "0"`). ~85 MB most devices will never use, and a camera box has no business running other people's builds. Opt in on the Sparks and AGX Thors.

**Installed but not auto-enabled.** The agent already gates `BuildImage` on its own marker file, so the unit ships disabled and enabling the role starts it. Starting a daemon on every image would spend memory on hosts that never build.

**Binaries in `/opt/buildkit/bin`, symlinks on PATH.** For the reason `wendyos-agent` already documents: a merged sysext driver add-on turns `/usr` into an ephemeral overlay, so anything installed there is discarded on reboot. The agent execs a bare `"buildctl"` (`build_service.go`), so the symlinks are load-bearing, not cosmetic.

**containerd worker disabled.** containerd on these devices belongs to the agent that runs the apps; a second client sharing its content store and namespaces means two writers to state the agent believes it owns.

**`OOMScoreAdjust=500`** — a build is best-effort work on a device whose real job is running apps, so it should die before the agent does.

**`RequiresMountsFor=/data`** — a daemon that starts before `/data` is mounted would create its state directory on the root filesystem, which is the exact failure this configuration exists to avoid.

## What is verified, and what is not

**Verified, by hand, on real hardware:** buildkit 0.32.2 with these binaries on a Jetson AGX Thor and a DGX Spark, both building and delivering images to Jetson camera boxes in another country. `root` on `/data` confirmed working; the default confirmed dangerous (4.6 GiB free).

**Not verified:** this recipe. It has never run through bitbake. Specifically unchecked —

- whether the prebuilt-binary inhibits (`INHIBIT_PACKAGE_STRIP` and friends) are the right set for this tarball
- whether `COMPATIBLE_MACHINE` and the arch mapping behave on an x86 machine
- image size impact with the flag on
- that `SYSTEMD_AUTO_ENABLE = "disable"` produces an installed-but-inactive unit as intended
- that the `find`-based install survives an upstream layout change as loudly as intended

The checksums are the digests GitHub reports for the release assets, not values recomputed locally — a truncated download hashes cleanly, and using one would produce a recipe that fails `do_fetch` with an error pointing at upstream rather than at this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)