### PR TITLE
data: default /data encryption off on Jetson and x86

### DIFF
--- a/conf/template/include/local/tegra-t234.inc
+++ b/conf/template/include/local/tegra-t234.inc
@@ -71,9 +71,10 @@ WENDYOS_EFI_DEBUG = "0"
 # recipe serves Orin (t234) and Thor (t264).
 WENDYOS_DEEPSTREAM = "1"
 
-# LUKS2 encryption of /data, sealed to the fTPM. Default ON.
-# Set WENDYOS_DATA_ENCRYPTED = "0" in local.conf for a plain-ext4 /data.
-WENDYOS_DATA_ENCRYPTED ?= "1"
+# LUKS2 encryption of /data, sealed to the fTPM. Default OFF: an image that
+# assumes LUKS leaves an already-provisioned plaintext /data unmounted, and
+# there is no in-place migration yet. Set = "1" in local.conf to build it.
+WENDYOS_DATA_ENCRYPTED ?= "0"
 
 # Master gate for the TPM 2.0 stack itself (fTPM over OP-TEE). Encrypting
 # /data needs a TPM at runtime, so it turns this on. Nothing turns encryption

--- a/conf/template/include/local/tegra-t264.inc
+++ b/conf/template/include/local/tegra-t264.inc
@@ -63,9 +63,10 @@ WENDYOS_EFI_DEBUG = "0"
 # (Was "0" in the wrynose/r38.4 era when no DeepStream recipe existed for Thor.)
 WENDYOS_DEEPSTREAM = "1"
 
-# LUKS2 encryption of /data, sealed to the fTPM. Default ON.
-# Set WENDYOS_DATA_ENCRYPTED = "0" in local.conf for a plain-ext4 /data.
-WENDYOS_DATA_ENCRYPTED ?= "1"
+# LUKS2 encryption of /data, sealed to the fTPM. Default OFF: an image that
+# assumes LUKS leaves an already-provisioned plaintext /data unmounted, and
+# there is no in-place migration yet. Set = "1" in local.conf to build it.
+WENDYOS_DATA_ENCRYPTED ?= "0"
 
 # Master gate for the TPM 2.0 stack itself (fTPM over OP-TEE, plus the Thor
 # DT overlay in tegra-overlays.inc). Encrypting /data needs a TPM at runtime,

--- a/conf/template/include/local/x86.inc
+++ b/conf/template/include/local/x86.inc
@@ -17,12 +17,13 @@ WENDYOS_NVIDIA_DGPU ?= "1"
 # parallelism pin now applied to every board in common.inc. Measured here: a full
 # cold image build peaks ~13 GiB anon under that pin, no OOM.
 
-# LUKS2 encryption of /data, sealed to the TPM. Default ON.
-# Set WENDYOS_DATA_ENCRYPTED = "0" in local.conf for a plain-ext4 /data.
+# LUKS2 encryption of /data, sealed to the TPM. Default OFF: an image that
+# assumes LUKS leaves an already-provisioned plaintext /data unmounted, and
+# there is no in-place migration yet. Set = "1" in local.conf to build it.
 # Gates the TPM/LUKS userspace, the first-boot enroll service (data-crypt),
 # systemd's cryptsetup support, and the fstab/mount rewiring. Jetson has the
 # same knob in local/tegra-t264.inc / tegra-t234.inc.
-WENDYOS_DATA_ENCRYPTED ?= "1"
+WENDYOS_DATA_ENCRYPTED ?= "0"
 
 # Master gate for the TPM 2.0 stack itself: the kernel TPM drivers
 # (x86-tpm.cfg), systemd's tpm2 support, and the tpm2 DISTRO feature below.

--- a/recipes-core/systemd-mount-tee/files/var-lib-tee-tpm.mount
+++ b/recipes-core/systemd-mount-tee/files/var-lib-tee-tpm.mount
@@ -1,5 +1,5 @@
-# Variant of var-lib-tee.mount for TPM /data-encryption builds
-# (WENDYOS_ENABLE_TPM=1), installed AS var-lib-tee.mount by the recipe.
+# Variant of var-lib-tee.mount for /data-encryption builds
+# (WENDYOS_DATA_ENCRYPTED=1), installed AS var-lib-tee.mount by the recipe.
 #
 # The default unit binds /var/lib/tee from /data/tee so OP-TEE secure storage
 # survives A/B OTA updates. With the fTPM encrypting /data that is circular: the

