### PR TITLE
drivers: treat 'all' as the every-device sentinel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1328,6 +1328,9 @@ jobs:
     uses: ./.github/workflows/drivers.yml
     with:
       version: ${{ needs.detect-changes.outputs.version }}
+      # Passed explicitly: an input the call omits resolves to this run's own
+      # dispatch value, not to blank.
+      device: ${{ inputs.device }}
     secrets: inherit
 
   # Advancing "latest" is what actually offers a version to a device, so it runs

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -8,14 +8,26 @@ name: Build driver add-ons
 on:
   workflow_call:
     inputs:
+      # Defaulted here, not just at the call site: an input the caller omits
+      # otherwise resolves to that run's own dispatch value.
       version:
         description: OS version whose devkits to build against; blank = each device's latest
         type: string
         required: false
+        default: ""
+      device:
+        description: Limit to one device ('' or 'all' = every device that publishes a devkit)
+        type: string
+        required: false
+        default: ""
   workflow_dispatch:
     inputs:
       device:
-        description: Limit to one device (blank = every device that publishes a devkit)
+        description: Limit to one device ('' or 'all' = every device that publishes a devkit)
+        type: string
+        required: false
+      version:
+        description: OS version whose devkits to build against; blank = each device's latest
         type: string
         required: false
 
@@ -67,7 +79,9 @@ jobs:
           # list; its keys are device/storage, so collapse to unique devices.
           mapfile -t DEVICES < <(jq -r 'keys[] | split("/")[0]' \
             .github/device-artifacts.json | sort -u)
-          if [[ -n "${ONLY_DEVICE:-}" ]]; then
+          # 'all' is build.yml's every-device sentinel, and its dispatch inputs
+          # reach this called workflow even though the call does not pass them.
+          if [[ -n "${ONLY_DEVICE:-}" && "$ONLY_DEVICE" != "all" ]]; then
             DEVICES=("$ONLY_DEVICE")
           fi
           # mapfile cannot fail the step, so an unreadable inventory would leave
@@ -127,7 +141,8 @@ jobs:
           # this run verified nothing. Reporting success would make an empty
           # check indistinguishable from a passing one.
           if [[ "$n" -eq 0 ]]; then
-            echo "::error::${#DRIVERS[@]} driver(s) present but no devkit published under '${PREFIX:-<public>}'"
+            echo "::error::${#DRIVERS[@]} driver(s) present but no devkit published" \
+                 "under '${PREFIX:-<public>}' for: ${DEVICES[*]}"
             exit 1
           fi
 


### PR DESCRIPTION
`workflow_dispatch` runs of `build.yml` fail; `push` and `pull_request` runs of the same commit pass
runs 33264472285 (dispatch, failed) and 33212078643 (push, passed) built the identical commit `ea070ee` - only the trigger differed.

`drivers.yml` reads `ONLY_DEVICE: ${{ inputs.device }}`, but declares `device` only under `workflow_dispatch`, and `build.yml` never passes it. On a dispatch run the parent's `device` input (choice default `all`) surfaces in the called workflow's `inputs` context anyway. `build.yml` treats `all` as "every device"; `drivers.yml` treated it as a device name, fetched `manifests/all.json`, 404'd, resolved zero devices and exited 1.

No add-ons were published, so `Promote to latest` then correctly refused to advance `raspberry-pi-5` onto a version with no drivers one cause

## The fix:
- `all`, like `''`, is the every-device sentinel in `drivers.yml`
- `device` and `version` are declared on both triggers, with `workflow_call` defaults of `""` so an omitted input is blank instead of inherited
- `build.yml` passes `device` explicitly
- The empty-result error now names the devices it searched
