### PR TITLE
Feature/vm support

### DIFF
--- a/.github/device-artifacts.json
+++ b/.github/device-artifacts.json
@@ -8,5 +8,7 @@
   "raspberry-pi-5/sd":      { "image_kind": "sdimg-gz-with-wic-fallback", "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": true },
   "raspberry-pi-4/sd":      { "image_kind": "sdimg-gz-with-wic-fallback", "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false },
   "raspberry-pi-3/sd":      { "image_kind": "sdimg-gz-with-wic-fallback", "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false },
-  "generic-x86-64/disk":    { "image_kind": "wic-disk",                   "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false }
+  "generic-x86-64/disk":    { "image_kind": "wic-disk",                   "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false },
+  "vm-arm64/disk":          { "image_kind": "wic-disk",                   "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false },
+  "vm-x86-64/disk":         { "image_kind": "wic-disk",                   "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ on:
           - jetson-orin-nano
           - jetson-agx-thor
           - generic-x86-64
+          - vm-arm64
+          - vm-x86-64
       version:
         description: "Git ref (commit SHA, tag, or branch) to build. Empty = latest main."
         type: string
@@ -159,7 +161,9 @@ jobs:
             {"device":"generic-x86-64","storages":"disk"},
             {"device":"raspberry-pi-5","storages":"nvme sd"},
             {"device":"raspberry-pi-4","storages":"sd"},
-            {"device":"raspberry-pi-3","storages":"sd"}
+            {"device":"raspberry-pi-3","storages":"sd"},
+            {"device":"vm-arm64","storages":"disk"},
+            {"device":"vm-x86-64","storages":"disk"}
           ]'
           # Collapse to one line so it can be written to $GITHUB_OUTPUT, which
           # requires single-line key=value pairs (no implicit multiline support).
@@ -167,7 +171,7 @@ jobs:
 
           emit_all() {
             echo "matrix={\"include\":${ALL_MATRIX}}" >> "$GITHUB_OUTPUT"
-            echo "devices=jetson-agx-thor jetson-agx-orin jetson-orin-nano generic-x86-64 raspberry-pi-5 raspberry-pi-4 raspberry-pi-3" >> "$GITHUB_OUTPUT"
+            echo "devices=jetson-agx-thor jetson-agx-orin jetson-orin-nano generic-x86-64 raspberry-pi-5 raspberry-pi-4 raspberry-pi-3 vm-arm64 vm-x86-64" >> "$GITHUB_OUTPUT"
           }
 
           emit_one() {
@@ -276,6 +280,8 @@ jobs:
               jetson-orin-nano:sd)   BOARD=jetson-orin-nano-sd;   MACHINE=jetson-orin-nano-devkit-wendyos ;;
               jetson-agx-thor:nvme) BOARD=jetson-agx-thor;       MACHINE=jetson-agx-thor-devkit-nvme-wendyos ;;
               generic-x86-64:disk)  BOARD=generic-x86-64;       MACHINE=genericx86-64-wendyos ;;
+              vm-arm64:disk)        BOARD=vm-arm64;             MACHINE=vm-arm64-wendyos ;;
+              vm-x86-64:disk)       BOARD=vm-x86-64;            MACHINE=vm-x86-64-wendyos ;;
               *) echo "Unknown device/storage: $DEVICE/$STORAGE"; exit 1 ;;
             esac
             MAP="$MAP $STORAGE|$BOARD|$MACHINE"
@@ -489,8 +495,8 @@ jobs:
       #
       # Arch-aware: the release publishes one tarball per arch and the recipe
       # fetches wendy-agent-linux-<arch>-<version>.tar.gz for the arch matching
-      # the MACHINE (arm64 for Tegra/RPi, amd64 for generic-x86-64 via
-      # WENDYOS_AGENT_RELEASE_ARCH:x86-wendyos). WENDYOS_AGENT_SHA256 must be the
+      # the MACHINE (arm64 for Tegra/RPi/vm-arm64, amd64 for generic-x86-64 and
+      # vm-x86-64 via WENDYOS_AGENT_RELEASE_ARCH). WENDYOS_AGENT_SHA256 must be the
       # checksum for THAT tarball, so resolve the digest for this job's arch —
       # passing the arm64 sha to an amd64 build fails do_fetch on checksum.
       - name: Resolve latest wendyos-agent version
@@ -500,8 +506,8 @@ jobs:
         run: |
           set -euo pipefail
           case "$DEVICE" in
-            generic-x86-64) ARCH=amd64 ;;
-            *)              ARCH=arm64 ;;
+            generic-x86-64|vm-x86-64) ARCH=amd64 ;;
+            *)                        ARCH=arm64 ;;
           esac
 
           release_json="$(curl -sSfL \
@@ -590,6 +596,7 @@ jobs:
           EXPECTED_KB=12582912  # 12 GiB, Jetson + generic-x86-64
           case "$DEVICE" in
             raspberry-pi-*) EXPECTED_KB=8388608 ;;  # 8 GiB, RPi
+            vm-*)           EXPECTED_KB=3145728 ;;  # 3 GiB, VM (two A/B slots on a laptop disk)
           esac
           EXPECTED=$((EXPECTED_KB * 1024))
 

--- a/README.md
+++ b/README.md
@@ -1257,8 +1257,9 @@ reboot
 
 > **Requirements:** a host CPU with x86-64-v3 (Haswell/Excavator or newer), plus
 > `qemu-system-x86_64`, `qemu-img` and OVMF firmware — on Debian/Ubuntu that is
-> `sudo apt install qemu-system-x86 qemu-utils ovmf`. KVM is used when `/dev/kvm`
-> is readable (add yourself to the `kvm` group); the script falls back to software
+> `sudo apt install qemu-system-x86 qemu-utils ovmf`, on macOS `brew install qemu`.
+> Acceleration is KVM on Linux (when `/dev/kvm` is readable — add yourself to the
+> `kvm` group) and Hypervisor.framework on macOS; the script falls back to software
 > emulation otherwise, which works but is slow.
 
 <a name="several-vms-at-once"></a>
@@ -1274,8 +1275,9 @@ clone costs a few hundred KB rather than a full disk copy:
 
 Instances are independent — separate disks, separate UEFI variables, separate
 device identities — and each gets its own forwarded SSH port. State lives in
-`<workspace>/vm/<name>/`. Delete that directory, or use `--recreate`, to reset
-one to a first boot.
+`<workspace>/vm/<machine>/<name>/`, namespaced by machine so the same instance
+name can be used for each without collision. Delete that directory, or use
+`--recreate`, to reset one to a first boot.
 
 After a rebuild, existing instances stay bound to the image they were created
 from. `run-vm.sh` warns when it notices this and `--recreate` moves an instance
@@ -1296,18 +1298,28 @@ the console, and the firmware in front of GRUB.
 The image boots on either UTM backend on an Apple Silicon Mac, and on bare QEMU
 with `-machine virt`. It carries a getty on both `ttyAMA0` (the PL011 on a QEMU
 `virt` guest) and `hvc0` (the virtio console under Apple's Virtualization
-framework), so a login prompt appears whichever one the host provides. For bare
-QEMU the build also deploys `u-boot-vm-arm64-wendyos-*.bin`, usable as `-bios`,
-so no host firmware package is needed; UTM supplies its own UEFI.
+framework), so a login prompt appears whichever one the host provides. Bare QEMU
+needs a UEFI implementation on the host (AAVMF); UTM supplies its own.
 
-`scripts/run-vm.sh` is x86_64-only — an arm64 host path has not been written
-yet. To boot the arm64 image on a Mac, follow
-`docs/howto/vm-arm64-utm-test.md`, which walks through UTM setup step by step.
+`scripts/run-vm.sh` runs it too — pass `-m vm-arm64-wendyos`. On an arm64 host
+that is hardware-accelerated (KVM on Linux, Hypervisor.framework on macOS); on an
+x86_64 host it falls back to TCG emulation, which is slow but exercises the same
+boot chain, so the arm64 image can be tested without arm64 hardware. Firmware is
+autodetected (`sudo apt install qemu-efi-aarch64 qemu-system-arm`, or
+`brew install qemu`).
 