--- a/recipes-core/wendyos-data-setup/files/data-luks.mount
+++ b/recipes-core/wendyos-data-setup/files/data-luks.mount
@@ -1,5 +1,5 @@
-# Full replacement for data.mount on TPM /data-encryption builds
-# (WENDYOS_ENABLE_TPM=1), installed AS data.mount by the wendyos-data-setup
+# Full replacement for data.mount on /data-encryption builds
+# (WENDYOS_DATA_ENCRYPTED=1), installed AS data.mount by the wendyos-data-setup
 # bbappend. A drop-in cannot be used here: the base unit hard-Requires
 # wendyos-data-init.service, and per systemd.unit(5) "dependencies cannot be
 # reset to an empty list, so dependencies can only be added in drop-ins. If you

--- a/recipes-support/data-crypt/files/data-enroll.sh
+++ b/recipes-support/data-crypt/files/data-enroll.sh
@@ -55,6 +55,15 @@ data_fills_disk() {
     [ "$disk_sz" -gt 0 ] && [ $((d_start + d_sz)) -ge $((disk_sz - END_SLACK)) ]
 }
 
+# True when /data carries real user data rather than a fresh partition: every
+# install path grows /data on first boot right before formatting it, so
+# "grown AND carries a filesystem" stands in for "live".
+# KNOWN GAP: a live /data that never reached the disk end reads as fresh here,
+# and is then formatted.
+data_holds_live_content() {
+    data_fills_disk && [ -n "$(lsblk -no FSTYPE "$DATA" 2>/dev/null | head -1)" ]
+}
+
 [ -b "$DATA" ] || fail "$DATA not present"
 
 # Resolve the partition/disk early: the idempotence check below needs
@@ -84,20 +93,13 @@ if cryptsetup isLuks "$DATA" 2>/dev/null; then
     wipefs -a "$DATA" || fail "wipefs of the stale LUKS header failed"
 fi
 
-# Migration guard: a non-LUKS /data that has both been grown to fill the disk
-# and carries a filesystem is a provisioned installation from a TPM-off build
-# (every install path grows /data only on its first boot, right before
-# formatting it). Encrypting it here would luksFormat over live user data, so
-# refuse loudly and leave the partition untouched -- the TPM-off -> TPM-on
-# migration story is an open topic. /data stays unmounted this boot (the LUKS
-# mount path expects /dev/mapper/data), but the data survives on disk.
-# Fresh installs are unaffected: their stock /data is small (tegra flashes it
-# empty, the x86 wic ships a 512M empty ext4), so fills-disk is false and
-# enrollment proceeds.
-# Fail CLOSED: without lsblk the command substitution below would be silently
-# empty and the guard would wave a provisioned /data through to luksFormat.
+# Refuse rather than luksFormat over a provisioned TPM-off installation. Fresh
+# installs are unaffected: their stock /data is small, so the predicate is false
+# and enrollment proceeds. /data stays unmounted this boot (the LUKS mount path
+# expects /dev/mapper/data) but the data survives on disk. Fail CLOSED if lsblk
+# is missing: the predicate would read empty and wave a provisioned /data through.
 command -v lsblk >/dev/null 2>&1 || fail "lsblk missing -- cannot run the migration guard"
-if data_fills_disk && [ -n "$(lsblk -no FSTYPE "$DATA" 2>/dev/null | head -1)" ]; then
+if data_holds_live_content; then
     announce "data-enroll REFUSING to encrypt: $DATA holds a grown filesystem from a previous (TPM-off) installation -- formatting would destroy its data. Leaving it untouched; /data will NOT mount until the device is migrated or re-flashed."
     exit 0
 fi


### PR DESCRIPTION
An image built with it on assumes /data is a LUKS volume, so a device provisioned before it boots with /data unmounted and no migration path.

Refs: WDY-2781