### PR TITLE
ci: drop download stamps whose payload the cache prune removed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,6 +247,17 @@ jobs:
             ln -sfn "$base/$d" "$GITHUB_WORKSPACE/$d"
             echo "linked $GITHUB_WORKSPACE/$d -> $base/$d"
           done
+          # The cache pool is shared and pruned on a timer we do not control, so
+          # validate it before trusting it. A fetch is gated purely on its .done
+          # stamp, so a stamp outliving its payload makes bitbake skip the
+          # download and then fail on the missing file, permanently.
+          # -e, not -f: git2/*.done stamps guard bare clone directories.
+          if [ -d "$base/downloads" ]; then
+            find "$base/downloads" -name '*.done' -type f | while IFS= read -r s; do
+              p="${s%.done}"
+              [ -e "$p" ] || { echo "repair: dropping orphaned stamp $s"; rm -f "$s"; }
+            done
+          fi
 
       # ---------- Build ----------
 


### PR DESCRIPTION
# Problem:
The daily cache prune (`find -mtime +30 -delete`) deleted `downloads/uninative/<sha>/x86_64-nativesdk-libc-5.2.tar.xz` but kept its `.done` stamp. `uninative.bbclass` gates the re-fetch solely on that stamp, so bitbake skips the download and then fails to untar a file that isn't there uninative silently disabled on every run since.

`Build jetson-agx-thor (nvme)` failed every run from 2026-08-31T00:01Z.

# Solution:
Drop any `downloads/**/*.done` whose payload is gone, so bitbake re-fetches.
The cache pool is shared, so the first job of a run repairs it for every branch.