-> **Status:** this machine builds and its artifacts are verified, but it has not
-> yet been booted. The howto above doubles as the first-boot test protocol and
-> names the two things still unproven — whether GRUB's menu reaches the serial
-> console, and whether the firmware publishes the device tree the kernel needs.
+The script is written to run on macOS as well as Linux, but the macOS path has
+not yet been exercised on a Mac — the Homebrew firmware locations and the `hvf`
+accelerator are marked UNVERIFIED in the script and are the two things to check
+first if it misbehaves there. `docs/howto/vm-arm64-utm-test.md` covers the UTM
+route, which needs no command line at all.
+
+> **Status:** validated on Linux under emulation — boot, GRUB menu on the serial
+> console, and a full A/B OTA install/switch/commit cycle. Not yet run on UTM,
+> which is what the howto above covers. U-Boot was evaluated as the guest
+> firmware and rejected: it loads our boot chain correctly but hands the kernel a
+> device tree with no disk buses, so root never appears. A real UEFI
+> implementation (AAVMF, or UTM's own) is the supported path.
 
 ## QEMU (ARM64)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ This repository provides the meta-layer and build flow to build **WendyOS** — 
 | Raspberry Pi 5 | Broadcom BCM2712 | 8GB | `rpi5-sd` | `raspberrypi5-wendyos` | SD | Mender |
 | Raspberry Pi 5 | Broadcom BCM2712 | 8GB | `rpi5-nvme` | `raspberrypi5-nvme-wendyos` | NVMe | Mender |
 | QEMU ARM64 | virtual | configurable | `qemu-arm64` | `qemuarm64-wendyos` | virtio | none |
-| Generic x86_64 PC | Intel/AMD x86_64 | varies | `generic-x86-64` | `genericx86-64-wendyos` | USB / disk (.wic) | none |
+| Generic x86_64 PC | Intel/AMD x86_64 | varies | `generic-x86-64` | `genericx86-64-wendyos` | USB / disk (.wic) | wendyos-update |
+| Virtual machine (x86_64) | virtual | configurable | `vm-x86-64` | `vm-x86-64-wendyos` | virtio (.wic) | wendyos-update |
 
 ## TL;DR
 
@@ -69,6 +70,10 @@ make flash-to-external  # Flash to external NVMe/USB drive
 - [Generic x86_64 PCs](#generic-x86_64-pcs)
   - [Build](#x86-build)
   - [Flash the Image](#x86-flash-the-image)
+- [Virtual Machine (x86_64)](#virtual-machine-x86_64)
+  - [Build](#vm-build)
+  - [Run](#vm-run)
+  - [Several VMs at once](#several-vms-at-once)
 - [QEMU (ARM64)](#qemu-arm64)
   - [Prerequisites](#qemu-prerequisites)
   - [Build](#qemu-build)
@@ -201,6 +206,10 @@ make build
 # Generic x86_64 PC (experimental)
 make setup BOARD=generic-x86-64
 make build MACHINE=genericx86-64-wendyos
+
+# Virtual machine, x86_64 host (device simulation, no hardware)
+make setup BOARD=vm-x86-64
+make build MACHINE=vm-x86-64-wendyos
 ```
 
 > `BOARD` must be set to a board id matching a directory
@@ -252,6 +261,7 @@ make build MACHINE=genericx86-64-wendyos
    BOARD=rpi5-nvme             ./meta-wendyos/bootstrap.sh
    BOARD=qemu-arm64            ./meta-wendyos/bootstrap.sh
    BOARD=generic-x86-64        ./meta-wendyos/bootstrap.sh
+   BOARD=vm-x86-64             ./meta-wendyos/bootstrap.sh
    ```
 
    `MACHINE=<board-id>` remains supported as a deprecated alias (prints a
@@ -285,6 +295,7 @@ make build MACHINE=genericx86-64-wendyos
      - `rpi5-nvme`               → `raspberrypi5-nvme-wendyos`
      - `qemu-arm64`              → `qemuarm64-wendyos`
      - `generic-x86-64`          → `genericx86-64-wendyos`
+     - `vm-x86-64`               → `vm-x86-64-wendyos`
    - `WENDYOS_FLASH_IMAGE_SIZE` - Flash image size: "64GB"):
      - `"4GB"` - 3.2GB Mender storage (~1.3GB per rootfs partition)
      - `"8GB"` - 6.4GB Mender storage (~2.9GB per rootfs partition)
@@ -1154,6 +1165,108 @@ builds (RPi5 only), connect the NVMe drive via a PCIe adapter. The board EEPROM 
 generically by the `rpi-eeprom-config` package (included on every RPi5 image) to boot either
 SD or NVMe — it sets `BOOT_ORDER=0xf461` (SD then NVMe), `PCIE_PROBE=1`, and `PSU_MAX_CURRENT`
 — so the same board boots whichever medium is present regardless of which image flashed it.
+
+## Virtual Machine (x86_64)
+
+A WendyOS image that behaves like a real device without hardware: the same
+agent, the same app deployment flow, and the same A/B OTA stack. Input comes
+from network-attached sensors (IP cameras and similar), so there is no GPU
+acceleration and no peripheral passthrough.
+
+Unlike the QEMU ARM64 target below — which boots a kernel and rootfs directly as
+a development loop — this boots the real UEFI/GPT disk image through OVMF and
+the A/B GRUB chain. The guest takes the same boot path a physical device does,
+so an OTA installed in the VM exercises the code that runs on hardware.
+
+<a name="vm-build"></a>
+### Build
+
+```bash
+make setup BOARD=vm-x86-64
+make build MACHINE=vm-x86-64-wendyos
+```
+
+The build produces a bootable UEFI disk image (about 6.9 GiB, sparse):
+
+```
+build/tmp/deploy/images/vm-x86-64-wendyos/wendyos-image-vm-x86-64-wendyos.rootfs-<ts>.wic
+build/tmp/deploy/images/vm-x86-64-wendyos/wendyos-image-vm-x86-64-wendyos.rootfs-<ts>.wendy
+```
+
+The `.wic` is the disk. The `.wendy` is the OTA payload, the same artifact format
+the hardware boards use.
+
+<a name="vm-run"></a>
+### Run
+
+From the **host**, not inside the Docker container:
+
+```bash
+./scripts/run-vm.sh
+```
+
+That handles the parts that are easy to get wrong: it picks the newest build,
+creates a copy-on-write overlay so the built image stays pristine, grows the
+virtual disk so `/data` has room to expand on first boot, finds the host's OVMF
+firmware, and selects a CPU model the image can actually run on.
+
+```bash
+./scripts/run-vm.sh --dry-run --verbose    # print the qemu command, run nothing
+./scripts/run-vm.sh --memory 8192 --cpus 8 # a bigger guest
+./scripts/run-vm.sh --recreate             # wipe back to a first boot
+./scripts/run-vm.sh --help                 # all options
+```
+
+Log in on the serial console, or over SSH on the forwarded port the script
+prints (2222 by default):
+
+```bash
+ssh -p 2222 wendy@localhost
+```
+
+**To shut down cleanly**, run `poweroff` in the guest, or press **Ctrl-A** then
+**C** for the QEMU monitor and type `system_powerdown`. Do not use Ctrl-A X —
+that kills the VM instantly and can leave an in-progress A/B update half
+applied.
+
+The guest reaches services on the host at **10.0.2.2** (QEMU user networking).
+That address is virtual and will not appear in `ip addr` on the host. It is the
+simplest way to serve an OTA payload to the VM:
+
+```bash
+# host, in the deploy directory
+python3 -m http.server 8000
+
+# guest
+wendyos-update install http://10.0.2.2:8000/<image>.wendy
+reboot
+```
+
+> **Requirements:** a host CPU with x86-64-v3 (Haswell/Excavator or newer), plus
+> `qemu-system-x86_64`, `qemu-img` and OVMF firmware — on Debian/Ubuntu that is
+> `sudo apt install qemu-system-x86 qemu-utils ovmf`. KVM is used when `/dev/kvm`
+> is readable (add yourself to the `kvm` group); the script falls back to software
+> emulation otherwise, which works but is slow.
+
+<a name="several-vms-at-once"></a>
+### Several VMs at once
+
+Each instance is a named copy-on-write overlay on one shared base image, so a
+clone costs a few hundred KB rather than a full disk copy:
+
+```bash
+./scripts/run-vm.sh --name train-01
+./scripts/run-vm.sh --name train-02
+```
+
+Instances are independent — separate disks, separate UEFI variables, separate
+device identities — and each gets its own forwarded SSH port. State lives in
+`<workspace>/vm/<name>/`. Delete that directory, or use `--recreate`, to reset
+one to a first boot.
+
+After a rebuild, existing instances stay bound to the image they were created
+from. `run-vm.sh` warns when it notices this and `--recreate` moves an instance
+to the newest build.
 
 ## QEMU (ARM64)
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository provides the meta-layer and build flow to build **WendyOS** — 
 | QEMU ARM64 | virtual | configurable | `qemu-arm64` | `qemuarm64-wendyos` | virtio | none |
 | Generic x86_64 PC | Intel/AMD x86_64 | varies | `generic-x86-64` | `genericx86-64-wendyos` | USB / disk (.wic) | wendyos-update |
 | Virtual machine (x86_64) | virtual | configurable | `vm-x86-64` | `vm-x86-64-wendyos` | virtio (.wic) | wendyos-update |
+| Virtual machine (arm64) | virtual | configurable | `vm-arm64` | `vm-arm64-wendyos` | virtio (.wic) | wendyos-update |
 
 ## TL;DR
 
@@ -70,10 +71,11 @@ make flash-to-external  # Flash to external NVMe/USB drive
 - [Generic x86_64 PCs](#generic-x86_64-pcs)
   - [Build](#x86-build)
   - [Flash the Image](#x86-flash-the-image)
-- [Virtual Machine (x86_64)](#virtual-machine-x86_64)
+- [Virtual Machines](#virtual-machines)
   - [Build](#vm-build)
   - [Run](#vm-run)
   - [Several VMs at once](#several-vms-at-once)
+  - [arm64 guests](#arm64-guests)
 - [QEMU (ARM64)](#qemu-arm64)
   - [Prerequisites](#qemu-prerequisites)
   - [Build](#qemu-build)
@@ -210,6 +212,10 @@ make build MACHINE=genericx86-64-wendyos
 # Virtual machine, x86_64 host (device simulation, no hardware)
 make setup BOARD=vm-x86-64
 make build MACHINE=vm-x86-64-wendyos
+
+# Virtual machine, arm64 host (Apple Silicon via UTM, or arm64 Linux)
+make setup BOARD=vm-arm64
+make build MACHINE=vm-arm64-wendyos
 ```
 
 > `BOARD` must be set to a board id matching a directory
@@ -262,6 +268,7 @@ make build MACHINE=vm-x86-64-wendyos
    BOARD=qemu-arm64            ./meta-wendyos/bootstrap.sh
    BOARD=generic-x86-64        ./meta-wendyos/bootstrap.sh
    BOARD=vm-x86-64             ./meta-wendyos/bootstrap.sh
+   BOARD=vm-arm64              ./meta-wendyos/bootstrap.sh
    ```
 
    `MACHINE=<board-id>` remains supported as a deprecated alias (prints a
@@ -296,6 +303,7 @@ make build MACHINE=vm-x86-64-wendyos
      - `qemu-arm64`              → `qemuarm64-wendyos`
      - `generic-x86-64`          → `genericx86-64-wendyos`
      - `vm-x86-64`               → `vm-x86-64-wendyos`
+     - `vm-arm64`                → `vm-arm64-wendyos`
    - `WENDYOS_FLASH_IMAGE_SIZE` - Flash image size: "64GB"):
      - `"4GB"` - 3.2GB Mender storage (~1.3GB per rootfs partition)
      - `"8GB"` - 6.4GB Mender storage (~2.9GB per rootfs partition)
@@ -1166,7 +1174,7 @@ generically by the `rpi-eeprom-config` package (included on every RPi5 image) to
 SD or NVMe — it sets `BOOT_ORDER=0xf461` (SD then NVMe), `PCIE_PROBE=1`, and `PSU_MAX_CURRENT`
 — so the same board boots whichever medium is present regardless of which image flashed it.
 
-## Virtual Machine (x86_64)
+## Virtual Machines
 
 A WendyOS image that behaves like a real device without hardware: the same
 agent, the same app deployment flow, and the same A/B OTA stack. Input comes
@@ -1174,9 +1182,14 @@ from network-attached sensors (IP cameras and similar), so there is no GPU
 acceleration and no peripheral passthrough.
 
 Unlike the QEMU ARM64 target below — which boots a kernel and rootfs directly as
-a development loop — this boots the real UEFI/GPT disk image through OVMF and
-the A/B GRUB chain. The guest takes the same boot path a physical device does,
-so an OTA installed in the VM exercises the code that runs on hardware.
+a development loop — these boot the real UEFI/GPT disk image through UEFI
+firmware and the A/B GRUB chain. The guest takes the same boot path a physical
+device does, so an OTA installed in the VM exercises the code that runs on
+hardware.
+
+Two machines, one layout: `vm-x86-64` for x86_64 hosts and `vm-arm64` for arm64
+hosts (Apple Silicon via UTM, or arm64 Linux). The sections below cover x86_64;
+see [arm64 guests](#arm64-guests) for the differences.
 
 <a name="vm-build"></a>
 ### Build
@@ -1267,6 +1280,34 @@ one to a first boot.
 After a rebuild, existing instances stay bound to the image they were created
 from. `run-vm.sh` warns when it notices this and `--recreate` moves an instance
 to the newest build.
+
+<a name="arm64-guests"></a>
+### arm64 guests
+
+```bash
+make setup BOARD=vm-arm64
+make build MACHINE=vm-arm64-wendyos
+```
+
+Same partition layout, same A/B OTA, same 3 GiB slots and ~6.9 GiB `.wic` as the
+x86_64 machine. The differences are the kernel (`Image` rather than `bzImage`),
+the console, and the firmware in front of GRUB.
+
+The image boots on either UTM backend on an Apple Silicon Mac, and on bare QEMU
+with `-machine virt`. It carries a getty on both `ttyAMA0` (the PL011 on a QEMU
+`virt` guest) and `hvc0` (the virtio console under Apple's Virtualization
+framework), so a login prompt appears whichever one the host provides. For bare
+QEMU the build also deploys `u-boot-vm-arm64-wendyos-*.bin`, usable as `-bios`,
+so no host firmware package is needed; UTM supplies its own UEFI.
+
+`scripts/run-vm.sh` is x86_64-only — an arm64 host path has not been written
+yet. To boot the arm64 image on a Mac, follow
+`docs/howto/vm-arm64-utm-test.md`, which walks through UTM setup step by step.
+
+> **Status:** this machine builds and its artifacts are verified, but it has not
+> yet been booted. The howto above doubles as the first-boot test protocol and
+> names the two things still unproven — whether GRUB's menu reaches the serial
+> console, and whether the firmware publishes the device tree the kernel needs.
 
 ## QEMU (ARM64)
 

--- a/conf/distro/include/vm-distro.inc
+++ b/conf/distro/include/vm-distro.inc
@@ -1,0 +1,37 @@
+# WendyOS VM distro configuration.
+# Required from wendyos.conf when MACHINEOVERRIDES contains "vm-wendyos".
+
+# No firmware-update, USB-gadget or GPU story in a VM.
+# These four are read by nothing on the VM path, but all four are in
+# wendyos-image.bb's BUILDCFG_VARS, so setting them keeps the build banner
+# truthful (the distro otherwise defaults WENDYOS_UPDATE_BOOTLOADER to "1", which
+# would be a lie for a VM). WENDYOS_EFI_DEBUG is deliberately NOT set: it is
+# Tegra-only and is not even in BUILDCFG_VARS, so a value here would be dead text.
+WENDYOS_UPDATE_BOOTLOADER ?= "0"
+WENDYOS_USB_GADGET ?= "0"
+WENDYOS_DEEPSTREAM ?= "0"
+WENDYOS_NVIDIA_DGPU ?= "0"
+
+# The VM is discovered over the host network, not a direct USB gadget link, so
+# do not restrict Avahi to usb0.
+WENDYOS_MDNS_INTERFACES ?= ""
+
+# /data encryption seals the LUKS2 keyslot to a TPM, and a plain VM has none.
+# Turning this on means providing a virtual TPM to the guest (swtpm on the QEMU
+# path, or UTM's TPM 2.0 device on the Apple path) and layering meta-tpm. 
+# wendyos-image.bb hard-fails if this is "1" while WENDYOS_ENABLE_TPM is "0", 
+# so the two must move together.
+WENDYOS_DATA_ENCRYPTED ?= "0"
+
+# wifi and bluetooth are NOT set here, and deliberately not removed either.
+# Both are poky DISTRO_FEATURES_DEFAULTS (oe-core default-distrovars.inc) and
+# wendyos.conf removes only x11/wayland/sysvinit/ptest/3g, so they are on either
+# way. x86-distro.inc appends them explicitly, which is a no-op for the same reason.
+#
+# Keeping them is what the VM wants. The agent drives Bluetooth over D-Bus to
+# org.bluez -- verified in the shipped binary (org.bluez.Adapter1.StartDiscovery,
+# AgentManager1.RegisterAgent, Device1.Connect; no bluetoothctl anywhere). Without
+# bluez5 in the image the agent gets a D-Bus "service unknown" instead of the clean
+# "no adapter" a radio-less real device would report -- a parity difference, not a
+# saving. MACHINE_FEATURES in the machine conf carries the matching half.
+

--- a/conf/distro/include/vm-image.inc
+++ b/conf/distro/include/vm-image.inc
@@ -1,0 +1,109 @@
+# WendyOS VM image configuration.
+# Required from wendyos-image.bb when MACHINEOVERRIDES contains "vm-wendyos".
+#
+# Origin: conf/distro/include/x86-image.inc, trimmed to what a VM needs. What was
+# deliberately dropped, and why:
+#   - packagegroup-wendyos-x86  lives in meta-x86-extensions, which the VM boards
+#                               do not layer. It is NUC network/BT/GPU modules.
+#   - linux-firmware            device firmware for physical cards, radios and GPUs;
+#                               a guest has none. NOTE: dropping it from
+#                               IMAGE_INSTALL here is NOT what removes it -- the BSP
+#                               re-adds it through MACHINE_EXTRA_RRECOMMENDS, so the
+#                               cut that actually works is the :remove in
+#                               conf/machine/vm-x86-64-wendyos.conf. That one is
+#                               worth 1.8 GiB; this line alone was worth nothing.
+#   - the NVIDIA dGPU block     out of scope (no GPU passthrough).
+#   - the TPM/LUKS block        WENDYOS_DATA_ENCRYPTED defaults off for a VM and
+#                               meta-tpm is not layered. See vm-distro.inc.
+# create_lib64_compat is KEPT (below) — it is not NVIDIA-only in effect.
+
+# A/B rootfs sizing: image == slot == .wendy payload, pinned to one constant via
+# floor==ceiling, so an OTA image can never outgrow its fixed on-device slot. The
+# VM machine overrides WENDYOS_ROOTFS_SIZE_KB:vm-wendyos from its own
+# WENDYOS_VM_ROOTFS_SIZE_KB knob. The matching --fixed-size rootfsA/rootfsB slots
+# are in meta-vm-extensions/files/wic/vm-ab.wks, which reads the same variable
+# (exported to wic via WICVARS in this include). On the OTA path wendyos-update.inc
+# requires this same file, so requiring it here too is idempotent.
+require conf/distro/include/wendyos-rootfs-size.inc
+
+# sshd on: a VM is a developer target and there is no serial cable to fall back on.
+WENDYOS_SSHD:vm-wendyos ?= "1"
+
+# kernel-image puts /boot/${KERNEL_IMAGETYPE} (bzImage) INSIDE the rootfs so GRUB
+# can load the kernel from the selected A/B slot's own /boot (vm-grubAB-x64.cfg),
+# keeping each slot self-contained. The ESP carries only GRUB + grubenv
+# (install-kernel-into-boot-dir=false in the wks), never the kernel.
+# grub-editenv edits the A/B grubenv (EFI/BOOT/grubenv) from Linux — needed by the
+# wendyos-update grubenv connector, and to flip the slot by hand when debugging.
+IMAGE_INSTALL:append = " \
+    pciutils \
+    ca-certificates \
+    kernel-image \
+    grub-editenv \
+    "
+
+# A/B wic build: GPT + ext4 label tooling, and DO NOT let wic write an fstab. The
+# stock wic fstab update would bake a single "/" entry, wrong on the other slot;
+# the A/B fstab (vm-wendy-fstab, no "/" entry, LABEL mounts) is installed by
+# base-files instead. Mirrors x86-image.inc / rpi-image.inc.
+WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
+do_image_wic[depends] += " \
+    wic-tools:do_populate_sysroot \
+    e2fsprogs-native:do_populate_sysroot \
+    gptfdisk-native:do_populate_sysroot \
+    "
+
+# --- wendyos-update (wendy OTA) image deltas ------------------------------
+# Gated on WENDYOS_OTA == "wendy". When set, wendyos.conf auto-requires
+# wendyos-update.inc (the client + wendyos-data-setup + the .wendy payload) and
+# packagegroup-wendyos-base pulls in wendyos-etc-binds.
+#
+# 1) wendyos-update-config pins the OTA connector to grubenv (meta-vm-extensions).
+#    grow-data-part grows /data to fill the disk on first boot (board-agnostic;
+#    the wks makes /data the last partition so it can grow).
+WENDYOS_VM_OTA_INSTALL = " \
+    wendyos-update-config \
+    grow-data-part \
+    "
+IMAGE_INSTALL:append = "${@' ' + d.getVar('WENDYOS_VM_OTA_INSTALL') if d.getVar('WENDYOS_OTA') == 'wendy' else ''}"
+
+# 2) Drop wendyos-data-setup (pulled by wendyos-update.inc). Its explicit
+#    data.mount uses /dev/disk/by-partlabel/data and its data-init would not grow
+#    our wic-preformatted ext4 /data anyway. The VM instead relies on the
+#    fstab-generated data.mount (LABEL=data, vm-wendy-fstab), which also satisfies
+#    wendyos-etc-binds' Requires=data.mount, plus grow-data-part above for the
+#    first-boot grow. Mirrors x86-image.inc / rpi-image.inc.
+IMAGE_INSTALL:remove = "${@'wendyos-data-setup' if d.getVar('WENDYOS_OTA') == 'wendy' else ''}"
+
+# /config and /data mount points. Both are real partitions in vm-ab.wks mounted by
+# LABEL from vm-wendy-fstab, so the rootfs must carry empty mount-point
+# directories for the mounts to land on. install -d is idempotent.
+create_wendyos_vm_dirs() {
+    install -d -m 0755 ${IMAGE_ROOTFS}/config
+    install -d -m 0755 ${IMAGE_ROOTFS}/data
+}
+
+ROOTFS_POSTPROCESS_COMMAND:append:vm-wendyos = " create_wendyos_vm_dirs;"
+
+# /lib64 -> lib compatibility symlink. x86-image.inc has the same helper but gates
+# it on the NVIDIA stack, describing it as a fix for NVIDIA's prebuilt binaries.
+# That undersells it: the wendy AGENT needs it too, so this copy is ungated.
+#
+# The agent baked into the image is statically linked and runs fine. But
+# wendyos-agent-updater.timer fires a few minutes after boot and replaces
+# /opt/wendyos/bin/wendy-agent with the upstream release tarball's build, which is
+# DYNAMICALLY linked against the x86-64 ABI loader path /lib64/ld-linux-x86-64.so.2.
+# OE is usrmerge: /lib is a symlink to usr/lib, the loader is at
+# /usr/lib/ld-linux-x86-64.so.2, and /lib64 does not exist. So the updated agent
+# dies with "cannot execute: required file not found" (systemd 203/EXEC) on a
+# restart loop, a few minutes into every boot. Verified on the first VM boot.
+#
+# The generic-x86-64 board never sees this because WENDYOS_NVIDIA_DGPU defaults to
+# "1" there, so its gated symlink is always created. Setting that knob to "0" on
+# that board would break the agent the same way.
+create_lib64_compat() {
+    [ -e ${IMAGE_ROOTFS}/lib64 ] || ln -sf lib ${IMAGE_ROOTFS}/lib64
+}
+
+ROOTFS_POSTPROCESS_COMMAND:append:vm-wendyos = " create_lib64_compat;"
+

--- a/conf/distro/include/vm-image.inc
+++ b/conf/distro/include/vm-image.inc
@@ -21,7 +21,7 @@
 # floor==ceiling, so an OTA image can never outgrow its fixed on-device slot. The
 # VM machine overrides WENDYOS_ROOTFS_SIZE_KB:vm-wendyos from its own
 # WENDYOS_VM_ROOTFS_SIZE_KB knob. The matching --fixed-size rootfsA/rootfsB slots
-# are in meta-vm-extensions/files/wic/vm-ab.wks, which reads the same variable
+# are in meta-vm-extensions/files/wic/vm-ab{,-aa64}.wks, which read the same variable
 # (exported to wic via WICVARS in this include). On the OTA path wendyos-update.inc
 # requires this same file, so requiring it here too is idempotent.
 require conf/distro/include/wendyos-rootfs-size.inc
@@ -29,8 +29,9 @@ require conf/distro/include/wendyos-rootfs-size.inc
 # sshd on: a VM is a developer target and there is no serial cable to fall back on.
 WENDYOS_SSHD:vm-wendyos ?= "1"
 
-# kernel-image puts /boot/${KERNEL_IMAGETYPE} (bzImage) INSIDE the rootfs so GRUB
-# can load the kernel from the selected A/B slot's own /boot (vm-grubAB-x64.cfg),
+# kernel-image puts /boot/${KERNEL_IMAGETYPE} (bzImage on x86_64, Image on arm64)
+# INSIDE the rootfs so GRUB can load the kernel from the selected A/B slot's own
+# /boot (vm-grubAB-x64.cfg / vm-grubAB-aa64.cfg),
 # keeping each slot self-contained. The ESP carries only GRUB + grubenv
 # (install-kernel-into-boot-dir=false in the wks), never the kernel.
 # grub-editenv edits the A/B grubenv (EFI/BOOT/grubenv) from Linux — needed by the
@@ -75,7 +76,8 @@ IMAGE_INSTALL:append = "${@' ' + d.getVar('WENDYOS_VM_OTA_INSTALL') if d.getVar(
 #    first-boot grow. Mirrors x86-image.inc / rpi-image.inc.
 IMAGE_INSTALL:remove = "${@'wendyos-data-setup' if d.getVar('WENDYOS_OTA') == 'wendy' else ''}"
 
-# /config and /data mount points. Both are real partitions in vm-ab.wks mounted by
+# /config and /data mount points. Both are real partitions in the VM wks files,
+# mounted by
 # LABEL from vm-wendy-fstab, so the rootfs must carry empty mount-point
 # directories for the mounts to land on. install -d is idempotent.
 create_wendyos_vm_dirs() {
@@ -85,7 +87,9 @@ create_wendyos_vm_dirs() {
 
 ROOTFS_POSTPROCESS_COMMAND:append:vm-wendyos = " create_wendyos_vm_dirs;"
 
-# /lib64 -> lib compatibility symlink. x86-image.inc has the same helper but gates
+# /lib64 -> lib compatibility symlink (x86_64 only in effect: the aarch64 ELF
+# interpreter is /lib/ld-linux-aarch64.so.1, which usrmerge already resolves, so
+# this is a harmless no-op there). x86-image.inc has the same helper but gates
 # it on the NVIDIA stack, describing it as a fix for NVIDIA's prebuilt binaries.
 # That undersells it: the wendy AGENT needs it too, so this copy is ungated.
 #

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -168,6 +168,7 @@ WENDYOS_CONFIG_PART_NUMBER ?= "16"
 require ${@'conf/distro/include/qemu-distro.inc' if 'qemuall' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 require ${@'conf/distro/include/rpi-distro.inc'  if 'rpi'     in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 require ${@'conf/distro/include/x86-distro.inc'  if 'x86-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
+require ${@'conf/distro/include/vm-distro.inc'   if 'vm-wendyos'  in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 
 # Driver add-ons (systemd-sysext): systemd's sysext support, the boot-time merge
 # service and the kernel devkit. Gated on WENDYOS_DRIVER_EXTENSIONS, so it must

--- a/conf/machine/genericx86-64-wendyos.conf
+++ b/conf/machine/genericx86-64-wendyos.conf
@@ -26,7 +26,7 @@ WKS_FILE = "genericx86-ab.wks"
 # via meta-x86-extensions' wendyos-update-config. WENDYOS_OTA is the gate
 # (wendyos.conf defaults it to "mender" for any non-qemu/rpi/tegra machine), so it
 # must be pinned here — WENDYOS_MENDER is not the selector.
-WENDYOS_OTA = "wendy"
+WENDYOS_OTA ?= "wendy"
 WENDYOS_UPDATE_BOOTLOADER = "0"
 WENDYOS_EFI_DEBUG = "0"
 WENDYOS_DEEPSTREAM = "0"

--- a/conf/machine/vm-arm64-wendyos.conf
+++ b/conf/machine/vm-arm64-wendyos.conf
@@ -55,8 +55,7 @@ EFI_PROVIDER = "grub-efi"
 INITRAMFS_IMAGE = ""
 
 # A directly bootable UEFI GPT disk image plus the bmap. Hard "=" to drop
-# genericarm64's "wic.zst" — qemu-img wants it uncompressed. (scripts/run-vm.sh is
-# x86-only today; an arm64 host path still has to be written.)
+# genericarm64's "wic.zst" — the launcher and qemu-img want it uncompressed.
 # wendyos-image.bb appends ext4; wendyos-update.inc appends the .wendy payload.
 IMAGE_FSTYPES = "wic wic.bmap"
 
@@ -78,18 +77,23 @@ WKS_FILE = "vm-ab-aa64.wks"
 # (ttyS0/1/2, ttyPS1) are real-board devices no hypervisor here presents.
 SERIAL_CONSOLES = "115200;ttyAMA0 115200;hvc0"
 
-# Build U-Boot so it is deployed alongside the image. genericarm64 already
-# defaults UBOOT_MACHINE ?= "qemu_arm64_defconfig" and QB_DEFAULT_BIOS ?= "u-boot.bin" for
-# its own runqemu path, but does not build it ("You will need to build u-boot
-# explicitly"). Shipping it means bare-QEMU hosts need no distro firmware
-# package and the firmware is versioned with the image. UTM on Apple Silicon
-# bundles its own EDK2 UEFI and ignores this. Either way GRUB installs to the
-# removable-media fallback path EFI/BOOT/bootaa64.efi, so the boot chain does
-# not depend on which firmware is in front of it, nor on UEFI NVRAM entries.
-# ":do_deploy" is required, not decoration: image.bbclass turns a bare recipe
-# name in EXTRA_IMAGEDEPENDS into "<recipe>:do_populate_sysroot", which builds
-# U-Boot but never puts u-boot.bin in the deploy directory.
-EXTRA_IMAGEDEPENDS:append = " u-boot:do_deploy"
+# U-Boot is deliberately NOT built or deployed, though genericarm64 sets
+# UBOOT_MACHINE ?= "qemu_arm64_defconfig" and QB_DEFAULT_BIOS ?= "u-boot.bin" for
+# its own runqemu path. It was tried as the guest firmware -- the appeal being
+# that it ships with the image, so bare-QEMU hosts need no distro firmware
+# package -- and it does not work. U-Boot runs our whole boot chain correctly:
+# finds the ESP, executes EFI/BOOT/bootaa64.efi, GRUB draws its menu and loads
+# the kernel. The kernel then hangs forever at "Waiting for root device" because
+# the device tree U-Boot hands over carries no PCI and no virtio-mmio nodes.
+# Both disk transports fail identically, so it is not a transport question.
+# Tested 2026-08-31; see vm-support-plan.md 4.20.
+#
+# Guests therefore use a real UEFI implementation: AAVMF on bare QEMU (which
+# scripts/run-vm.sh autodetects) or UTM's bundled EDK2 on Apple Silicon. Either
+# way GRUB installs to the removable-media fallback path EFI/BOOT/bootaa64.efi,
+# so the boot chain does not care which firmware precedes it, nor rely on UEFI
+# NVRAM entries. Building U-Boot here would only leave a binary in the deploy
+# directory that looks like the intended firmware and cannot boot the image.
 
 # OTA / device parity — see the x86 twin for the reasoning. "?=" so a build can
 # drop to a single-slot image with WENDYOS_OTA = "none" in local.conf.

--- a/conf/machine/vm-arm64-wendyos.conf
+++ b/conf/machine/vm-arm64-wendyos.conf
@@ -1,0 +1,126 @@
+#@TYPE: Machine
+#@NAME: WendyOS VM arm64
+#@DESCRIPTION:
+# WendyOS as a virtual machine on arm64 hosts (UTM on Apple Silicon,
+# QEMU/KVM on arm64 Linux). Device parity without hardware: same agent,
+# same app deployment flow, same A/B OTA. No GPU, no peripheral
+# passthrough — network-attached sensors are the input path.
+# Twin of vm-x86-64-wendyos.
+
+# Reuse the upstream Yocto reference BSP. "genericarm64" is carried so the BSP's
+# own overrides apply (KBRANCH/SRCREV_machine for the kernel, the armv8a-crc
+# tune). "vm-wendyos" is the shared VM token that selects vm-distro.inc,
+# vm-image.inc and vm-base-files.inc — the same three the x86 VM machine uses,
+# so the two stay in step.
+#
+# Carrying "genericarm64" is also what satisfies linux-yocto's
+# COMPATIBLE_MACHINE:genericarm64 = "genericarm64": base.bbclass re.match's
+# COMPATIBLE_MACHINE against each MACHINEOVERRIDES token, not against MACHINE.
+# It does NOT bring a KMACHINE, though — meta-yocto-bsp sets that only for
+# beaglebone/genericx86/genericx86-64, and the real genericarm64 machine gets
+# away with it because its MACHINE and KMACHINE are the same string. This one
+# does not, so meta-vm-extensions' linux-yocto bbappend supplies it. Without that
+# the kernel build fails to locate a BSP definition.
+MACHINEOVERRIDES =. "vm-wendyos:genericarm64:"
+require conf/machine/genericarm64.conf
+
+# Drop the BSP's device firmware. NOTE: this is NOT the same line the x86 VM
+# machine uses. genericx86-64 pulls the single `linux-firmware` meta-package, so
+# there a `:remove` of that one name is enough. genericarm64 instead appends ~10
+# individually named subpackages (bcm43455, wl12xx, wl18xx, rtl-nic, the qcom
+# qcm6490 set, qcom-vpu, ath11k-wcn6750, qca-wcn6750), so a `:remove` of
+# "linux-firmware" would match nothing and silently do nothing.
+#
+# A hard assignment is used instead of listing every subpackage: it cannot go
+# stale when the BSP adds another one. All of it is firmware for Broadcom, TI and
+# Qualcomm silicon that a guest cannot have. kernel-modules is kept — 36 MiB on
+# x86, and module loading is part of device parity.
+MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
+
+# The A/B chain is GRUB-EFI + grubenv on every WendyOS board. genericarm64
+# defaults EFI_PROVIDER to systemd-boot whenever systemd is in DISTRO_FEATURES
+# (it always is here), which would install a bootloader the wendyos-update
+# grubenv connector cannot drive.
+EFI_PROVIDER = "grub-efi"
+
+# No initramfs. genericarm64 sets INITRAMFS_IMAGE ?= "core-image-initramfs-boot"
+# to carry modules and firmware for real SystemReady hardware. A guest needs
+# neither, and with an A/B layout an initramfs is actively awkward: it would land
+# on the shared ESP (not per-slot, so the two slots stop being self-contained) or
+# have to be bundled into each slot's kernel. Safe to drop: everything needed to
+# reach root=PARTLABEL= is already built into this BSP's kernel — genericarm64.scc
+# includes cfg/virtio.scc (VIRTIO_BLK/_NET/_PCI/_MMIO all =y) plus boot-live,
+# usb-mass-storage, efi-ext and kubernetes for vfat/NLS/GPT/ext4. Checked against
+# yocto-kernel-cache yocto-6.18, not assumed.
+INITRAMFS_IMAGE = ""
+
+# A directly bootable UEFI GPT disk image plus the bmap. Hard "=" to drop
+# genericarm64's "wic.zst" — qemu-img wants it uncompressed. (scripts/run-vm.sh is
+# x86-only today; an arm64 host path still has to be written.)
+# wendyos-image.bb appends ext4; wendyos-update.inc appends the .wendy payload.
+IMAGE_FSTYPES = "wic wic.bmap"
+
+# A/B disk layout, in meta-vm-extensions. Same partition table as the x86 VM,
+# different GRUB config (aarch64 kernel name and console).
+WKS_FILE = "vm-ab-aa64.wks"
+
+# Two consoles, because the two arm64 hypervisors expose different ones and both
+# are supported hosts:
+#   ttyAMA0  the PL011 on a QEMU `-machine virt` guest (bare QEMU, and UTM's
+#            default QEMU backend)
+#   hvc0     the virtio console under Apple's Virtualization.framework, which is
+#            UTM's other backend on Apple Silicon. There is no PL011 there, so
+#            without this an Apple-backend guest boots with no console output and
+#            no login prompt -- indistinguishable from a failed boot.
+# Listing both costs nothing: serial-getty@.service has BindsTo=dev-%i.device, so
+# the instance for whichever device is absent never activates and never appears
+# as failed. genericarm64 lists six for the same reason; the other four
+# (ttyS0/1/2, ttyPS1) are real-board devices no hypervisor here presents.
+SERIAL_CONSOLES = "115200;ttyAMA0 115200;hvc0"
+
+# Build U-Boot so it is deployed alongside the image. genericarm64 already
+# defaults UBOOT_MACHINE ?= "qemu_arm64_defconfig" and QB_DEFAULT_BIOS ?= "u-boot.bin" for
+# its own runqemu path, but does not build it ("You will need to build u-boot
+# explicitly"). Shipping it means bare-QEMU hosts need no distro firmware
+# package and the firmware is versioned with the image. UTM on Apple Silicon
+# bundles its own EDK2 UEFI and ignores this. Either way GRUB installs to the
+# removable-media fallback path EFI/BOOT/bootaa64.efi, so the boot chain does
+# not depend on which firmware is in front of it, nor on UEFI NVRAM entries.
+# ":do_deploy" is required, not decoration: image.bbclass turns a bare recipe
+# name in EXTRA_IMAGEDEPENDS into "<recipe>:do_populate_sysroot", which builds
+# U-Boot but never puts u-boot.bin in the deploy directory.
+EXTRA_IMAGEDEPENDS:append = " u-boot:do_deploy"
+
+# OTA / device parity — see the x86 twin for the reasoning. "?=" so a build can
+# drop to a single-slot image with WENDYOS_OTA = "none" in local.conf.
+WENDYOS_OTA ?= "wendy"
+
+# A/B slot size, and therefore the whole disk image size:
+#   ESP 128M + config 256M + 2 x slot + data 512M = ~6.9 GiB at 3 GiB/slot.
+# Same starting value as the x86 VM, but deliberately its own knob: the two
+# images do not carry identical content (different kernel, different graphics
+# userspace), so their floors can legitimately diverge. The pin is
+# floor==ceiling, so outgrowing it is a loud build failure. Multiple of 128 MiB.
+# Revisit against the first arm64 build rather than assuming x86's number holds.
+WENDYOS_VM_ROOTFS_SIZE_KB ?= "3145728"
+WENDYOS_ROOTFS_SIZE_KB:vm-wendyos = "${WENDYOS_VM_ROOTFS_SIZE_KB}"
+
+# WENDYOS_PERSIST_JOURNAL_LOGS is deliberately NOT set — wendyos.conf derives it
+# from WENDYOS_OTA. See the note in vm-x86-64-wendyos.conf.
+
+# WENDYOS_AGENT_RELEASE_ARCH is deliberately NOT set: the agent recipe already
+# defaults to "arm64" and only switches to "amd64" under an override this
+# machine does not carry. The x86 VM machine has to set it; this one must not.
+
+# genericarm64 assigns MACHINE_FEATURES with a hard "=" and already has bluetooth
+# and vfat (the two the x86 VM machine has to add on top of its BSP), but unlike
+# x86-base.inc it has no ext2. That pulls packagegroup-base-ext2 ->
+# e2fsprogs-e2fsck + mke2fs. With WENDYOS_OTA = "wendy" the fsck binary arrives
+# anyway as a grow-data-part RDEPENDS, but "none" is a supported setting and drops
+# grow-data-part while vm-wendy-fstab still gives /data a pass-2 fsck -- which
+# would then fail on every boot with no fsck.ext4 in the image.
+MACHINE_FEATURES:append = " ext2"
+
+# Stable board identity written to /etc/wendyos/device-type.
+WENDYOS_BOARD_ID = "vm-arm64"
+

--- a/conf/machine/vm-x86-64-wendyos.conf
+++ b/conf/machine/vm-x86-64-wendyos.conf
@@ -14,11 +14,12 @@
 # x86-distro.inc / x86-image.inc, which carry the NVIDIA dGPU stack, the NUC
 # driver packagegroup and the PC-sized rootfs pin. See vm-support-plan.md 2.1.
 #
-# Carrying "genericx86-64" also brings:
-# COMPATIBLE_MACHINE:genericx86-64 = "genericx86-64"
-# for linux-yocto, which is re-search'd against MACHINE and does not match
-# this machine's name — meta-vm-extensions' linux-yocto bbappend widens it.
-# Without that append there is no virtual/kernel provider.
+# Carrying "genericx86-64" is also what satisfies linux-yocto's
+# COMPATIBLE_MACHINE:genericx86-64 = "genericx86-64". base.bbclass re.match's
+# COMPATIBLE_MACHINE against each MACHINEOVERRIDES token (not against MACHINE),
+# so the token above matches and no bbappend is needed to widen it. It likewise
+# brings KMACHINE:genericx86-64 = "common-pc-64", which is what lets
+# do_kernel_metadata find a BSP definition.
 MACHINEOVERRIDES =. "vm-wendyos:genericx86-64:"
 require conf/machine/genericx86-64.conf
 

--- a/conf/machine/vm-x86-64-wendyos.conf
+++ b/conf/machine/vm-x86-64-wendyos.conf
@@ -1,0 +1,120 @@
+
+#@TYPE: Machine
+#@NAME: WendyOS VM x86_64
+#@DESCRIPTION:
+# WendyOS as a virtual machine on x86_64 hosts (QEMU/KVM, and any
+# plain UEFI hypervisor). Device parity without hardware: same agent,
+# same app deployment flow, same A/B OTA. No GPU, no peripheral
+# passthrough — network-attached sensors are the input path.
+
+# Reuse the upstream Yocto reference BSP. "genericx86-64" is carried so the BSP's
+# own overrides apply (notably KMACHINE:genericx86-64 = "common-pc-64" in
+# meta-yocto-bsp's linux-yocto bbappend). "vm-wendyos" is this machine's own
+# token and is deliberately NOT "x86-wendyos": the VM must not inherit
+# x86-distro.inc / x86-image.inc, which carry the NVIDIA dGPU stack, the NUC
+# driver packagegroup and the PC-sized rootfs pin. See vm-support-plan.md 2.1.
+#
+# Carrying "genericx86-64" also brings:
+# COMPATIBLE_MACHINE:genericx86-64 = "genericx86-64"
+# for linux-yocto, which is re-search'd against MACHINE and does not match
+# this machine's name — meta-vm-extensions' linux-yocto bbappend widens it.
+# Without that append there is no virtual/kernel provider.
+MACHINEOVERRIDES =. "vm-wendyos:genericx86-64:"
+require conf/machine/genericx86-64.conf
+
+# Drop linux-firmware, inherited from the BSP one line above
+# (genericx86-common.inc: MACHINE_EXTRA_RRECOMMENDS += "kernel-modules
+# linux-firmware"). oe-core's packagegroup-base turns that variable into image
+# content via RRECOMMENDS:packagegroup-machine-base.
+#
+# linux-firmware is an empty meta-package (FILES:${PN} = "") whose populate_packages
+# hook RRECOMMENDS every one of its ~600 split-out subpackages, so the one name
+# pulls 1.8 GiB of blobs -- 65% of the whole image. All of it is for physical PCIe
+# cards, radios and GPUs: Intel WiFi, NVIDIA/AMD GPU, Netronome and Mellanox NICs.
+# A guest has none of those. The virtio devices, the emulated e1000/rtl8139 NICs
+# and the bochs VGA all load no firmware at all, and microcode is the host's job.
+#
+# Nothing else in the tree references linux-firmware (checked across all runtime
+# pkgdata: packagegroup-machine-base is the only referrer) and it arrives as a weak
+# RRECOMMENDS, so removing it cannot leave a dangling dependency. If a firmware blob
+# is ever genuinely needed -- GPU passthrough would be the case, currently out of
+# scope -- add that ONE subpackage back to IMAGE_INSTALL by name.
+#
+# Must live in the machine conf, not vm-image.inc: MACHINE_EXTRA_RRECOMMENDS is read
+# by packagegroup-base.bb, a different recipe from wendyos-image.bb, so a value set
+# in the image include would never reach it.
+#
+# kernel-modules stays: 36 MiB, and module loading is part of device parity.
+MACHINE_EXTRA_RRECOMMENDS:remove = "linux-firmware"
+
+# A directly bootable UEFI GPT disk image, plus the bmap so it can be written
+# sparsely. wendyos-image.bb appends ext4 globally; wendyos-update.inc appends the
+# .wendy OTA payload when WENDYOS_OTA == "wendy".
+#
+# Hard "=" to drop genericx86-common.inc's "wic.zst" — the VM launcher and
+# qemu-img want an uncompressed image.
+#
+# No "tar.bz2": the x86 board carries one for inspection and SDK workflows, but a
+# multi-GB rootfs tarball costs build time and disk on every VM build and nothing
+# in the VM workflow consumes it. Mount the .wic or the ext4 to inspect a rootfs.
+IMAGE_FSTYPES = "wic wic.bmap"
+
+# A/B disk layout (GRUB-EFI + grubenv), in meta-vm-extensions.
+WKS_FILE = "vm-ab.wks"
+
+# OTA / device parity. "wendy" auto-requires wendyos-update.inc (the update client
+# and the .wendy payload) and turns on wendyos-etc-binds, which binds
+# /data/etc/wendyos over /etc/wendyos so device identity persists across an A/B
+# slot switch — the behaviour that makes this a simulated device rather than a
+# throwaway rootfs. "?=" so a build can drop to a plain single-slot image with
+# WENDYOS_OTA = "none" in local.conf (local.conf is parsed before machine confs,
+# see bitbake.conf).
+WENDYOS_OTA ?= "wendy"
+
+# A/B slot size, and therefore the whole disk image size:
+#   ESP 128M + config 256M + 2 x slot + data 512M = ~6.9 GiB at 3 GiB/slot.
+# Pinned per machine so the VM does not inherit the 12 GiB PC slot. Exposed as its
+# own knob so it can be tuned from local.conf without touching the shared
+# wendyos-rootfs-size.inc. The pin is floor==ceiling: outgrowing it is a loud
+# build failure, never a silently bigger image. Keep a multiple of 128 MiB
+# (3 GiB = 24 x 128 MiB).
+#
+# 3 GiB is measured, not guessed: a built image reports 0.97 GiB of installed
+# content and 1.1 GiB used on the mounted rootfs, so this leaves ~2.7x headroom.
+# That measurement is from a WENDYOS_DEBUG = "1" build, which is the pessimistic
+# case -- a production image carries less. Raise it here if the build ever fails
+# the ceiling. The VM has no linux-firmware (see MACHINE_EXTRA_RRECOMMENDS above),
+# which is what makes a slot this small reasonable when the PC board needs 12 GiB.
+WENDYOS_VM_ROOTFS_SIZE_KB ?= "3145728"
+WENDYOS_ROOTFS_SIZE_KB:vm-wendyos = "${WENDYOS_VM_ROOTFS_SIZE_KB}"
+
+# WENDYOS_PERSIST_JOURNAL_LOGS is deliberately NOT set here. wendyos.conf already
+# derives it from the OTA setting ("0" when WENDYOS_OTA == "none", else "1"), which
+# is exactly what the VM wants: with OTA on, systemd-conf installs var-log.mount
+# and the journal persists on the shared /data across A/B slots; with WENDYOS_OTA =
+# "none" there is no grow-data-part and no wendyos-etc-binds, so persisting the
+# journal onto an un-grown 512M /data would be wrong. A pin here would win (machine
+# confs parse before the distro) and would break that second case silently.
+
+# The wendy agent ships as a prebuilt per-arch release tarball. Its recipe
+# defaults to arm64 and switches to amd64 only under the "x86-wendyos" override,
+# which this machine deliberately does not carry — so without this line an x86_64
+# VM image would install the arm64 agent binary. Must be an override-suffixed
+# assignment: the recipe sets the base key with a hard "=" at recipe-parse time,
+# which is after this file, so a plain assignment here would be overwritten.
+# Scoped to the machine, not to "vm-wendyos", because the arm64 VM machine wants
+# the recipe's arm64 default.
+WENDYOS_AGENT_RELEASE_ARCH:vm-x86-64-wendyos = "amd64"
+
+# Only these two are new. The BSP already sets screen/keyboard/pci/usbhost/ext2/
+# ext3/x86/acpi/serial/usbgadget/alsa (x86-base.inc) and wifi/efi/pcbios
+# (genericx86-common.inc). Both of these matter and should not be trimmed further:
+# vfat pulls packagegroup-base-vfat -> dosfstools, and the A/B fstab gives the FAT
+# ESP a fsck pass; bluetooth pulls bluez5, which the agent needs on the system bus
+# (it drives org.bluez over D-Bus). See conf/distro/include/vm-distro.inc.
+MACHINE_FEATURES:append = " bluetooth vfat"
+
+# Stable board identity written to /etc/wendyos/device-type. Lets the agent and
+# the cloud tell a VM apart from a physical generic-x86-64 PC.
+WENDYOS_BOARD_ID = "vm-x86-64"
+

--- a/conf/template/boards/vm-arm64/bblayers.conf
+++ b/conf/template/boards/vm-arm64/bblayers.conf
@@ -1,0 +1,5 @@
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/core.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/oe-common.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/vm.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/wendyos.inc
+

--- a/conf/template/boards/vm-arm64/local.conf
+++ b/conf/template/boards/vm-arm64/local.conf
@@ -1,0 +1,24 @@
+# vm-arm64: WendyOS as a virtual machine on arm64 hosts (blacksail tree).
+#
+# Primary host is UTM on Apple Silicon, which supplies its own EDK2 UEFI and
+# boots the image's EFI/BOOT/bootaa64.efi from the removable-media path. Also
+# boots on bare QEMU with `-machine virt` using the u-boot.bin this build
+# deploys as -bios, or any other AArch64 UEFI implementation.
+#
+# Under KVM on an arm64 host use `-cpu host -machine virt,gic-version=3`; under
+# TCG emulation `-cpu cortex-a76`. Unlike the x86_64 VM there is no minimum CPU
+# feature level to satisfy -- genericarm64 targets armv8a-crc, which every
+# Apple Silicon and server-class arm64 part provides.
+
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/vm.inc
+
+# blacksail bring-up: bridge LAYERSERIES_COMPAT for meta-oe/meta-virt (not yet
+# declaring blacksail upstream). Gated on WENDYOS_LAYER_TREE=="blacksail", inert
+# on other trees.
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/blacksail-compat.inc
+
+DEVICE  = "vm-arm64"
+STORAGE = "disk"
+MACHINE = "vm-arm64-wendyos"
+

--- a/conf/template/boards/vm-arm64/repos.overrides
+++ b/conf/template/boards/vm-arm64/repos.overrides
@@ -1,0 +1,22 @@
+# Per-board repo version overrides for vm-arm64.
+#
+# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set,
+# but before the repos[] array is built. Uncomment a line below to pin
+# this board to a different commit of an upstream layer.
+#
+# Also available (see bootstrap.sh):
+#   URL_<name>           override a source URL (e.g. to use a fork)
+#   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
+#                        each entry "enabled|url|folder|commit"
+
+# WENDYOS_LAYER_TREE="blacksail" makes bootstrap clone every upstream repo under
+# repos/blacksail/, the shared tree used by the whole fleet. Set explicitly (not
+# left to the default in scripts/upstream-repos.env) to document the intent.
+WENDYOS_LAYER_TREE="blacksail"
+
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
+#SRCREV_OE="<commit-hash>"
+#SRCREV_VIRT="<commit-hash>"
+

--- a/conf/template/boards/vm-x86-64/bblayers.conf
+++ b/conf/template/boards/vm-x86-64/bblayers.conf
@@ -1,0 +1,4 @@
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/core.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/oe-common.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/vm.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/wendyos.inc

--- a/conf/template/boards/vm-x86-64/local.conf
+++ b/conf/template/boards/vm-x86-64/local.conf
@@ -1,0 +1,19 @@
+# vm-x86-64: WendyOS as a virtual machine on x86_64 hosts (blacksail tree).
+#
+# Boots on QEMU/KVM with UEFI firmware (OVMF) and a virtio-blk disk. The guest
+# CPU must support x86-64-v3 (Haswell/Excavator and later) because the upstream
+# genericx86-64 BSP is tuned for it — run with `-cpu host` under KVM, or
+# `-cpu Skylake-Client` otherwise. The default `qemu64` model will NOT boot this
+# image. See docs/plans/vm-support-plan.md 4.1.
+
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/vm.inc
+
+# blacksail bring-up: bridge LAYERSERIES_COMPAT for meta-oe/meta-virt (not yet
+# declaring blacksail upstream). Gated on WENDYOS_LAYER_TREE=="blacksail", inert
+# on other trees.
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/blacksail-compat.inc
+
+DEVICE  = "vm-x86-64"
+STORAGE = "disk"
+MACHINE = "vm-x86-64-wendyos"

--- a/conf/template/boards/vm-x86-64/repos.overrides
+++ b/conf/template/boards/vm-x86-64/repos.overrides
@@ -1,0 +1,21 @@
+# Per-board repo version overrides for vm-x86-64.
+#
+# Sourced by bootstrap.sh after the default URL_*/SRCREV_* values are set,
+# but before the repos[] array is built. Uncomment a line below to pin
+# this board to a different commit of an upstream layer.
+#
+# Also available (see bootstrap.sh):
+#   URL_<name>           override a source URL (e.g. to use a fork)
+#   REPOS_EXTRA=(...)    append extra clones that coexist with defaults,
+#                        each entry "enabled|url|folder|commit"
+
+# WENDYOS_LAYER_TREE="blacksail" makes bootstrap clone every upstream repo under
+# repos/blacksail/, the shared tree used by the whole fleet. Set explicitly (not
+# left to the default in scripts/upstream-repos.env) to document the intent.
+WENDYOS_LAYER_TREE="blacksail"
+
+#SRCREV_BITBAKE="<commit-hash>"
+#SRCREV_OECORE="<commit-hash>"
+#SRCREV_METAYOCTO="<commit-hash>"
+#SRCREV_OE="<commit-hash>"
+#SRCREV_VIRT="<commit-hash>"

--- a/conf/template/include/bblayers/vm.inc
+++ b/conf/template/include/bblayers/vm.inc
@@ -1,7 +1,7 @@
 # WendyOS VM layer set.
 #
-# meta-yocto-bsp provides the upstream genericx86-64 reference BSP that the VM
-# machine wraps. meta-vm-extensions carries the VM-only boot layer (A/B wks, the
+# meta-yocto-bsp provides both upstream reference BSPs the VM machines wrap:
+# genericx86-64 and genericarm64. meta-vm-extensions carries the VM-only boot layer (A/B wks, the
 # GRUB config and its module bbappend, the OTA connector pin) and is layered only
 # here, so it never reaches a hardware board.
 #

--- a/conf/template/include/bblayers/vm.inc
+++ b/conf/template/include/bblayers/vm.inc
@@ -1,0 +1,16 @@
+# WendyOS VM layer set.
+#
+# meta-yocto-bsp provides the upstream genericx86-64 reference BSP that the VM
+# machine wraps. meta-vm-extensions carries the VM-only boot layer (A/B wks, the
+# GRUB config and its module bbappend, the OTA connector pin) and is layered only
+# here, so it never reaches a hardware board.
+#
+# Deliberately NOT layered: meta-x86-extensions (the VM is isolated from the PC
+# board by design) and meta-security/ meta-tpm (the VM defaults to unencrypted /data;
+# add it together with WENDYOS_DATA_ENCRYPTED = "1").
+
+BBLAYERS += " \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-yocto/meta-yocto-bsp \
+    ${TOPDIR}/../${WENDYOS_META_REPO}/meta-vm-extensions \
+    "
+

--- a/conf/template/include/local/vm.inc
+++ b/conf/template/include/local/vm.inc
@@ -1,0 +1,31 @@
+# WendyOS VM defaults.
+#
+# Target: a developer's machine running QEMU/KVM (or any plain UEFI hypervisor).
+# The image is a full WendyOS device minus peripherals and GPU.
+
+# No USB peripheral controller in a VM; discovery happens on the host network.
+WENDYOS_USB_GADGET = "0"
+WENDYOS_MDNS_INTERFACES = ""
+
+# Console login on the serial port. The VM is normally run headless
+# (qemu -nographic), so the serial console is the only way in before sshd is up,
+# and there is no physical console to protect. Root stays locked either way — log
+# in as the wendy user (passwordless sudo). Set to "0" to match the hardware
+# fleet's default of no interactive login at all.
+WENDYOS_ENABLE_UART_LOGIN ?= "1"
+
+# Two knobs worth knowing about are deliberately NOT defaulted here — the machine
+# conf owns them, so there is one value to change rather than two that can drift.
+# Override either in this file with a hard "=" (local.conf is parsed before machine
+# confs, so a "=" here wins over the machine's "?="):
+#
+#   WENDYOS_VM_ROOTFS_SIZE_KB   A/B slot size, and so the total disk image size:
+#                               ESP 128M + config 256M + 2 x slot + data 512M.
+#                               Default 3 GiB/slot => a ~6.9 GiB sparse .wic. The
+#                               pin is floor==ceiling, so too small fails the build
+#                               loudly. Keep a multiple of 128 MiB.
+#   WENDYOS_OTA                 "wendy" (default) gives the full A/B OTA stack,
+#                               persistent /data and identity that survives a slot
+#                               switch — the point of a simulated device. "none"
+#                               gives a lightweight single-slot image, no updates.
+

--- a/meta-vm-extensions/conf/layer.conf
+++ b/meta-vm-extensions/conf/layer.conf
@@ -1,0 +1,22 @@
+BBPATH:prepend := "${LAYERDIR}:"
+
+BBFILES += " \
+    ${LAYERDIR}/recipes-*/*/*.bb \
+    ${LAYERDIR}/recipes-*/*/*.bbappend \
+    "
+
+BBFILE_COLLECTIONS += "wendyos-vm"
+BBFILE_PATTERN_wendyos-vm := "^${LAYERDIR}/"
+BBFILE_PRIORITY_wendyos-vm = "51"
+
+# Only layered for the VM boards (see conf/template/include/bblayers/vm.inc), so
+# its recipes never reach a hardware board. The VM boards build on blacksail.
+LAYERSERIES_COMPAT_wendyos-vm = "blacksail"
+LAYERVERSION_wendyos-vm = "1"
+LAYERDEPENDS_wendyos-vm = "core wendyos"
+
+# BBPATH carries ${LAYERDIR}, which is what puts ${LAYERDIR}/files/wic on wic's
+# search path for both the .wks (WKS_SEARCH_PATH, image_types_wic.bbclass) and
+# the `bootloader --configfile` GRUB config (build_canned_image_list in wic's
+# engine.py walks BBPATH for <layer>/files/wic). Do not move files/wic.
+

--- a/meta-vm-extensions/files/wic/vm-ab-aa64.wks
+++ b/meta-vm-extensions/files/wic/vm-ab-aa64.wks
@@ -1,0 +1,47 @@
+# WendyOS VM arm64 A/B layout for the wendyos-update OTA stack.
+#
+# Origin: vm-ab.wks (the x86_64 twin). The partition table is identical -- the
+# layout is architecture-neutral. Only the bootloader --configfile differs, and
+# only because wic cannot expand variables in a GRUB config, so each arch needs
+# its own static one. Keep the two in step.
+#
+# Device-agnostic GPT. Nothing here pins a runtime device: --ondisk names the
+# disk only while wic assembles the raw image, and the resulting .wic is written
+# unchanged to whatever the guest boots from (virtio-blk /dev/vda, SATA /dev/sda,
+# NVMe). At runtime everything is found by GPT partlabel / fs-label — GRUB does
+# `search`/partition number, the kernel gets root=PARTLABEL=, and the fstab
+# mounts by LABEL. So one image boots any of those with no per-disk variant.
+#
+# Partition ORDER is load-bearing and mirrors the x86 and RPi A/B layouts:
+#   p1 boot    (FAT)  EFI System Partition: GRUB (EFI/BOOT/bootaa64.efi + grub.cfg)
+#                     + the A/B grubenv. Shared, not per-slot. The kernel is NOT
+#                     kept here (install-kernel-into-boot-dir=false) — GRUB loads
+#                     it from the selected slot's own /boot instead (A/B-safe).
+#   p2 config  (FAT)  first-boot provisioning seed (label "config").
+#   p3 rootfsA (ext4) slot 0  ─┐ both slots flashed with the SAME rootfs so the
+#   p4 rootfsB (ext4) slot 1  ─┘ VM is bootable + recoverable from first launch
+#                              and A->B->A is testable immediately.
+#   p5 data    (ext4) persistent /data — LAST so it can grow to fill the disk on
+#                     first boot.
+#
+# The A/B trial/rollback logic lives in vm-grubAB-aa64.cfg (copied verbatim to
+# EFI/BOOT/grub.cfg by the bootimg_efi plugin via `bootloader --configfile`).
+# rootfsA/rootfsB are --fixed-size so the OTA agent raw-writes a full rootfs image
+# into a slot without repartitioning: image == slot == .wendy payload, one pinned
+# constant (WENDYOS_ROOTFS_SIZE_KB in conf/distro/include/wendyos-rootfs-size.inc,
+# overridden per VM machine from WENDYOS_VM_ROOTFS_SIZE_KB).
+# Do NOT add expand-rootfs: it would grow rootfsA over rootfsB. The /data grow is
+# a separate first-boot step (grow-data-part).
+bootloader --ptable gpt --configfile="vm-grubAB-aa64.cfg" --timeout=3
+
+# --part-type gives p1 the EFI System Partition GPT type GUID. wic does NOT set it
+# by itself -- neither the bootimg_efi plugin nor --active does, so without this the
+# partition is typed "Microsoft basic data" and only *looks* like an ESP. Firmware is
+# supposed to locate the boot loader on the partition typed ESP, and systemd's ESP
+# detection (find-esp.c, used by bootctl and anything built on it) rejects a
+# candidate whose type GUID is not this one.
+part /boot --source bootimg_efi --sourceparams="loader=grub-efi,install-kernel-into-boot-dir=false" --ondisk sda --fstype=vfat --label boot --active --align 1024 --size 128M --part-type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+part --ondisk sda --fstype=vfat --label config --align 1024 --size 256M
+part --source rootfs --ondisk sda --fstype=ext4 --label rootfsA --align 1024 --fixed-size ${WENDYOS_ROOTFS_SIZE_KB}K
+part --source rootfs --ondisk sda --fstype=ext4 --label rootfsB --align 1024 --fixed-size ${WENDYOS_ROOTFS_SIZE_KB}K
+part --ondisk sda --fstype=ext4 --label data --align 1024 --size 512M

--- a/meta-vm-extensions/files/wic/vm-ab.wks
+++ b/meta-vm-extensions/files/wic/vm-ab.wks
@@ -1,0 +1,47 @@
+# WendyOS VM A/B layout for the wendyos-update OTA stack.
+#
+# Origin: meta-x86-extensions/files/wic/genericx86-ab.wks. Kept deliberately
+# close to it so the two can be merged into one shared wks later (see
+# docs/plans/vm-support-plan.md 2.1). Differences from the origin are marked
+# "VM:" below.
+#
+# Device-agnostic GPT. Nothing here pins a runtime device: --ondisk names the
+# disk only while wic assembles the raw image, and the resulting .wic is written
+# unchanged to whatever the guest boots from (virtio-blk /dev/vda, SATA /dev/sda,
+# NVMe). At runtime everything is found by GPT partlabel / fs-label — GRUB does
+# `search`/partition number, the kernel gets root=PARTLABEL=, and the fstab
+# mounts by LABEL. So one image boots any of those with no per-disk variant.
+#
+# Partition ORDER is load-bearing and mirrors the x86 and RPi A/B layouts:
+#   p1 boot    (FAT)  EFI System Partition: GRUB (EFI/BOOT/bootx64.efi + grub.cfg)
+#                     + the A/B grubenv. Shared, not per-slot. The kernel is NOT
+#                     kept here (install-kernel-into-boot-dir=false) — GRUB loads
+#                     it from the selected slot's own /boot instead (A/B-safe).
+#   p2 config  (FAT)  first-boot provisioning seed (label "config").
+#   p3 rootfsA (ext4) slot 0  ─┐ both slots flashed with the SAME rootfs so the
+#   p4 rootfsB (ext4) slot 1  ─┘ VM is bootable + recoverable from first launch
+#                              and A->B->A is testable immediately.
+#   p5 data    (ext4) persistent /data — LAST so it can grow to fill the disk on
+#                     first boot.
+#
+# The A/B trial/rollback logic lives in vm-grubAB-x64.cfg (copied verbatim to
+# EFI/BOOT/grub.cfg by the bootimg_efi plugin via `bootloader --configfile`).
+# rootfsA/rootfsB are --fixed-size so the OTA agent raw-writes a full rootfs image
+# into a slot without repartitioning: image == slot == .wendy payload, one pinned
+# constant (WENDYOS_ROOTFS_SIZE_KB in conf/distro/include/wendyos-rootfs-size.inc,
+# overridden per VM machine from WENDYOS_VM_ROOTFS_SIZE_KB).
+# Do NOT add expand-rootfs: it would grow rootfsA over rootfsB. The /data grow is
+# a separate first-boot step (grow-data-part).
+bootloader --ptable gpt --configfile="vm-grubAB-x64.cfg" --timeout=3
+
+# --part-type gives p1 the EFI System Partition GPT type GUID. wic does NOT set it
+# by itself -- neither the bootimg_efi plugin nor --active does, so without this the
+# partition is typed "Microsoft basic data" and only *looks* like an ESP. Firmware is
+# supposed to locate the boot loader on the partition typed ESP, and systemd's ESP
+# detection (find-esp.c, used by bootctl and anything built on it) rejects a
+# candidate whose type GUID is not this one.
+part /boot --source bootimg_efi --sourceparams="loader=grub-efi,install-kernel-into-boot-dir=false" --ondisk sda --fstype=vfat --label boot --active --align 1024 --size 128M --part-type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+part --ondisk sda --fstype=vfat --label config --align 1024 --size 256M
+part --source rootfs --ondisk sda --fstype=ext4 --label rootfsA --align 1024 --fixed-size ${WENDYOS_ROOTFS_SIZE_KB}K
+part --source rootfs --ondisk sda --fstype=ext4 --label rootfsB --align 1024 --fixed-size ${WENDYOS_ROOTFS_SIZE_KB}K
+part --ondisk sda --fstype=ext4 --label data --align 1024 --size 512M

--- a/meta-vm-extensions/files/wic/vm-grubAB-aa64.cfg
+++ b/meta-vm-extensions/files/wic/vm-grubAB-aa64.cfg
@@ -1,0 +1,126 @@
+# WendyOS VM arm64 A/B trial-boot GRUB config (wendyos-update OTA stack).
+#
+# Origin: meta-x86-extensions/files/wic/grubAB.cfg. Kept deliberately close to it
+# so the two can be merged later. The only intended difference is the kernel
+# cmdline console order — marked "VM:" below.
+#
+# Copied verbatim to EFI/BOOT/grub.cfg on the ESP by the wic bootimg_efi plugin
+# (referenced as `bootloader --configfile` in vm-ab-aa64.wks). wic reads this file with
+# a plain read() and does NOT expand bitbake variables (get_custom_config in wic's
+# engine.py), so everything here must be literal — no ${...}.
+#
+# Env-var contract (identical to the U-Boot boot script + the connector):
+#   wendyos_boot_slot          0|1  slot to boot (0=rootfsA, 1=rootfsB)
+#   wendyos_upgrade_available  0|1  a trial boot is armed
+#   bootcount                  0|1  trial attempt counter (bootlimit is 1)
+#
+# GRUB module note: bootaa64.efi here is built with search/ext2/test/loadenv/
+# part_gpt plus regexp/reboot/sleep (see the grub-efi bbappend in this layer),
+# but no savedefault, so this script uses only load_env/save_env/set/test and
+# integer-free {0,1} bootcount logic.
+
+# aa64: no `serial --unit=0` / `terminal_*` lines here. That configures an
+# ns16550, which is what a PC has; a QEMU/UTM `virt` guest exposes a PL011 and
+# GRUB's serial driver does not drive it. GRUB's default aarch64 console goes
+# through the firmware's EFI console protocol, which the firmware has already
+# pointed at that same PL011 -- so the menu appears on the serial line with no
+# configuration. UNVERIFIED until the first arm64 boot; if the menu is silent,
+# this is the first place to look.
+set timeout=3
+
+# Load the persistent A/B state from this ESP's grubenv (EFI/BOOT/grubenv). A
+# missing grubenv on a fresh image just leaves the vars unset, so the seed block
+# below applies the defaults and the first boot always lands on slot A.
+load_env
+
+# First-boot seed (idempotent). Stock grubenv has none of our vars.
+if [ -z "${wendyos_boot_slot}" ]; then set wendyos_boot_slot=0; fi
+if [ -z "${wendyos_upgrade_available}" ]; then set wendyos_upgrade_available=0; fi
+if [ -z "${bootcount}" ]; then set bootcount=0; fi
+
+# Trial boot. Only while an update is armed (wendyos_upgrade_available=1, set by
+# `wendyos-update install`) do we count. bootlimit is 1, so bootcount is just a
+# {0,1} "have we already tried" flag and no arithmetic is needed. The first boot
+# of a trial sets bootcount=1. A healthy boot is finalized by
+# `wendyos-update commit`, which clears the flag from Linux. If a later boot still
+# finds the trial uncommitted, fall back to the other slot.
+if [ "${wendyos_upgrade_available}" = "1" ]; then
+    if [ "${bootcount}" = "0" ]; then
+        set bootcount=1
+        save_env bootcount
+    else
+        echo "wendyos: trial slot ${wendyos_boot_slot} did not commit, falling back"
+        if [ "${wendyos_boot_slot}" = "0" ]; then
+            set wendyos_boot_slot=1
+        else
+            set wendyos_boot_slot=0
+        fi
+        set wendyos_upgrade_available=0
+        set bootcount=0
+        save_env wendyos_boot_slot
+        save_env wendyos_upgrade_available
+        save_env bootcount
+    fi
+fi
+
+# Slot -> rootfs partition on the boot disk. Resolve by PARTITION NUMBER, never the
+# ext4 fs label: an OTA raw-writes the payload into the slot, which CLOBBERS the
+# slot's fs label (the payload carries its own single label), so `search --label
+# rootfsA/B` breaks after the first update. The GPT partition NUMBER survives (the
+# partition table is never rewritten), as does the GPT PARTLABEL used by root=.
+#
+# $root is the ESP GRUB booted from (e.g. "hd0,gpt1"); derive its disk and address
+# the slot as a fixed partition on that SAME disk (vm-ab-aa64.wks order: p3 rootfsA,
+# p4 rootfsB). Device-agnostic: $root's disk is whatever GRUB booted from
+# (virtio-blk, SATA, NVMe), so nothing here is pinned to a device name.
+regexp -s 1:bootdisk '^([^,]+),' "${root}"
+
+if [ "${wendyos_boot_slot}" = "1" ]; then
+    set slotdev="(${bootdisk},gpt4)"
+    set slot_partlabel=rootfsB
+else
+    set slotdev="(${bootdisk},gpt3)"
+    set slot_partlabel=rootfsA
+fi
+
+echo "wendyos: booting slot ${wendyos_boot_slot} (${slot_partlabel} = ${slotdev})"
+
+set default=0
+menuentry "WendyOS VM (slot ${wendyos_boot_slot})" {
+    # aa64: two consoles, because the two arm64 hypervisors expose different ones.
+    # ttyAMA0 is the PL011 on a QEMU `-machine virt` guest; hvc0 is the virtio
+    # console under Apple's Virtualization.framework (UTM's non-QEMU backend),
+    # which has no PL011 at all. The kernel logs to every console= that
+    # registers and silently skips the ones that do not exist, so listing both
+    # covers either host. ORDER MATTERS: the LAST console to register becomes
+    # /dev/console, so ttyAMA0 goes last -- on a QEMU guest that is the terminal
+    # the operator is watching, and on an Apple guest it simply fails to register
+    # and hvc0 wins by default. There is no tty0 on either: an arm64 guest has no
+    # VGA text console.
+    #
+    # If the slot's kernel cannot be LOADED (missing/corrupt), reboot so the
+    # bootcount logic at the top of this config re-runs and falls back to the other
+    # slot. A failed `linux` otherwise leaves GRUB hung at the interactive menu on a
+    # headless guest. `||` is not supported in GRUB script, hence `if ! ...`.
+    # The sleep only matters if BOTH slots are unbootable (it paces that reboot loop
+    # so it is observable); the common one-bad-slot case flips on the very next boot.
+    if ! linux ${slotdev}/boot/Image root=PARTLABEL=${slot_partlabel} rw rootwait console=hvc0 console=ttyAMA0,115200 ; then
+        echo "wendyos: slot ${wendyos_boot_slot} kernel failed to load; rebooting to fall back"
+        sleep 10
+        reboot
+    fi
+}
+
+# Manual slot overrides, handy from the console (press a key to stop the timeout).
+# Plain linux (no reboot-on-failure): a human picking a slot wants to SEE the error,
+# not have it reboot out from under them.
+menuentry "WendyOS VM slot A (rootfsA)" {
+    regexp -s 1:d '^([^,]+),' "${root}"
+    linux (${d},gpt3)/boot/Image root=PARTLABEL=rootfsA rw rootwait console=hvc0 console=ttyAMA0,115200
+}
+
+menuentry "WendyOS VM slot B (rootfsB)" {
+    regexp -s 1:d '^([^,]+),' "${root}"
+    linux (${d},gpt4)/boot/Image root=PARTLABEL=rootfsB rw rootwait console=hvc0 console=ttyAMA0,115200
+}
+

--- a/meta-vm-extensions/files/wic/vm-grubAB-x64.cfg
+++ b/meta-vm-extensions/files/wic/vm-grubAB-x64.cfg
@@ -1,0 +1,116 @@
+# WendyOS VM x86_64 A/B trial-boot GRUB config (wendyos-update OTA stack).
+#
+# Origin: meta-x86-extensions/files/wic/grubAB.cfg. Kept deliberately close to it
+# so the two can be merged later. The only intended difference is the kernel
+# cmdline console order — marked "VM:" below.
+#
+# Copied verbatim to EFI/BOOT/grub.cfg on the ESP by the wic bootimg_efi plugin
+# (referenced as `bootloader --configfile` in vm-ab.wks). wic reads this file with
+# a plain read() and does NOT expand bitbake variables (get_custom_config in wic's
+# engine.py), so everything here must be literal — no ${...}.
+#
+# Env-var contract (identical to the U-Boot boot script + the connector):
+#   wendyos_boot_slot          0|1  slot to boot (0=rootfsA, 1=rootfsB)
+#   wendyos_upgrade_available  0|1  a trial boot is armed
+#   bootcount                  0|1  trial attempt counter (bootlimit is 1)
+#
+# GRUB module note: bootx64.efi here is built with search/ext2/test/loadenv/
+# part_gpt plus regexp/reboot/sleep (see the grub-efi bbappend in this layer),
+# but no savedefault, so this script uses only load_env/save_env/set/test and
+# integer-free {0,1} bootcount logic.
+
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal_input console serial
+terminal_output console serial
+set timeout=3
+
+# Load the persistent A/B state from this ESP's grubenv (EFI/BOOT/grubenv). A
+# missing grubenv on a fresh image just leaves the vars unset, so the seed block
+# below applies the defaults and the first boot always lands on slot A.
+load_env
+
+# First-boot seed (idempotent). Stock grubenv has none of our vars.
+if [ -z "${wendyos_boot_slot}" ]; then set wendyos_boot_slot=0; fi
+if [ -z "${wendyos_upgrade_available}" ]; then set wendyos_upgrade_available=0; fi
+if [ -z "${bootcount}" ]; then set bootcount=0; fi
+
+# Trial boot. Only while an update is armed (wendyos_upgrade_available=1, set by
+# `wendyos-update install`) do we count. bootlimit is 1, so bootcount is just a
+# {0,1} "have we already tried" flag and no arithmetic is needed. The first boot
+# of a trial sets bootcount=1. A healthy boot is finalized by
+# `wendyos-update commit`, which clears the flag from Linux. If a later boot still
+# finds the trial uncommitted, fall back to the other slot.
+if [ "${wendyos_upgrade_available}" = "1" ]; then
+    if [ "${bootcount}" = "0" ]; then
+        set bootcount=1
+        save_env bootcount
+    else
+        echo "wendyos: trial slot ${wendyos_boot_slot} did not commit, falling back"
+        if [ "${wendyos_boot_slot}" = "0" ]; then
+            set wendyos_boot_slot=1
+        else
+            set wendyos_boot_slot=0
+        fi
+        set wendyos_upgrade_available=0
+        set bootcount=0
+        save_env wendyos_boot_slot
+        save_env wendyos_upgrade_available
+        save_env bootcount
+    fi
+fi
+
+# Slot -> rootfs partition on the boot disk. Resolve by PARTITION NUMBER, never the
+# ext4 fs label: an OTA raw-writes the payload into the slot, which CLOBBERS the
+# slot's fs label (the payload carries its own single label), so `search --label
+# rootfsA/B` breaks after the first update. The GPT partition NUMBER survives (the
+# partition table is never rewritten), as does the GPT PARTLABEL used by root=.
+#
+# $root is the ESP GRUB booted from (e.g. "hd0,gpt1"); derive its disk and address
+# the slot as a fixed partition on that SAME disk (vm-ab.wks order: p3 rootfsA,
+# p4 rootfsB). Device-agnostic: $root's disk is whatever GRUB booted from
+# (virtio-blk, SATA, NVMe), so nothing here is pinned to a device name.
+regexp -s 1:bootdisk '^([^,]+),' "${root}"
+
+if [ "${wendyos_boot_slot}" = "1" ]; then
+    set slotdev="(${bootdisk},gpt4)"
+    set slot_partlabel=rootfsB
+else
+    set slotdev="(${bootdisk},gpt3)"
+    set slot_partlabel=rootfsA
+fi
+
+echo "wendyos: booting slot ${wendyos_boot_slot} (${slot_partlabel} = ${slotdev})"
+
+set default=0
+menuentry "WendyOS VM (slot ${wendyos_boot_slot})" {
+    # VM: console order is REVERSED relative to the x86 board's grubAB.cfg. The
+    # LAST console= on the cmdline becomes /dev/console, and a VM is normally run
+    # headless (qemu -nographic), so the serial port must win — otherwise the
+    # boot log and console-getty land on the graphical VT nobody is looking at.
+    # The hardware board wants the opposite (monitor attached), hence the flip.
+    #
+    # If the slot's kernel cannot be LOADED (missing/corrupt), reboot so the
+    # bootcount logic at the top of this config re-runs and falls back to the other
+    # slot. A failed `linux` otherwise leaves GRUB hung at the interactive menu on a
+    # headless guest. `||` is not supported in GRUB script, hence `if ! ...`.
+    # The sleep only matters if BOTH slots are unbootable (it paces that reboot loop
+    # so it is observable); the common one-bad-slot case flips on the very next boot.
+    if ! linux ${slotdev}/boot/bzImage root=PARTLABEL=${slot_partlabel} rw rootwait console=tty0 console=ttyS0,115200 ; then
+        echo "wendyos: slot ${wendyos_boot_slot} kernel failed to load; rebooting to fall back"
+        sleep 10
+        reboot
+    fi
+}
+
+# Manual slot overrides, handy from the console (press a key to stop the timeout).
+# Plain linux (no reboot-on-failure): a human picking a slot wants to SEE the error,
+# not have it reboot out from under them.
+menuentry "WendyOS VM slot A (rootfsA)" {
+    regexp -s 1:d '^([^,]+),' "${root}"
+    linux (${d},gpt3)/boot/bzImage root=PARTLABEL=rootfsA rw rootwait console=tty0 console=ttyS0,115200
+}
+
+menuentry "WendyOS VM slot B (rootfsB)" {
+    regexp -s 1:d '^([^,]+),' "${root}"
+    linux (${d},gpt4)/boot/bzImage root=PARTLABEL=rootfsB rw rootwait console=tty0 console=ttyS0,115200
+}

--- a/meta-vm-extensions/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-vm-extensions/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,6 +1,7 @@
 # Origin: meta-x86-extensions/recipes-bsp/grub/grub-efi_%.bbappend.
 #
-# The A/B grub.cfg (files/wic/vm-grubAB-x64.cfg) resolves the rootfs slot by
+# The A/B grub.cfgs (files/wic/vm-grubAB-x64.cfg and vm-grubAB-aa64.cfg) resolve
+# the rootfs slot by
 # PARTITION NUMBER on the boot disk, deriving the disk from $root with `regexp`.
 # Stock GRUB_BUILDIN does not ship the regexp module, so add it.
 #
@@ -15,5 +16,12 @@
 # the bootcount logic re-runs and falls back to the other slot. Otherwise GRUB HANGS
 # at the interactive menu on a headless guest; `||` is not supported in GRUB script,
 # and reboot/sleep are separate modules not in `normal`.
-GRUB_BUILDIN:append = " regexp reboot sleep"
+# echo: oe-core's GRUB_BUILDIN default has no `echo`, and grub-2.14 builds it as
+# its own module (Makefile.core.def: name = echo, common = commands/echo.c), not
+# part of the kernel or `normal`. wic copies only the built EFI binary to the
+# ESP, so there is no .mod to load at runtime -- without this every diagnostic
+# line in the A/B configs printed "error: unknown command 'echo'" instead. Those
+# messages are the fallback path's only observability, and on arm64 the serial
+# line is the only output channel at all.
+GRUB_BUILDIN:append = " regexp reboot sleep echo"
 

--- a/meta-vm-extensions/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-vm-extensions/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,0 +1,19 @@
+# Origin: meta-x86-extensions/recipes-bsp/grub/grub-efi_%.bbappend.
+#
+# The A/B grub.cfg (files/wic/vm-grubAB-x64.cfg) resolves the rootfs slot by
+# PARTITION NUMBER on the boot disk, deriving the disk from $root with `regexp`.
+# Stock GRUB_BUILDIN does not ship the regexp module, so add it.
+#
+# Why partition number and not `search --label`: an OTA raw-writes the payload into
+# the target slot, which CLOBBERS that slot's ext4 filesystem label (the payload
+# carries its own single label). So a slot's fs label is not a durable identity. The
+# GPT partition NUMBER and PARTLABEL survive (the partition table is never rewritten
+# by an OTA), so the boot chain keys off those instead.
+#
+# reboot + sleep: when the selected slot's kernel fails to LOAD (missing/corrupt),
+# the config does `if ! linux ...; then sleep N; reboot; fi` so the guest reboots and
+# the bootcount logic re-runs and falls back to the other slot. Otherwise GRUB HANGS
+# at the interactive menu on a headless guest; `||` is not supported in GRUB script,
+# and reboot/sleep are separate modules not in `normal`.
+GRUB_BUILDIN:append = " regexp reboot sleep"
+

--- a/meta-vm-extensions/recipes-core/wendyos-update-config/files/config.json
+++ b/meta-vm-extensions/recipes-core/wendyos-update-config/files/config.json
@@ -1,0 +1,3 @@
+{
+  "connector": "grubenv"
+}

--- a/meta-vm-extensions/recipes-core/wendyos-update-config/wendyos-update-config.bb
+++ b/meta-vm-extensions/recipes-core/wendyos-update-config/wendyos-update-config.bb
@@ -1,0 +1,23 @@
+SUMMARY = "wendyos-update connector config for the WendyOS VM machines (grubenv)"
+DESCRIPTION = "Installs /etc/wendyos-update/config.json pinning the wendyos-update \
+OTA client to the grubenv connector. Auto-detect would also pick it (grub-editenv \
+present + our env layout), but a build-time pin is one less runtime failure mode. \
+Sibling of meta-x86-extensions' recipe of the same name; the two never coexist in \
+one build because the VM boards do not layer meta-x86-extensions."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://config.json"
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "vm-x86-64-wendyos"
+
+do_install() {
+    install -d ${D}${sysconfdir}/wendyos-update
+    install -m 0644 ${UNPACKDIR}/config.json ${D}${sysconfdir}/wendyos-update/config.json
+}
+
+# The config dir is also created by the wendyos-update recipe (the <phase>.d
+# hook dirs); allow both to ship it.
+FILES:${PN} = "${sysconfdir}/wendyos-update/config.json"
+

--- a/meta-vm-extensions/recipes-core/wendyos-update-config/wendyos-update-config.bb
+++ b/meta-vm-extensions/recipes-core/wendyos-update-config/wendyos-update-config.bb
@@ -10,7 +10,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SRC_URI = "file://config.json"
 S = "${UNPACKDIR}"
 
-COMPATIBLE_MACHINE = "vm-x86-64-wendyos"
+# Both VM machines: the connector is the bootloader interface, and both boot the
+# same GRUB-EFI + grubenv A/B chain. re.search'd against MACHINE, so an
+# alternation covers the pair without matching anything else.
+COMPATIBLE_MACHINE = "vm-x86-64-wendyos|vm-arm64-wendyos"
 
 do_install() {
     install -d ${D}${sysconfdir}/wendyos-update

--- a/meta-vm-extensions/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-vm-extensions/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,14 +1,26 @@
-# Make linux-yocto build for the VM machines.
+# Point the arm64 VM machine at the BSP definition it wraps.
 #
-# The VM machines carry the "genericx86-64" MACHINEOVERRIDE so they inherit the
-# upstream BSP wiring from meta-yocto-bsp's linux-yocto_6.18.bbappend
-# (KMACHINE:genericx86-64 ?= "common-pc-64"). That same override also sets
-# COMPATIBLE_MACHINE:genericx86-64 = "genericx86-64", which is re.search'd
-# against MACHINE — it matches "genericx86-64-wendyos" as a substring, but NOT
-# "vm-x86-64-wendyos". Without this append the kernel recipe is skipped and the
-# build fails with no virtual/kernel provider.
+# kernel-yocto.bbclass defaults KMACHINE to ${MACHINE}, and do_kernel_metadata
+# resolves it by searching yocto-kernel-cache for an .scc that declares
+# `define KMACHINE <value>` (bsp/genericarm64/genericarm64-standard.scc declares
+# "genericarm64"). Nothing declares "vm-arm64-wendyos", so without this the build
+# fails with "Could not locate BSP definition for vm-arm64-wendyos/standard and
+# no defconfig was provided".
 #
-# :append (not an override assignment) so it lands after the override is
-# resolved. Same pattern meta-qemu-extensions uses for qemuarm64-wendyos.
-COMPATIBLE_MACHINE:append = "|vm-x86-64-wendyos"
+# The x86_64 VM machine needs no equivalent: meta-yocto-bsp's linux-yocto append
+# sets KMACHINE:genericx86-64 = "common-pc-64" under an override this machine
+# carries. That same append has no KMACHINE:genericarm64 -- the real genericarm64
+# machine gets the right value only because its MACHINE and KMACHINE are the same
+# string, which is not true here.
+KMACHINE:vm-arm64-wendyos = "genericarm64"
 
+# Deliberately NO COMPATIBLE_MACHINE:append. base.bbclass checks it with
+# re.match against each MACHINEOVERRIDES token, not re.search against MACHINE, and
+# both VM machines put their BSP's name into MACHINEOVERRIDES themselves -- so the
+# BSP's own COMPATIBLE_MACHINE:<bsp> = "<bsp>" already matches.
+#
+# Deliberately NO virtio kernel fragment. genericarm64.scc includes cfg/virtio.scc
+# (VIRTIO/_PCI/_MMIO/_BLK/_NET/_CONSOLE/HW_RANDOM_VIRTIO all =y) plus boot-live,
+# usb-mass-storage, efi-ext and kubernetes for vfat/NLS/GPT/ext4. Everything an
+# initramfs-less VM needs to reach root=PARTLABEL= is already built in. Verified
+# against yocto-kernel-cache branch yocto-6.18.

--- a/meta-vm-extensions/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-vm-extensions/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,0 +1,14 @@
+# Make linux-yocto build for the VM machines.
+#
+# The VM machines carry the "genericx86-64" MACHINEOVERRIDE so they inherit the
+# upstream BSP wiring from meta-yocto-bsp's linux-yocto_6.18.bbappend
+# (KMACHINE:genericx86-64 ?= "common-pc-64"). That same override also sets
+# COMPATIBLE_MACHINE:genericx86-64 = "genericx86-64", which is re.search'd
+# against MACHINE — it matches "genericx86-64-wendyos" as a substring, but NOT
+# "vm-x86-64-wendyos". Without this append the kernel recipe is skipped and the
+# build fails with no virtual/kernel provider.
+#
+# :append (not an override assignment) so it lands after the override is
+# resolved. Same pattern meta-qemu-extensions uses for qemuarm64-wendyos.
+COMPATIBLE_MACHINE:append = "|vm-x86-64-wendyos"
+

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -46,3 +46,6 @@ require ${@'rpi-base-files.inc' if 'rpi' in d.getVar('MACHINEOVERRIDES').split('
 
 # x86 A/B fstab — isolated so other boards are unaffected
 require ${@'x86-base-files.inc' if 'x86-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
+
+# VM A/B fstab — isolated so other boards are unaffected
+require ${@'vm-base-files.inc' if 'vm-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}

--- a/recipes-core/base-files/files/vm-wendy-fstab
+++ b/recipes-core/base-files/files/vm-wendy-fstab
@@ -6,7 +6,8 @@
 #
 # Deliberately NO "/" entry: the rootfs slot is A/B and is mounted by the kernel
 # from the root= that GRUB sets per slot (root=PARTLABEL=rootfsA|rootfsB, see
-# vm-grubAB-x64.cfg), so a fixed root device here would be wrong on the other slot.
+# vm-grubAB-{x64,aa64}.cfg), so a fixed root device here would be wrong on the
+# other slot.
 # GRUB mounts "/" read-write via `rw` in the kernel cmdline.
 #
 # /var/volatile tmpfs: shipped by stock oe-core base-files (our custom fstab

--- a/recipes-core/base-files/files/vm-wendy-fstab
+++ b/recipes-core/base-files/files/vm-wendy-fstab
@@ -1,0 +1,26 @@
+# WendyOS VM A/B fstab (wendyos-update OTA stack).
+#
+# Origin: recipes-core/base-files/files/x86-wendy-fstab. Identical content — every
+# entry is label-based and carries nothing architecture- or board-specific — kept
+# as a separate file only so the VM boards stay isolated from the x86 board.
+#
+# Deliberately NO "/" entry: the rootfs slot is A/B and is mounted by the kernel
+# from the root= that GRUB sets per slot (root=PARTLABEL=rootfsA|rootfsB, see
+# vm-grubAB-x64.cfg), so a fixed root device here would be wrong on the other slot.
+# GRUB mounts "/" read-write via `rw` in the kernel cmdline.
+#
+# /var/volatile tmpfs: shipped by stock oe-core base-files (our custom fstab
+# replaces that file, so carry it). Keeps churny /var data in RAM.
+#
+# /boot is the shared EFI System Partition (GRUB + grubenv). It must stay mounted:
+# the wendyos-update grubenv connector edits /boot/EFI/BOOT/grubenv via
+# grub-editenv. Referenced by LABEL, not a per-build PARTUUID, since OTA writes
+# only the rootfs slot and never re-partitions.
+#
+# /data is grown to fill the disk on first boot. /config is the FAT provisioning
+# partition. All by LABEL, all nofail.
+tmpfs                   /var/volatile  tmpfs  defaults              0 0
+LABEL=boot              /boot    vfat  defaults,nofail          0 2
+LABEL=config            /config  vfat  defaults,nofail          0 0
+LABEL=data              /data    ext4  defaults,noatime,nofail  0 2
+

--- a/recipes-core/base-files/vm-base-files.inc
+++ b/recipes-core/base-files/vm-base-files.inc
@@ -1,0 +1,25 @@
+# WendyOS VM base-files extensions.
+# Included conditionally from base-files_%.bbappend — safe for other machines.
+#
+# Origin: recipes-core/base-files/x86-base-files.inc, minus the encryption branch:
+# the VM defaults to WENDYOS_DATA_ENCRYPTED = "0" (vm-distro.inc) and does not
+# layer meta-tpm, so there is no /dev/mapper/data to point at. Re-add that branch
+# together with the TPM stack if VM /data encryption is ever turned on.
+
+SRC_URI:append = " \
+    file://vm-wendy-fstab \
+    "
+
+# The VM uses the wendyos-update A/B layout (two rootfs slots): the stock wic fstab
+# update is disabled (WIC_CREATE_EXTRA_ARGS = "--no-fstab-update") because a baked
+# "/" entry would be wrong on the other slot. Install our A/B fstab instead — no
+# "/" entry (GRUB mounts the slot via root=PARTLABEL), /boot stays mounted so the
+# grubenv connector can edit EFI/BOOT/grubenv, and /boot, /config and /data are all
+# referenced by LABEL so there is nothing to substitute.
+#
+# Installed unconditionally for the VM machines: it describes the disk layout, which
+# the wks always creates, so it is correct whether WENDYOS_OTA is "wendy" or "none".
+do_install:append() {
+    install -m 0644 ${UNPACKDIR}/vm-wendy-fstab ${D}${sysconfdir}/fstab
+}
+

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -208,6 +208,7 @@ require ${@'conf/distro/include/qemu-image.inc' if 'qemuall' in d.getVar('MACHIN
 require ${@'conf/distro/include/tegra-image.inc' if 'tegra' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 require ${@'conf/distro/include/rpi-image.inc' if 'rpi' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 require ${@'conf/distro/include/x86-image.inc' if 'x86-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
+require ${@'conf/distro/include/vm-image.inc' if 'vm-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 
 # Config sanity check. Encrypting /data needs a TPM at runtime -- data-enroll seals
 # the LUKS2 keyslot to it -- so WENDYOS_DATA_ENCRYPTED turns WENDYOS_ENABLE_TPM on

--- a/scripts/resolve-artifacts.sh
+++ b/scripts/resolve-artifacts.sh
@@ -143,18 +143,17 @@ case "$IMAGE_KIND" in
     fi
     ;;
   wic-disk)
-    # Generic x86_64 PC: the primary flashable artifact is a directly-flashable
-    # UEFI/BIOS .wic disk image (IMAGE_FSTYPES="wic wic.bmap ..." in
-    # genericx86-64-wendyos.conf) — this is what a fresh install is written to.
-    # x86 runs the wendy A/B OTA stack (WENDYOS_OTA="wendy"), so it also builds a
-    # .wendy payload, but that is published by the workflow's device-agnostic OTA
-    # glob (--ota-update), not resolved here; this kind only names the flashable
-    # image. No tegraflash bundle (not a Tegra board). Uploaded as-is (bmap
-    # generated in the workflow like the RPi wic path); the publisher
-    # recompresses .wic. A missing wic here is fatal.
+    # Generic x86_64 PC and the VM machines: the primary flashable artifact is a
+    # directly-bootable UEFI .wic disk image — what a fresh install is written
+    # to, or what a VM boots. All three run the wendy A/B OTA stack, so they also
+    # build a .wendy payload, but that is published by the workflow's
+    # device-agnostic OTA glob (--ota-update), not resolved here; this kind only
+    # names the flashable image. No tegraflash bundle (not a Tegra board).
+    # Uploaded as-is (bmap generated in the workflow like the RPi wic path); the
+    # publisher recompresses .wic. A missing wic here is fatal.
     wic="$DEPLOY_DIR/wendyos-image-${MACHINE}.rootfs.wic"
     if [[ ! -f "$wic" ]]; then
-      fail "no x86 disk image for $KEY ($MACHINE): expected wendyos-image-${MACHINE}.rootfs.wic in $DEPLOY_DIR (map entry image_kind=wic-disk)"
+      fail "no disk image for $KEY ($MACHINE): expected wendyos-image-${MACHINE}.rootfs.wic in $DEPLOY_DIR (map entry image_kind=wic-disk)"
     fi
     IMAGE_FILE="$wic"
     ;;

--- a/scripts/resolve-artifacts.test.sh
+++ b/scripts/resolve-artifacts.test.sh
@@ -178,6 +178,29 @@ test_x86_wic_disk() {
   rm -rf "$d"
 }
 
+# The VM machines share the x86 wic-disk kind. Covered separately because they
+# are the only arm64 device on that kind, so a resolver that quietly assumed
+# x86 would still pass the test above.
+test_vm_wic_disk() {
+  local d M dev token
+  for token in vm-arm64:vm-arm64-wendyos vm-x86-64:vm-x86-64-wendyos; do
+    IFS=':' read -r dev M <<<"$token"
+    d=$(newdir)
+    : >"$d/wendyos-image-$M.rootfs.wic"
+    local out; out=$(run_resolver "$dev" disk "$M" "$d"); local rc=$?
+    assert_eq "$dev wic-disk: exits 0" 0 "$rc"
+    assert_eq "$dev wic-disk: kind"         wic-disk "$(field IMAGE_KIND <<<"$out")"
+    assert_eq "$dev wic-disk: image"        "$d/wendyos-image-$M.rootfs.wic" "$(field IMAGE_FILE <<<"$out")"
+    assert_eq "$dev wic-disk: no bundle"    "" "$(field TEGRAFLASH_BUNDLE <<<"$out")"
+    assert_eq "$dev wic-disk: recovery"     false "$(field RECOVERY_EXPECTED <<<"$out")"
+    assert_eq "$dev wic-disk: bmap"         true  "$(field BMAP_REQUIRED <<<"$out")"
+    assert_eq "$dev wic-disk: flashpack"    false "$(field FLASHPACK_REQUIRED <<<"$out")"
+    assert_eq "$dev wic-disk: pass_storage" false "$(field PASS_STORAGE <<<"$out")"
+    assert_eq "$dev wic-disk: no gzip"      false "$(field RPI_NEEDS_GZIP <<<"$out")"
+    rm -rf "$d"
+  done
+}
+
 # ---------------------------------------------------------------------------
 # (b) Missing expected artifact exits non-zero with an informative error
 # ---------------------------------------------------------------------------
@@ -254,6 +277,8 @@ test_matrix_coverage() {
     raspberry-pi-4/sd
     raspberry-pi-3/sd
     generic-x86-64/disk
+    vm-arm64/disk
+    vm-x86-64/disk
   )
   local c
   for c in "${combos[@]}"; do
@@ -282,6 +307,7 @@ test_rpi_sdimg
 test_rpi_wic
 test_rpi5_pass_storage
 test_x86_wic_disk
+test_vm_wic_disk
 test_missing_bundle_fatal
 test_missing_rpi_fatal
 test_missing_x86_fatal

--- a/scripts/run-vm.sh
+++ b/scripts/run-vm.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 #
-# Launch a WendyOS VM image (vm-x86-64-wendyos) under QEMU.
+# Launch a WendyOS VM image (vm-x86-64-wendyos or vm-arm64-wendyos) under QEMU.
 #
 # Supersedes run-qemu.sh for the VM machines. The differences are deliberate:
 # run-qemu.sh boots a kernel+rootfs directly on a host bridge for the old
-# qemuarm64 dev loop; this boots the real UEFI/GPT disk image through OVMF and
-# the A/B GRUB chain, so the guest exercises the same boot path a device does.
+# qemuarm64 dev loop; this boots the real UEFI/GPT disk image through UEFI
+# firmware and the A/B GRUB chain, so the guest exercises the same boot path a
+# device does.
+#
+# Either machine runs on either host. A guest whose architecture differs from the
+# host falls back to TCG emulation -- slow, but it exercises the real boot chain,
+# which is how the arm64 image can be tested without an arm64 machine.
 #
 # Each VM is a named instance: one read-only .wic base shared by N qcow2
 # overlays, so a clone costs a few hundred KB and a second. That is what makes
@@ -37,21 +42,75 @@ CPUS="4"
 SSH_PORT=""
 EXTRA_ARGS=()
 
+BIOS=""
+
 # --- arch-varying values ------------------------------------------------------
-# x86_64 only for now. Phase 2 (arm64) adds a second column here rather than a
-# second script: qemu-system-aarch64, AAVMF_CODE/VARS instead of OVMF, and
-# -machine virt instead of q35. Everything below this block is arch-neutral.
-QEMU_BIN="qemu-system-x86_64"
-QEMU_MACHINE="q35"
-# Firmware CODE/VARS pairs, most preferred first. The _4M pair is what Debian 13
-# and Ubuntu ship. Deliberately NOT matched: *.secboot.fd / *_MS.fd — those
-# enroll Microsoft's Secure Boot keys and would refuse our unsigned GRUB.
-FIRMWARE_PAIRS=(
-    "/usr/share/OVMF/OVMF_CODE_4M.fd:/usr/share/OVMF/OVMF_VARS_4M.fd"
-    "/usr/share/OVMF/OVMF_CODE.fd:/usr/share/OVMF/OVMF_VARS.fd"
-    "/usr/share/edk2/ovmf/OVMF_CODE.fd:/usr/share/edk2/ovmf/OVMF_VARS.fd"
-    "/usr/share/qemu/ovmf-x86_64-code.bin:/usr/share/qemu/ovmf-x86_64-vars.bin"
-)
+# Everything outside select_arch() is architecture-neutral. Adding a third VM
+# machine means adding a case here, not touching the rest of the script.
+#
+# Firmware is a CODE/VARS pflash pair in both cases. Deliberately NOT matched:
+# *.secboot.fd, *_MS.fd, AAVMF_CODE.ms.fd -- those enroll Microsoft's Secure Boot
+# keys and would refuse our unsigned GRUB. That trap applies equally on both
+# arches, which is why the preferred entry is explicitly the no-secboot build.
+#
+# UNVERIFIED (macOS): the Homebrew firmware paths below have not been run on a
+# Mac. They assume Homebrew's qemu installs QEMU's own pc-bios/edk2-*.fd set into
+# $(brew --prefix)/share/qemu -- /opt/homebrew on Apple Silicon, /usr/local on
+# Intel. Debian splits that firmware into separate ovmf/AAVMF packages, so the
+# naming could not be confirmed from the development host. If a Mac reports "No
+# UEFI firmware found", check `ls $(brew --prefix)/share/qemu/edk2-*` and correct
+# these two entries; nothing else in the script depends on the names.
+select_arch() {
+    case "${MACHINE}" in
+        vm-x86-64-wendyos)
+            GUEST_ARCH="x86_64"
+            QEMU_BIN="qemu-system-x86_64"
+            QEMU_MACHINE="q35"
+            # genericx86-64 is tuned for x86-64-v3 (AVX2/BMI/FMA), so the default
+            # qemu64 model cannot run the image at all. See plan 4.1.
+            CPU_KVM="host"
+            CPU_TCG="Skylake-Client"
+            FIRMWARE_PAIRS=(
+                "/usr/share/OVMF/OVMF_CODE_4M.fd:/usr/share/OVMF/OVMF_VARS_4M.fd"
+                "/usr/share/OVMF/OVMF_CODE.fd:/usr/share/OVMF/OVMF_VARS.fd"
+                "/usr/share/edk2/ovmf/OVMF_CODE.fd:/usr/share/edk2/ovmf/OVMF_VARS.fd"
+                "/usr/share/qemu/ovmf-x86_64-code.bin:/usr/share/qemu/ovmf-x86_64-vars.bin"
+            )
+            FIRMWARE_PAIRS+=(
+                # macOS/Homebrew. UNVERIFIED — see the note above select_arch.
+                "/opt/homebrew/share/qemu/edk2-x86_64-code.fd:/opt/homebrew/share/qemu/edk2-i386-vars.fd"
+                "/usr/local/share/qemu/edk2-x86_64-code.fd:/usr/local/share/qemu/edk2-i386-vars.fd"
+            )
+            FIRMWARE_HINT="Debian/Ubuntu: sudo apt install ovmf   |   macOS: brew install qemu"
+            ;;
+        vm-arm64-wendyos)
+            GUEST_ARCH="aarch64"
+            QEMU_BIN="qemu-system-aarch64"
+            QEMU_MACHINE="virt"
+            # cortex-a76 is what genericarm64's own runqemu config emulates
+            # (QB_CPU). There is no minimum feature level to satisfy the way
+            # x86-64-v3 constrains the x86 machine.
+            CPU_KVM="host"
+            CPU_TCG="cortex-a76"
+            FIRMWARE_PAIRS=(
+                "/usr/share/AAVMF/AAVMF_CODE.no-secboot.fd:/usr/share/AAVMF/AAVMF_VARS.fd"
+                "/usr/share/AAVMF/AAVMF_CODE.fd:/usr/share/AAVMF/AAVMF_VARS.fd"
+                "/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw:/usr/share/edk2/aarch64/vars-template-pflash.raw"
+            )
+            FIRMWARE_PAIRS+=(
+                # macOS/Homebrew. UNVERIFIED — see the note above select_arch.
+                "/opt/homebrew/share/qemu/edk2-aarch64-code.fd:/opt/homebrew/share/qemu/edk2-arm-vars.fd"
+                "/usr/local/share/qemu/edk2-aarch64-code.fd:/usr/local/share/qemu/edk2-arm-vars.fd"
+            )
+            FIRMWARE_HINT="Debian/Ubuntu: sudo apt install qemu-efi-aarch64 qemu-system-arm   |   macOS: brew install qemu"
+            ;;
+        *)
+            error "Unknown machine: ${MACHINE}"
+            error "Known: vm-x86-64-wendyos, vm-arm64-wendyos"
+            return 1
+            ;;
+    esac
+}
 
 # Print formatted/colored output
 info() { printf "%b\n" "$*"; }
@@ -75,6 +134,55 @@ execute() {
 
 check_command() { command -v "$1" &> /dev/null; }
 
+# --- portability helpers -------------------------------------------------------
+# This script runs on Linux and macOS. macOS ships BSD userland, so three things
+# used elsewhere are unavailable: `find -printf`, `ss`, and `realpath`. Each is
+# replaced below rather than assumed.
+
+# Normalise `uname -m` to the names QEMU uses for a guest architecture.
+# macOS on Apple Silicon reports "arm64" where Linux reports "aarch64" -- without
+# this the host/guest comparison never matches on a Mac and every guest would be
+# needlessly emulated on the one host where it should run natively.
+norm_arch() {
+    case "$1" in
+        arm64|aarch64)
+            printf 'aarch64\n'
+            ;;
+        x86_64|amd64)
+            printf 'x86_64\n'
+            ;;
+        *)
+            printf '%s\n' "$1"
+            ;;
+    esac
+}
+
+# Absolute path of a file, without realpath(1) (absent from base macOS).
+# The qcow2 overlay stores this, and a relative backing path would resolve
+# against the overlay's own directory.
+abs_path() {
+    local dir base
+    dir="$(cd -- "$(dirname -- "$1")" && pwd -P)" || return 1
+    base="$(basename -- "$1")"
+    printf '%s/%s\n' "${dir%/}" "${base}"
+}
+
+# Is a TCP port already listening? ss on Linux, lsof on macOS. If neither exists
+# we report "free" and let qemu fail with a bind error, which is still clearer
+# than refusing to start.
+port_in_use() {
+    local port="$1"
+    if check_command ss; then
+        ss -ltnH "sport = :${port}" 2>/dev/null | grep -q .
+        return $?
+    fi
+    if check_command lsof; then
+        lsof -nP -iTCP:"${port}" -sTCP:LISTEN > /dev/null 2>&1
+        return $?
+    fi
+    return 1
+}
+
 show_usage() {
     cat << EOF
 Usage: $0 [options] [-- extra qemu args]
@@ -86,7 +194,8 @@ Options:
                          own disk overlay and UEFI variables, so several can run
                          at once from one shared base image.
     -b, --build-dir DIR  Build directory (default: build)
-    -m, --machine NAME   Yocto MACHINE (default: ${MACHINE})
+    -m, --machine NAME   Yocto MACHINE: vm-x86-64-wendyos (default) or
+                         vm-arm64-wendyos
         --memory MB      Guest RAM in MB (default: ${MEMORY})
         --cpus N         Guest vCPUs (default: ${CPUS})
         --disk-size SIZE Grow the virtual disk by this much on creation
@@ -97,6 +206,10 @@ Options:
                          port from 2222 up)
         --recreate       Delete and recreate this instance's disk and UEFI
                          variables. Gives a fresh device identity.
+        --bios FILE      Use a single-file firmware via -bios instead of the
+                         autodetected CODE/VARS pflash pair. Mainly for booting
+                         a firmware this script does not know about; the
+                         normal path is autodetection.
     -v, --verbose        Verbose/debug output
         --dry-run        Print what would be done, run nothing
     -h, --help           Show this help
@@ -111,6 +224,7 @@ Examples:
     $0 --memory 8192 --cpus 8           # bigger guest
     $0 --dry-run --verbose              # show the qemu command line
     $0 -- -device usb-tablet            # append raw qemu arguments
+    $0 -m vm-arm64-wendyos              # the arm64 image (TCG on an x86_64 host)
 
 Shutting down cleanly:
     Run 'poweroff' in the guest, or press Ctrl-A then C for the QEMU monitor and
@@ -120,7 +234,10 @@ Shutting down cleanly:
 Notes:
     - The guest reaches host services at 10.0.2.2 (QEMU user networking). That
       address is virtual and never appears in 'ip addr' on the host.
-    - Instance state lives in <workspace>/vm/<name>/.
+    - Instance state lives in <workspace>/vm/<machine>/<name>/, so the same
+      instance name can be used for each machine without collision.
+    - Running a guest of a different architecture than the host uses TCG
+      emulation. It works, but expect a boot measured in minutes.
 EOF
 }
 
@@ -140,15 +257,22 @@ find_base_image() {
         return 1
     fi
 
-    newest=$(find "${deploy_dir}" -maxdepth 1 -name '*.wic' -type f -printf '%T@ %p\n' 2>/dev/null \
-        | sort -rn | head -1 | cut -d' ' -f2-)
+    # `ls -1t` rather than `find -printf`: the latter is GNU-only.
+    local -a candidates=()
+    local f
+    for f in "${deploy_dir}"/*.wic; do
+        if [[ -f "${f}" && ! -L "${f}" ]]; then
+            candidates+=("${f}")
+        fi
+    done
 
-    if [[ -z "${newest}" ]]; then
+    if [[ ${#candidates[@]} -eq 0 ]]; then
         error "No .wic image in ${deploy_dir}"
         return 1
     fi
 
-    realpath "${newest}"
+    newest="$(ls -1t "${candidates[@]}" | head -1)"
+    abs_path "${newest}"
 }
 
 # Pick the first firmware pair present on this host.
@@ -163,10 +287,10 @@ find_firmware() {
             return 0
         fi
     done
-    error "No UEFI firmware found. Install OVMF:"
-    error "  Debian/Ubuntu: sudo apt install ovmf"
-    error "  Fedora:        sudo dnf install edk2-ovmf"
+    error "No UEFI firmware found for ${GUEST_ARCH}."
+    error "  ${FIRMWARE_HINT}"
     error "Looked for: ${FIRMWARE_PAIRS[*]}"
+    error "Or pass --bios <file> to point at a single-file firmware directly."
     return 1
 }
 
@@ -175,13 +299,7 @@ find_free_port() {
     local port="$1"
     local limit=$((port + 100))
     while [[ "${port}" -lt "${limit}" ]]; do
-        if check_command ss; then
-            if ! ss -ltnH "sport = :${port}" 2>/dev/null | grep -q .; then
-                printf '%s\n' "${port}"
-                return 0
-            fi
-        else
-            # No ss: assume free and let qemu report a bind failure.
+        if ! port_in_use "${port}"; then
             printf '%s\n' "${port}"
             return 0
         fi
@@ -194,18 +312,59 @@ find_free_port() {
 main() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            -n|--name)       NAME="$2"; shift 2 ;;
-            -b|--build-dir)  BUILD_DIR="$2"; shift 2 ;;
-            -m|--machine)    MACHINE="$2"; shift 2 ;;
-            --memory)        MEMORY="$2"; shift 2 ;;
-            --cpus)          CPUS="$2"; shift 2 ;;
-            --disk-size)     DISK_GROW="$2"; shift 2 ;;
-            --ssh-port)      SSH_PORT="$2"; shift 2 ;;
-            --recreate)      RECREATE=true; shift ;;
-            -v|--verbose)    VERBOSE=true; shift ;;
-            --dry-run)       DRY_RUN=true; shift ;;
-            -h|--help)       show_usage; exit 0 ;;
-            --)              shift; EXTRA_ARGS=("$@"); break ;;
+            -n|--name)
+                NAME="$2"
+                shift 2
+                ;;
+            -b|--build-dir)
+                BUILD_DIR="$2"
+                shift 2
+                ;;
+            -m|--machine)
+                MACHINE="$2"
+                shift 2
+                ;;
+            --memory)
+                MEMORY="$2"
+                shift 2
+                ;;
+            --cpus)
+                CPUS="$2"
+                shift 2
+                ;;
+            --disk-size)
+                DISK_GROW="$2"
+                shift 2
+                ;;
+            --ssh-port)
+                SSH_PORT="$2"
+                shift 2
+                ;;
+            --bios)
+                BIOS="$2"
+                shift 2
+                ;;
+            --recreate)
+                RECREATE=true
+                shift
+                ;;
+            -v|--verbose)
+                VERBOSE=true
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            -h|--help)
+                show_usage
+                exit 0
+                ;;
+            --)
+                shift
+                EXTRA_ARGS=("$@")
+                break
+                ;;
             *)
                 error "Unknown argument: $1"
                 echo ""
@@ -219,6 +378,9 @@ main() {
     local state_dir overlay nvram fw_pair fw_code fw_vars
     local accel cpu_model
 
+    # Resolve the arch table first -- everything below depends on it.
+    select_arch || exit 1
+
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     workspace_dir="$(cd "${script_dir}/../.." && pwd)"
     deploy_dir="${workspace_dir}/${BUILD_DIR}/tmp/deploy/images/${MACHINE}"
@@ -228,13 +390,29 @@ main() {
     done
 
     base_image="$(find_base_image "${deploy_dir}")" || exit 1
-    fw_pair="$(find_firmware)" || exit 1
-    fw_code="${fw_pair%%:*}"
-    fw_vars="${fw_pair##*:}"
 
-    state_dir="${workspace_dir}/vm/${NAME}"
+    if [[ -n "${BIOS}" ]]; then
+        # Single-file firmware (-bios): no writable variable store, so UEFI
+        # variables do not persist across boots. Fine for our chain, which boots
+        # the removable-media path EFI/BOOT/boot{x64,aa64}.efi and never relies on
+        # NVRAM boot entries.
+        [[ -r "${BIOS}" ]] || { error "Firmware not readable: ${BIOS}"; exit 1; }
+        fw_code=""
+        fw_vars=""
+    else
+        fw_pair="$(find_firmware)" || exit 1
+        fw_code="${fw_pair%%:*}"
+        fw_vars="${fw_pair##*:}"
+    fi
+
+    # Namespaced by MACHINE, not just by name. An overlay is one machine's disk:
+    # its backing file, partition layout and guest architecture all belong to that
+    # machine, so "default" for vm-arm64-wendyos and "default" for
+    # vm-x86-64-wendyos must be different instances. Without this they collide and
+    # the second machine silently inherits the first machine's disk.
+    state_dir="${workspace_dir}/vm/${MACHINE}/${NAME}"
     overlay="${state_dir}/disk.qcow2"
-    nvram="${state_dir}/OVMF_VARS.fd"
+    nvram="${state_dir}/efi-vars.fd"
 
     info "Instance:  ${NAME}"
     info "Base image: ${base_image}"
@@ -263,13 +441,24 @@ main() {
         # The .wic ends one sector after its last partition, so /data has nowhere
         # to grow into. grow-data-part runs on first boot and needs this headroom.
         execute "qemu-img resize '${overlay}' '+${DISK_GROW}' >/dev/null"
-        execute "cp '${fw_vars}' '${nvram}'"
+        if [[ -z "${BIOS}" ]]; then
+            execute "cp '${fw_vars}' '${nvram}'"
+        fi
     else
         # Warn if the base moved on: a rebuild writes a new timestamped .wic, and
         # this overlay stays bound to the one it was created from.
         local bound
         bound="$(qemu-img info --output=json "${overlay}" 2>/dev/null \
             | sed -n 's/.*"full-backing-filename": *"\([^"]*\)".*/\1/p' | head -1)"
+        if [[ -n "${bound}" && ! -e "${bound}" ]]; then
+            # Fatal, not a warning: qemu cannot open the overlay at all, and the
+            # only recovery is to rebuild the instance.
+            error "Instance ${NAME} is bound to an image that no longer exists:"
+            error "  ${bound}"
+            error "Rebuild it against the current image with --recreate."
+            exit 1
+        fi
+
         if [[ -n "${bound}" && "${bound}" != "${base_image}" ]]; then
             warning "Instance ${NAME} is bound to an older image:"
             warning "  ${bound}"
@@ -277,20 +466,62 @@ main() {
             warning "  ${base_image}"
             warning "Use --recreate to move this instance to the new image."
         fi
+
+        if [[ -z "${BIOS}" && ! -e "${nvram}" ]]; then
+            error "Instance ${NAME} has no UEFI variable store at ${nvram}."
+            error "Use --recreate to rebuild this instance."
+            exit 1
+        fi
     fi
 
-    if [[ -w /dev/kvm ]]; then
-        accel="kvm"
-        # -cpu host: genericx86-64 is tuned for x86-64-v3 (AVX2/BMI/FMA), so the
-        # default qemu64 model cannot run the image at all. See plan 4.1.
-        cpu_model="host"
+    # Hardware acceleration needs the guest and host to share an architecture --
+    # a hypervisor virtualizes, it does not translate. An arm64 guest on an x86_64
+    # host is TCG regardless of what /dev/kvm says, which is exactly the case that
+    # lets a Linux x86_64 workstation boot the arm64 image at all.
+    local host_os host_arch
+    host_os="$(uname -s)"
+    host_arch="$(norm_arch "$(uname -m)")"
+
+    accel="tcg"
+    cpu_model="${CPU_TCG}"
+
+    if [[ "${host_arch}" == "${GUEST_ARCH}" ]]; then
+        case "${host_os}" in
+            Linux)
+                if [[ -w /dev/kvm ]]; then
+                    accel="kvm"
+                else
+                    warning "/dev/kvm not readable — falling back to software emulation (slow)."
+                    warning "Add yourself to the 'kvm' group to fix this."
+                fi
+                ;;
+            Darwin)
+                # Hypervisor.framework. UNVERIFIED: not run on a Mac. QEMU builds
+                # for macOS enable hvf by default and Homebrew's is signed for the
+                # hypervisor entitlement, so this is expected to work; if it does
+                # not, qemu says "invalid accelerator hvf" and --dry-run shows the
+                # exact command to adjust.
+                accel="hvf"
+                ;;
+            *)
+                warning "Unrecognised host OS '${host_os}': using software emulation."
+                ;;
+        esac
     else
-        accel="tcg"
-        cpu_model="Skylake-Client"
-        warning "/dev/kvm not available — falling back to software emulation (slow)."
-        warning "Add yourself to the 'kvm' group to fix this."
+        warning "${GUEST_ARCH} guest on a ${host_arch} host: TCG emulation."
+        warning "This works and exercises the real boot chain, but expect the"
+        warning "boot to take minutes rather than seconds."
     fi
-    debug "accel=${accel} cpu=${cpu_model}"
+
+    if [[ "${accel}" != "tcg" ]]; then
+        cpu_model="${CPU_KVM}"
+        if [[ "${GUEST_ARCH}" == "aarch64" ]]; then
+            # An accelerated arm64 guest needs a GICv3; virt's GICv2 default caps
+            # vCPUs at 8. genericarm64's own QB_CPU_KVM sets the same.
+            QEMU_MACHINE="${QEMU_MACHINE},gic-version=3"
+        fi
+    fi
+    debug "host=${host_os}/${host_arch} guest=${GUEST_ARCH} accel=${accel} cpu=${cpu_model}"
 
     if [[ -z "${SSH_PORT}" ]]; then
         SSH_PORT="$(find_free_port 2222)" || exit 1
@@ -302,14 +533,23 @@ main() {
     info "Exit cleanly with 'poweroff' in the guest, or Ctrl-A C then 'system_powerdown'."
     info ""
 
+    local -a fw_args=()
+    if [[ -n "${BIOS}" ]]; then
+        fw_args=(-bios "${BIOS}")
+    else
+        fw_args=(
+            -drive "if=pflash,format=raw,unit=0,readonly=on,file=${fw_code}"
+            -drive "if=pflash,format=raw,unit=1,file=${nvram}"
+        )
+    fi
+
     local -a qemu_cmd=(
         "${QEMU_BIN}"
         -machine "${QEMU_MACHINE},accel=${accel}"
         -cpu "${cpu_model}"
         -smp "${CPUS}"
         -m "${MEMORY}"
-        -drive "if=pflash,format=raw,unit=0,readonly=on,file=${fw_code}"
-        -drive "if=pflash,format=raw,unit=1,file=${nvram}"
+        "${fw_args[@]}"
         -drive "if=virtio,format=qcow2,file=${overlay}"
         -netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22"
         -device "virtio-net-pci,netdev=net0"

--- a/scripts/run-vm.sh
+++ b/scripts/run-vm.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+#
+# Launch a WendyOS VM image (vm-x86-64-wendyos) under QEMU.
+#
+# Supersedes run-qemu.sh for the VM machines. The differences are deliberate:
+# run-qemu.sh boots a kernel+rootfs directly on a host bridge for the old
+# qemuarm64 dev loop; this boots the real UEFI/GPT disk image through OVMF and
+# the A/B GRUB chain, so the guest exercises the same boot path a device does.
+#
+# Each VM is a named instance: one read-only .wic base shared by N qcow2
+# overlays, so a clone costs a few hundred KB and a second. That is what makes
+# the ML-training loop ("user code in the loop", many cheap instances) practical.
+#
+# See docs/plans/vm-support-plan.md.
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Global flags
+VERBOSE=false
+DRY_RUN=false
+RECREATE=false
+
+# Configuration (all overridable by flag; BUILD_DIR also by environment)
+BUILD_DIR="${BUILD_DIR:-build}"
+MACHINE="vm-x86-64-wendyos"
+NAME="default"
+DISK_GROW="32G"
+MEMORY="4096"
+CPUS="4"
+SSH_PORT=""
+EXTRA_ARGS=()
+
+# --- arch-varying values ------------------------------------------------------
+# x86_64 only for now. Phase 2 (arm64) adds a second column here rather than a
+# second script: qemu-system-aarch64, AAVMF_CODE/VARS instead of OVMF, and
+# -machine virt instead of q35. Everything below this block is arch-neutral.
+QEMU_BIN="qemu-system-x86_64"
+QEMU_MACHINE="q35"
+# Firmware CODE/VARS pairs, most preferred first. The _4M pair is what Debian 13
+# and Ubuntu ship. Deliberately NOT matched: *.secboot.fd / *_MS.fd — those
+# enroll Microsoft's Secure Boot keys and would refuse our unsigned GRUB.
+FIRMWARE_PAIRS=(
+    "/usr/share/OVMF/OVMF_CODE_4M.fd:/usr/share/OVMF/OVMF_VARS_4M.fd"
+    "/usr/share/OVMF/OVMF_CODE.fd:/usr/share/OVMF/OVMF_VARS.fd"
+    "/usr/share/edk2/ovmf/OVMF_CODE.fd:/usr/share/edk2/ovmf/OVMF_VARS.fd"
+    "/usr/share/qemu/ovmf-x86_64-code.bin:/usr/share/qemu/ovmf-x86_64-vars.bin"
+)
+
+# Print formatted/colored output
+info() { printf "%b\n" "$*"; }
+success() { printf "%b%s%b\n" "${GREEN}" "$*" "${NC}"; }
+warning() { printf "%bWARNING%b: %s\n" "${YELLOW}" "${NC}" "$*"; }
+error() { printf "%bERROR%b: %s\n" "${RED}" "${NC}" "$*" >&2; }
+debug() {
+    if [[ "${VERBOSE}" == "true" ]]; then
+        printf "%bDEBUG%b: %s\n" "${BLUE}" "${NC}" "$*" >&2
+    fi
+}
+
+# Execute a command, with dry-run support
+execute() {
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        printf "%bDRY-RUN%b: %s\n" "${YELLOW}" "${NC}" "$*"
+        return 0
+    fi
+    eval "$*"
+}
+
+check_command() { command -v "$1" &> /dev/null; }
+
+show_usage() {
+    cat << EOF
+Usage: $0 [options] [-- extra qemu args]
+
+Launch a WendyOS VM image under QEMU/KVM with UEFI firmware.
+
+Options:
+    -n, --name NAME      Instance name (default: default). Each instance gets its
+                         own disk overlay and UEFI variables, so several can run
+                         at once from one shared base image.
+    -b, --build-dir DIR  Build directory (default: build)
+    -m, --machine NAME   Yocto MACHINE (default: ${MACHINE})
+        --memory MB      Guest RAM in MB (default: ${MEMORY})
+        --cpus N         Guest vCPUs (default: ${CPUS})
+        --disk-size SIZE Grow the virtual disk by this much on creation
+                         (default: ${DISK_GROW}). Required: the .wic is exactly
+                         the size of its partitions, so without headroom /data
+                         cannot grow on first boot.
+        --ssh-port PORT  Host port forwarded to guest :22 (default: first free
+                         port from 2222 up)
+        --recreate       Delete and recreate this instance's disk and UEFI
+                         variables. Gives a fresh device identity.
+    -v, --verbose        Verbose/debug output
+        --dry-run        Print what would be done, run nothing
+    -h, --help           Show this help
+
+Environment:
+    BUILD_DIR            Build directory path (default: build)
+
+Examples:
+    $0                                  # boot the default instance
+    $0 --name train-01                  # a second, independent VM
+    $0 --name train-01 --recreate       # wipe it back to a first boot
+    $0 --memory 8192 --cpus 8           # bigger guest
+    $0 --dry-run --verbose              # show the qemu command line
+    $0 -- -device usb-tablet            # append raw qemu arguments
+
+Shutting down cleanly:
+    Run 'poweroff' in the guest, or press Ctrl-A then C for the QEMU monitor and
+    type 'system_powerdown'. Do NOT use Ctrl-A X — that kills the VM instantly,
+    which can leave an in-progress A/B update half-applied.
+
+Notes:
+    - The guest reaches host services at 10.0.2.2 (QEMU user networking). That
+      address is virtual and never appears in 'ip addr' on the host.
+    - Instance state lives in <workspace>/vm/<name>/.
+EOF
+}
+
+# Locate the newest real .wic in the deploy directory.
+#
+# Deliberately skips symlinks: every build repoints wendyos-image-*.rootfs.wic at
+# its newest output, and a qcow2 overlay records the path it was given. Backing an
+# overlay with the symlink means the next build silently swaps the disk under a
+# running VM. Always bind to the timestamped file.
+find_base_image() {
+    local deploy_dir="$1"
+    local newest
+
+    if [[ ! -d "${deploy_dir}" ]]; then
+        error "Deploy directory not found: ${deploy_dir}"
+        error "Build the image first, or pass --build-dir / --machine."
+        return 1
+    fi
+
+    newest=$(find "${deploy_dir}" -maxdepth 1 -name '*.wic' -type f -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | head -1 | cut -d' ' -f2-)
+
+    if [[ -z "${newest}" ]]; then
+        error "No .wic image in ${deploy_dir}"
+        return 1
+    fi
+
+    realpath "${newest}"
+}
+
+# Pick the first firmware pair present on this host.
+find_firmware() {
+    local pair code vars
+    for pair in "${FIRMWARE_PAIRS[@]}"; do
+        code="${pair%%:*}"
+        vars="${pair##*:}"
+        if [[ -r "${code}" && -r "${vars}" ]]; then
+            debug "firmware: ${code} + ${vars}"
+            printf '%s\n' "${pair}"
+            return 0
+        fi
+    done
+    error "No UEFI firmware found. Install OVMF:"
+    error "  Debian/Ubuntu: sudo apt install ovmf"
+    error "  Fedora:        sudo dnf install edk2-ovmf"
+    error "Looked for: ${FIRMWARE_PAIRS[*]}"
+    return 1
+}
+
+# First free TCP port at or above $1, so two instances never collide.
+find_free_port() {
+    local port="$1"
+    local limit=$((port + 100))
+    while [[ "${port}" -lt "${limit}" ]]; do
+        if check_command ss; then
+            if ! ss -ltnH "sport = :${port}" 2>/dev/null | grep -q .; then
+                printf '%s\n' "${port}"
+                return 0
+            fi
+        else
+            # No ss: assume free and let qemu report a bind failure.
+            printf '%s\n' "${port}"
+            return 0
+        fi
+        port=$((port + 1))
+    done
+    error "No free port in $1..${limit}"
+    return 1
+}
+
+main() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -n|--name)       NAME="$2"; shift 2 ;;
+            -b|--build-dir)  BUILD_DIR="$2"; shift 2 ;;
+            -m|--machine)    MACHINE="$2"; shift 2 ;;
+            --memory)        MEMORY="$2"; shift 2 ;;
+            --cpus)          CPUS="$2"; shift 2 ;;
+            --disk-size)     DISK_GROW="$2"; shift 2 ;;
+            --ssh-port)      SSH_PORT="$2"; shift 2 ;;
+            --recreate)      RECREATE=true; shift ;;
+            -v|--verbose)    VERBOSE=true; shift ;;
+            --dry-run)       DRY_RUN=true; shift ;;
+            -h|--help)       show_usage; exit 0 ;;
+            --)              shift; EXTRA_ARGS=("$@"); break ;;
+            *)
+                error "Unknown argument: $1"
+                echo ""
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+
+    local script_dir workspace_dir deploy_dir base_image
+    local state_dir overlay nvram fw_pair fw_code fw_vars
+    local accel cpu_model
+
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    workspace_dir="$(cd "${script_dir}/../.." && pwd)"
+    deploy_dir="${workspace_dir}/${BUILD_DIR}/tmp/deploy/images/${MACHINE}"
+
+    for tool in "${QEMU_BIN}" qemu-img; do
+        check_command "${tool}" || { error "Required tool not found: ${tool}"; exit 1; }
+    done
+
+    base_image="$(find_base_image "${deploy_dir}")" || exit 1
+    fw_pair="$(find_firmware)" || exit 1
+    fw_code="${fw_pair%%:*}"
+    fw_vars="${fw_pair##*:}"
+
+    state_dir="${workspace_dir}/vm/${NAME}"
+    overlay="${state_dir}/disk.qcow2"
+    nvram="${state_dir}/OVMF_VARS.fd"
+
+    info "Instance:  ${NAME}"
+    info "Base image: ${base_image}"
+    info "State:     ${state_dir}"
+
+    # Decide from intent, not from what is on disk after the fact: under --dry-run
+    # the rm below does not actually happen, so re-reading the filesystem would
+    # send a --recreate dry run down the "instance already exists" path and print
+    # the opposite of what a real run would do.
+    local needs_create=false
+    if [[ ! -e "${overlay}" ]]; then
+        needs_create=true
+    elif [[ "${RECREATE}" == "true" ]]; then
+        warning "Recreating ${NAME}: existing disk and UEFI variables are discarded."
+        execute "rm -f '${overlay}' '${nvram}'"
+        needs_create=true
+    fi
+
+    execute "mkdir -p '${state_dir}'"
+
+    if [[ "${needs_create}" == "true" ]]; then
+        info "Creating disk overlay (+${DISK_GROW} headroom for /data)"
+        # Absolute backing path: qemu-img resolves a relative one against the
+        # OVERLAY's directory, not the working directory.
+        execute "qemu-img create -f qcow2 -F raw -b '${base_image}' '${overlay}' >/dev/null"
+        # The .wic ends one sector after its last partition, so /data has nowhere
+        # to grow into. grow-data-part runs on first boot and needs this headroom.
+        execute "qemu-img resize '${overlay}' '+${DISK_GROW}' >/dev/null"
+        execute "cp '${fw_vars}' '${nvram}'"
+    else
+        # Warn if the base moved on: a rebuild writes a new timestamped .wic, and
+        # this overlay stays bound to the one it was created from.
+        local bound
+        bound="$(qemu-img info --output=json "${overlay}" 2>/dev/null \
+            | sed -n 's/.*"full-backing-filename": *"\([^"]*\)".*/\1/p' | head -1)"
+        if [[ -n "${bound}" && "${bound}" != "${base_image}" ]]; then
+            warning "Instance ${NAME} is bound to an older image:"
+            warning "  ${bound}"
+            warning "Newest build is:"
+            warning "  ${base_image}"
+            warning "Use --recreate to move this instance to the new image."
+        fi
+    fi
+
+    if [[ -w /dev/kvm ]]; then
+        accel="kvm"
+        # -cpu host: genericx86-64 is tuned for x86-64-v3 (AVX2/BMI/FMA), so the
+        # default qemu64 model cannot run the image at all. See plan 4.1.
+        cpu_model="host"
+    else
+        accel="tcg"
+        cpu_model="Skylake-Client"
+        warning "/dev/kvm not available — falling back to software emulation (slow)."
+        warning "Add yourself to the 'kvm' group to fix this."
+    fi
+    debug "accel=${accel} cpu=${cpu_model}"
+
+    if [[ -z "${SSH_PORT}" ]]; then
+        SSH_PORT="$(find_free_port 2222)" || exit 1
+    fi
+
+    info "SSH:       ssh -p ${SSH_PORT} wendy@localhost"
+    info ""
+    success "Starting ${NAME} (${CPUS} vCPU, ${MEMORY} MB, ${accel})."
+    info "Exit cleanly with 'poweroff' in the guest, or Ctrl-A C then 'system_powerdown'."
+    info ""
+
+    local -a qemu_cmd=(
+        "${QEMU_BIN}"
+        -machine "${QEMU_MACHINE},accel=${accel}"
+        -cpu "${cpu_model}"
+        -smp "${CPUS}"
+        -m "${MEMORY}"
+        -drive "if=pflash,format=raw,unit=0,readonly=on,file=${fw_code}"
+        -drive "if=pflash,format=raw,unit=1,file=${nvram}"
+        -drive "if=virtio,format=qcow2,file=${overlay}"
+        -netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22"
+        -device "virtio-net-pci,netdev=net0"
+        -object "rng-random,filename=/dev/urandom,id=rng0"
+        -device "virtio-rng-pci,rng=rng0"
+        -nographic
+    )
+    qemu_cmd+=("${EXTRA_ARGS[@]}")
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        printf "%bDRY-RUN%b: %s\n" "${YELLOW}" "${NC}" "${qemu_cmd[*]}"
+        exit 0
+    fi
+
+    exec "${qemu_cmd[@]}"
+}
+
+main "$@"


### PR DESCRIPTION
Ship a VM image of WendyOS for both arm64 and x86_64.

A lightweight OS image that behaves like a real WendyOS device, minus peripherals and GPU. Developers point it at IP cameras and other network-attached sensors (already supported today), so a VM is a viable entryway for testing their code without hardware.