### PR TITLE
fix(tegra): expose Vulkan GLX driver to GPU containers

### DIFF
--- a/meta-tegra-extensions/recipes-bsp/tegra-binaries/tegra-libraries-glxcore_%.bbappend
+++ b/meta-tegra-extensions/recipes-bsp/tegra-binaries/tegra-libraries-glxcore_%.bbappend
@@ -1,0 +1,3 @@
+# NVIDIA's Vulkan ICD loads libGLX_nvidia.so.0 even for headless workloads.
+# WendyOS does not run X11, but containers still need this driver entry point.
+REQUIRED_DISTRO_FEATURES:remove = "x11"

--- a/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-nvidia-container.bb
+++ b/meta-tegra-extensions/recipes-core/packagegroups/packagegroup-nvidia-container.bb
@@ -56,7 +56,9 @@ inherit packagegroup
 # - nvidia-container-toolkit (nvidia-ctk for CDI generation)
 # - nvidia-container-runtime
 
-# Core packages required for l4t.csv container support (always included)
+# Core packages required for l4t.csv container support (always included).
+# glxcore supplies the entry point named by NVIDIA's Vulkan ICD, including for
+# headless container workloads that never create an X11 surface.
 RDEPENDS:${PN} = " \
     nvidia-container-config \
     nvidia-container-toolkit \
@@ -77,6 +79,7 @@ RDEPENDS:${PN} = " \
     tegra-libraries-camera \
     tegra-libraries-eglcore \
     tegra-libraries-glescore \
+    tegra-libraries-glxcore \
     cudnn \
     cusparselt \
     tensorrt-core \

--- a/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-blacksail.csv
+++ b/meta-tegra-extensions/recipes-support/nvidia-container-config/files/l4t-blacksail.csv
@@ -5,6 +5,13 @@
 #   - System libs: /usr/lib/ (not /usr/lib/aarch64-linux-gnu/)
 
 # =============================================================================
+# VULKAN DRIVER ENTRY POINT
+# =============================================================================
+# NVIDIA's upstream drivers.csv uses the Debian multiarch path for this file.
+# meta-tegra installs it in /usr/lib on WendyOS, so map the Yocto path too.
+lib, /usr/lib/libGLX_nvidia.so.0
+
+# =============================================================================
 # DEVICE NODES
 # =============================================================================
 dev, /dev/nvidiactl


### PR DESCRIPTION
## Summary

- install `tegra-libraries-glxcore` with the Jetson NVIDIA container package group
- allow that driver-only package to build on headless WendyOS without enabling the X11 distro feature
- add the Yocto `/usr/lib/libGLX_nvidia.so.0` location to the CDI CSV

## Observed failure

On a Jetson AGX Thor running WendyOS 0.18.1 / JetPack 7.2, the Isaac Sim 6.0.1 ARM64 compatibility checker received the NVIDIA device nodes and `/etc/vulkan/icd.d/nvidia_icd.json`, but Vulkan failed during instance creation:

```text
VkResult: ERROR_INCOMPATIBLE_DRIVER
vkCreateInstance failed
System checking result: FAILED
```

The injected ICD names `libGLX_nvidia.so.0`, while neither that library nor `libnvidia-glcore.so.595.78` was present in the container. The WendyOS NVIDIA package group includes EGL and GLES core packages but omits `tegra-libraries-glxcore`, which provides both files.

There are two headless-image details behind the omission:

1. WendyOS removes the `x11` distro feature, while the upstream OE4T glxcore recipe requires it even though the NVIDIA Vulkan ICD uses `libGLX_nvidia.so.0` for headless workloads.
2. The upstream CDI `drivers.csv` names the Debian multiarch path for `libGLX_nvidia.so.0`, but meta-tegra installs the library at `/usr/lib` in this Yocto image.

## Why this change

The bbappend removes only the recipe feature gate; it does not enable an X server or change the WendyOS display stack. Adding the package supplies the NVIDIA driver entry point and its runtime dependencies. The extra CDI row maps the actual Yocto host path into GPU-entitled containers.

## Validation

Completed locally:

- `git diff --check`
- CDI CSV syntax validation
- static assertions for the package dependency, headless feature override, and `/usr/lib` mapping

Still required before merge:

- build the Jetson AGX Thor WendyOS image
- verify the generated CDI spec contains both GLX driver libraries
- run a Vulkan smoke test or the Isaac Sim compatibility checker after OTA

This PR fixes the demonstrated missing-driver packaging and CDI path. It does not by itself claim that Isaac Sim is fully supported on Jetson AGX Thor.