### PR TITLE
ci: select Wendy-owned self-hosted Linux runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,7 +218,7 @@ jobs:
       # GitHub mints the OIDC token (not the runner), so GCP Workload Identity
       # Federation still works on the self-hosted platform.
       id-token: write
-    runs-on: [self-hosted, linux, x64, wendyos-builder]
+    runs-on: [self-hosted, linux, x64, wendy-linux, wendyos-builder]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}


### PR DESCRIPTION
> **In plain terms:** Jobs meant for private Wendy machines could otherwise rely only on generic system labels. They now also request a Wendy-specific Linux label, keeping private runner selection explicit and separate from GitHub's hosted machines.

## Summary
- Require `wendy-linux` on every active self-hosted Linux job in this repository.
- Preserve existing architecture, tenant, and hardware capability labels.
- Leave GitHub-hosted runner selectors and workflow permissions unchanged.

## Tests
- `actionlint -shellcheck '' -ignore 'label ".*" is unknown'` on every changed workflow
- YAML parse validation on every changed workflow
- `git diff --check`

## Rollout
- Keep this draft until the corresponding self-hosted runners expose `wendy-linux`.
- If jobs remain queued, roll back this workflow selector rather than introducing an ambiguous GitHub-hosted image label.
