### PR TITLE
 add Qualcomm Dragonwing IQ-8275 EVK support

### DIFF
--- a/.github/device-artifacts.json
+++ b/.github/device-artifacts.json
@@ -9,6 +9,7 @@
   "raspberry-pi-4/sd":      { "image_kind": "sdimg-gz-with-wic-fallback", "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false },
   "raspberry-pi-3/sd":      { "image_kind": "sdimg-gz-with-wic-fallback", "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false },
   "generic-x86-64/disk":    { "image_kind": "wic-disk",                   "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false },
+  "dragonwing-iq-8275/ufs": { "image_kind": "qcomflash-bundle",           "recovery_bundle_expected": false, "bmap": false, "flashpack": false, "pass_storage": false },
   "vm-arm64/disk":          { "image_kind": "wic-disk",                   "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false },
   "vm-x86-64/disk":         { "image_kind": "wic-disk",                   "recovery_bundle_expected": false, "bmap": true,  "flashpack": false, "pass_storage": false }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ on:
           - jetson-orin-nano
           - jetson-agx-thor
           - generic-x86-64
+          - dragonwing-iq-8275
           - vm-arm64
           - vm-x86-64
       version:
@@ -149,8 +150,8 @@ jobs:
           # slowest are dispatched first: jetson-agx-thor is the long pole
           # (~14 min warm vs ~5 min for a Pi; heavier still on release builds,
           # which add tegraflash + flashpack + upload), then the other Jetsons,
-          # then generic-x86-64 (coldest sstate — newest board), then the
-          # Raspberry Pis. The merged multi-storage jobs (agx-orin, orin-nano,
+          # then dragonwing-iq-8275 and generic-x86-64 (coldest sstate — newest boards),
+          # then the Raspberry Pis. The merged multi-storage jobs (agx-orin, orin-nano,
           # rpi-5) are heavier than a single-variant build of the same device
           # (one full build + a mostly-cached second variant) but lighter than
           # two separate jobs. Do NOT sort this alphabetically.
@@ -158,6 +159,7 @@ jobs:
             {"device":"jetson-agx-thor","storages":"nvme"},
             {"device":"jetson-agx-orin","storages":"nvme emmc"},
             {"device":"jetson-orin-nano","storages":"nvme sd"},
+            {"device":"dragonwing-iq-8275","storages":"ufs"},
             {"device":"generic-x86-64","storages":"disk"},
             {"device":"raspberry-pi-5","storages":"nvme sd"},
             {"device":"raspberry-pi-4","storages":"sd"},
@@ -171,7 +173,7 @@ jobs:
 
           emit_all() {
             echo "matrix={\"include\":${ALL_MATRIX}}" >> "$GITHUB_OUTPUT"
-            echo "devices=jetson-agx-thor jetson-agx-orin jetson-orin-nano generic-x86-64 raspberry-pi-5 raspberry-pi-4 raspberry-pi-3 vm-arm64 vm-x86-64" >> "$GITHUB_OUTPUT"
+            echo "devices=jetson-agx-thor jetson-agx-orin jetson-orin-nano dragonwing-iq-8275 generic-x86-64 raspberry-pi-5 raspberry-pi-4 raspberry-pi-3 vm-arm64 vm-x86-64" >> "$GITHUB_OUTPUT"
           }
 
           emit_one() {
@@ -291,6 +293,7 @@ jobs:
               jetson-orin-nano:sd)   BOARD=jetson-orin-nano-sd;   MACHINE=jetson-orin-nano-devkit-wendyos ;;
               jetson-agx-thor:nvme) BOARD=jetson-agx-thor;       MACHINE=jetson-agx-thor-devkit-nvme-wendyos ;;
               generic-x86-64:disk)  BOARD=generic-x86-64;       MACHINE=genericx86-64-wendyos ;;
+              dragonwing-iq-8275:ufs) BOARD=dragonwing-iq8275;   MACHINE=iq-8275-evk-wendyos ;;
               vm-arm64:disk)        BOARD=vm-arm64;             MACHINE=vm-arm64-wendyos ;;
               vm-x86-64:disk)       BOARD=vm-x86-64;            MACHINE=vm-x86-64-wendyos ;;
               *) echo "Unknown device/storage: $DEVICE/$STORAGE"; exit 1 ;;
@@ -921,6 +924,10 @@ jobs:
                 # No offline disk image for eMMC / Thor NVMe; IMAGE_FILE is the
                 # tegraflash bundle itself, already resolved and existence-checked
                 # (with df/ls diagnostics) by the resolver. No bmap for this kind.
+                : ;;
+              qcomflash-bundle)
+                # IMAGE_FILE is the qcomflash tarball itself, already
+                # existence-checked by the resolver. No bmap, no gzip.
                 : ;;
               sdimg-gz-with-wic-fallback)
                 # RPi: IMAGE_FILE is the readlink-resolved raw image (.sdimg real

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -20,6 +20,7 @@ on:
       - 'meta-qcom-extensions/files/grub/*'
       - 'meta-qcom-extensions/recipes-bsp/grub/*'
       - 'meta-qcom-extensions/recipes-bsp/partition/files/*'
+      - 'meta-qcom-extensions/recipes-core/wendyos-config-setup/files/*'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
   push:
@@ -40,6 +41,7 @@ on:
       - 'meta-qcom-extensions/files/grub/*'
       - 'meta-qcom-extensions/recipes-bsp/grub/*'
       - 'meta-qcom-extensions/recipes-bsp/partition/files/*'
+      - 'meta-qcom-extensions/recipes-core/wendyos-config-setup/files/*'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
 
@@ -64,7 +66,8 @@ jobs:
           shellcheck scripts/build-driver.sh scripts/pack-sysext.sh \
                      recipes-core/wendyos-sysext-apply/files/wendyos-sysext-apply.sh \
                      recipes-kernel/wendyos-kernel-devkit/files/setup.sh \
-                     meta-qcom-extensions/files/grub/grubAB-qcom.test.sh
+                     meta-qcom-extensions/files/grub/grubAB-qcom.test.sh \
+                     meta-qcom-extensions/recipes-core/wendyos-config-setup/files/wendyos-config-init.sh
           shellcheck recipes-core/wendyos-identity/files/wendyos-identity-lib.sh \
                      recipes-core/wendyos-identity/files/update-mdns-uuid.sh \
                      recipes-core/wendyos-identity/files/update-mdns-uuid.test.sh \

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -17,6 +17,9 @@ on:
       - 'recipes-kernel/wendyos-kernel-devkit/files/*.sh'
       - 'recipes-core/wendyos-identity/files/*.sh'
       - 'recipes-connectivity/avahi/files/*.sh'
+      - 'meta-qcom-extensions/files/grub/*'
+      - 'meta-qcom-extensions/recipes-bsp/grub/*'
+      - 'meta-qcom-extensions/recipes-bsp/partition/files/*'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
   push:
@@ -34,6 +37,9 @@ on:
       - 'recipes-kernel/wendyos-kernel-devkit/files/*.sh'
       - 'recipes-core/wendyos-identity/files/*.sh'
       - 'recipes-connectivity/avahi/files/*.sh'
+      - 'meta-qcom-extensions/files/grub/*'
+      - 'meta-qcom-extensions/recipes-bsp/grub/*'
+      - 'meta-qcom-extensions/recipes-bsp/partition/files/*'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
 
@@ -57,7 +63,8 @@ jobs:
           # a failed boot or an unusable devkit rather than a build error.
           shellcheck scripts/build-driver.sh scripts/pack-sysext.sh \
                      recipes-core/wendyos-sysext-apply/files/wendyos-sysext-apply.sh \
-                     recipes-kernel/wendyos-kernel-devkit/files/setup.sh
+                     recipes-kernel/wendyos-kernel-devkit/files/setup.sh \
+                     meta-qcom-extensions/files/grub/grubAB-qcom.test.sh
           shellcheck recipes-core/wendyos-identity/files/wendyos-identity-lib.sh \
                      recipes-core/wendyos-identity/files/update-mdns-uuid.sh \
                      recipes-core/wendyos-identity/files/update-mdns-uuid.test.sh \
@@ -84,6 +91,11 @@ jobs:
       - name: Run mDNS identity publisher tests
         run: bash recipes-core/wendyos-identity/files/update-mdns-uuid.test.sh
 
+      # This config runs before any userspace exists, so a mistake in it surfaces
+      # only as a device that will not boot. Asserts its couplings to
+      # partitions.conf, the grub-efi bbappend and the grubenv connector.
+      - name: Run Dragonwing GRUB A/B config checks
+        run: bash meta-qcom-extensions/files/grub/grubAB-qcom.test.sh
 
       - name: Run T234 flashpack manifest tests
         run: python3 -m unittest scripts/t234_flashpack_manifest_test.py

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repository provides the meta-layer and build flow to build **WendyOS** — 
 | Generic x86_64 PC | Intel/AMD x86_64 | varies | `generic-x86-64` | `genericx86-64-wendyos` | USB / disk (.wic) | wendyos-update |
 | Virtual machine (x86_64) | virtual | configurable | `vm-x86-64` | `vm-x86-64-wendyos` | virtio (.wic) | wendyos-update |
 | Virtual machine (arm64) | virtual | configurable | `vm-arm64` | `vm-arm64-wendyos` | virtio (.wic) | wendyos-update |
+| Qualcomm Dragonwing IQ-8275 EVK | QCS8275 (aarch64) | 12 GB | `dragonwing-iq8275` | `iq-8275-evk-wendyos` | UFS (EDL / qdl) | wendyos-update |
 
 ## TL;DR
 
@@ -216,6 +217,10 @@ make build MACHINE=vm-x86-64-wendyos
 # Virtual machine, arm64 host (Apple Silicon via UTM, or arm64 Linux)
 make setup BOARD=vm-arm64
 make build MACHINE=vm-arm64-wendyos
+
+# Qualcomm Dragonwing IQ-8275 EVK (UFS, flashed over EDL with qdl)
+make setup BOARD=dragonwing-iq8275
+make build MACHINE=iq-8275-evk-wendyos
 ```
 
 > `BOARD` must be set to a board id matching a directory
@@ -269,6 +274,7 @@ make build MACHINE=vm-arm64-wendyos
    BOARD=generic-x86-64        ./meta-wendyos/bootstrap.sh
    BOARD=vm-x86-64             ./meta-wendyos/bootstrap.sh
    BOARD=vm-arm64              ./meta-wendyos/bootstrap.sh
+   BOARD=dragonwing-iq8275     ./meta-wendyos/bootstrap.sh
    ```
 
    `MACHINE=<board-id>` remains supported as a deprecated alias (prints a
@@ -304,6 +310,7 @@ make build MACHINE=vm-arm64-wendyos
      - `generic-x86-64`          → `genericx86-64-wendyos`
      - `vm-x86-64`               → `vm-x86-64-wendyos`
      - `vm-arm64`                → `vm-arm64-wendyos`
+     - `dragonwing-iq8275`       → `iq-8275-evk-wendyos`
    - `WENDYOS_FLASH_IMAGE_SIZE` - Flash image size: "64GB"):
      - `"4GB"` - 3.2GB Mender storage (~1.3GB per rootfs partition)
      - `"8GB"` - 6.4GB Mender storage (~2.9GB per rootfs partition)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -622,6 +622,7 @@ declare -a repos=(
     "1|${URL_TEGRA_COMM}||${SRCREV_TEGRA_COMM}"
     "1|${URL_VIRT}||${SRCREV_VIRT}"
     "1|${URL_RPI}||${SRCREV_RPI}"
+    "1|${URL_QCOM}||${SRCREV_QCOM}"
     "1|${URL_SECURITY}||${SRCREV_SECURITY}"
 )
 

--- a/conf/distro/include/qcom-image.inc
+++ b/conf/distro/include/qcom-image.inc
@@ -1,0 +1,63 @@
+# Qualcomm Dragonwing image configuration.
+# Required from wendyos-image.bb when MACHINEOVERRIDES contains 'qcom-wendyos'.
+
+# wendyos-image.bb pairs these with WENDYOS_USB_GADGET for every board, but both
+# live in meta-tegra-extensions. IMAGE_INSTALL resolves at task-scheduling time, so
+# an absent package must be removed explicitly or the build fails on it. Neither is
+# needed here: the gadget stack is built into the kernel (see usb-gadget.cfg).
+IMAGE_INSTALL:remove = " \
+    usb-gadget-modules \
+    usb-network-tuning \
+    "
+
+# The flashable output is the qcomflash package via image_types_qcom. Deliberately
+# no wic/WKS_FILE: the layout comes from a partitions.conf compiled by qcom-ptool.
+
+# wendy OTA deltas, gated on WENDYOS_OTA == "wendy".
+#  - wendyos-update-config pins the OTA connector to grubenv.
+#  - grub-editenv lets that connector edit EFI/BOOT/grubenv from Linux.
+#  - grow-data-part is deliberately absent: the flash tool already grew /data
+#    (patch0.xml rewrites the last partition's end LBA from the real disk size).
+WENDYOS_QCOM_OTA_INSTALL = " \
+    wendyos-update-config \
+    grub-editenv \
+    wendyos-config-setup \
+    "
+
+# The DTB must travel with the kernel, inside the rootfs slot. Supplied with none,
+# the kernel inherits the one UEFI installs from dtb_a -- the vendor DTB for
+# Qualcomm Linux's 6.6 kernel, which lacks the UFS regulator bindings this 7.2
+# kernel expects, so the controller never probes and rootwait hangs forever with no
+# error. In the slot rather than the ESP also keeps an OTA a single-partition write.
+IMAGE_INSTALL:append = " kernel-devicetree"
+
+# meta-qcom's kernel builds the Wi-Fi, EEPROM and Ethernet PHY modules but installs
+# none of them, and each absence surfaces only as a missing interface.
+IMAGE_INSTALL:append = " packagegroup-wendyos-qcom"
+IMAGE_INSTALL:append = "${@' ' + d.getVar('WENDYOS_QCOM_OTA_INSTALL') if d.getVar('WENDYOS_OTA') == 'wendy' else ''}"
+
+# wendyos-data-setup is KEPT, unlike the wic boards (rpi/x86) which create and label
+# the filesystems at image-build time. qcom-ptool only ALLOCATES partitions, so
+# nothing would otherwise put a filesystem on /data -- Tegra keeps it for the same
+# reason. /data is left out of qcom-wendy-fstab so the recipe's own data.mount, and
+# its Requires= on the formatter, is the unit that mounts it.
+
+# /config and /data need mount points in the rootfs to mount onto, and the /data
+# bind targets must exist or the binds fail and the agent never starts.
+create_wendyos_qcom_dirs() {
+    install -d -m 0755 ${IMAGE_ROOTFS}/config
+    install -d -m 0755 ${IMAGE_ROOTFS}/data
+    install -d -m 0755 ${IMAGE_ROOTFS}/var/lib/wendy
+    install -d -m 0755 ${IMAGE_ROOTFS}/var/lib/containerd
+}
+ROOTFS_POSTPROCESS_COMMAND:append = " create_wendyos_qcom_dirs;"
+
+# MACHINE_FEATURES has "efi", so packagegroup-core-boot RDEPENDS ${EFI_PROVIDER}
+# (unremovable) and grub-efi drops bootaa64.efi, grub.cfg and a writable grubenv
+# into every rootfs slot. /boot is nofail, so an unmounted ESP would leave
+# grub-editenv writing a shadow grubenv the bootloader never reads; with no payload
+# there, that failure is loud instead. The real ESP is built by wendyos-esp-image.
+prune_wendyos_qcom_shadow_esp() {
+    rm -rf ${IMAGE_ROOTFS}/boot/EFI
+}
+ROOTFS_POSTPROCESS_COMMAND:append = " prune_wendyos_qcom_shadow_esp;"

--- a/conf/distro/include/wendyos-rootfs-size.inc
+++ b/conf/distro/include/wendyos-rootfs-size.inc
@@ -39,6 +39,15 @@ WENDYOS_ROOTFS_SIZE_KB:rpi = "8388608"
 # from x86-image.inc.
 WENDYOS_ROOTFS_SIZE_KB:x86-wendyos = "12582912"
 
+# Dragonwing A/B: 12 GiB/slot, same as the base default. Stated explicitly because
+# the slot size is duplicated in meta-qcom-extensions/recipes-bsp/partition/files/
+# partitions.conf (ptool needs a literal, it cannot read bitbake vars), and that
+# recipe's do_compile asserts the two agree — so a change here fails the build
+# loudly instead of producing an image that does not fit its slot. The measured
+# rootfs is ~1.1 GiB, so 12 GiB is generous; two slots plus efi+config leave
+# ~89.6 GiB of the 114.4 GiB UFS LUN 0 for /data.
+WENDYOS_ROOTFS_SIZE_KB:qcom-wendyos = "12582912"
+
 # Expose it to wic so the RPi A/B slots derive their --fixed-size straight from
 # this one constant (rpi-wendy-ab*.wks: `--fixed-size ${WENDYOS_ROOTFS_SIZE_KB}K`
 # — wic reads a K suffix as KiB, so slot == the pinned image size exactly, with

--- a/conf/machine/iq-8275-evk-wendyos.conf
+++ b/conf/machine/iq-8275-evk-wendyos.conf
@@ -84,4 +84,9 @@ WENDYOS_ENABLE_TPM = "0"
 WENDYOS_QCOM_DTB = "monaco-evk.dtb"
 
 # Stable board identity written to /etc/wendyos/device-type
+# Qualcomm AI stack for the on-SoC Hexagon NPU (QAIRT/QNN runtime + the DSP
+# blobs). Off by default: it adds ~500 MB to every rootfs slot, roughly triples
+# the OTA payload, and pulls in proprietary redistributables.
+WENDYOS_QCOM_NPU ?= "0"
+
 WENDYOS_BOARD_ID = "dragonwing-iq-8275"

--- a/conf/machine/iq-8275-evk-wendyos.conf
+++ b/conf/machine/iq-8275-evk-wendyos.conf
@@ -1,0 +1,87 @@
+#@TYPE: Machine
+#@NAME: Qualcomm Dragonwing IQ-8275 EVK
+#@DESCRIPTION: WendyOS target for the Qualcomm Dragonwing IQ-8275 Evaluation Kit
+#              (QCS8275, QCS8300 SoC family, board codename "monaco").
+
+# "qcom-wendyos" is the WendyOS dispatch token the distro/image includes key on
+# (mirroring x86-wendyos); it deliberately does NOT reuse meta-qcom's own "qcom"
+# override, which upstream already sets. "iq-8275-evk" is re-added because MACHINE
+# is the wrapper name, so the upstream board override would otherwise be absent.
+MACHINEOVERRIDES =. "qcom-wendyos:iq-8275-evk:"
+require conf/machine/iq-8275-evk.conf
+
+# Upstream keys the flash-package lookups on literal strings, not ${MACHINE}
+# (QCOM_PARTITION_FILES_SUBDIR = "partitions/iq-8275-evk/ufs",
+# QCOM_BOOT_FILES_SUBDIR = "qcs8300"), so the wrapper rename does not break them.
+# Only MACHINE_ARCH changes (iq_8275_evk -> iq_8275_evk_wendyos), which just
+# re-namespaces machine-specific sstate.
+
+# wendyos-update A/B OTA stack. Pulls in the update client, the fixed rootfs-size
+# pin (image == slot == .wendy payload) and the .wendy artifact, plus
+# wendyos-etc-binds so device identity persists on /data across a slot switch.
+WENDYOS_OTA = "wendy"
+
+# --- A/B boot chain ---------------------------------------------------------
+# ROM -> XBL -> the SoC's own UEFI 2.70 -> GRUB on the ESP -> kernel from the
+# selected ext4 slot. GRUB rather than the vendor's systemd-boot because
+# systemd-boot reads only FAT (ESP/XBOOTLDR) and so cannot reach the kernel that
+# ships inside each rootfs slot; after an OTA the new rootfs would boot the stale
+# ESP kernel. GRUB's ext2 module reads ext4, so /boot/Image travels with the
+# rootfs and an OTA stays a single raw partition write.
+#
+# EFI_PROVIDER must be set here, not in the ESP image recipe: grub-efi's own
+# anonymous python reads it to decide its output name, emitting bootaa64.efi only
+# when it is "grub-efi" (upstream qcom-common.inc sets systemd-boot, which would
+# make it grub-efi-bootaa64.efi and leave the firmware with nothing to chainload
+# at EFI/BOOT/BOOTAA64.EFI).
+EFI_PROVIDER = "grub-efi"
+
+# Our ESP (GRUB + grub.cfg + grubenv) instead of upstream's systemd-boot + UKI one.
+QCOM_ESP_IMAGE = "wendyos-esp-image"
+
+# grub-efi RDEPENDS on virtual-grub-bootconf; both oe-core's grub-bootconf and our
+# wendyos-grub-ab provide it and ship ${EFI_FILES_PATH}/grub.cfg, so the choice has
+# to be explicit or dnf fails the image transaction on a file conflict.
+PREFERRED_RPROVIDER_virtual-grub-bootconf = "wendyos-grub-ab"
+
+# Our A/B partition layout instead of upstream's pre-generated single-rootfs one.
+# Declares LUN 0 only, so a flash cannot rewrite the XBL/UEFI/TZ firmware LUNs --
+# the board stays recoverable by construction.
+QCOM_PARTITION_CONF = "wendyos-partition-conf"
+QCOM_PARTITION_FILES_SUBDIR = "partitions/${MACHINE}/ufs"
+
+# The kernel gets root= from grub.cfg per slot, so the single-rootfs default
+# (PARTLABEL=rootfs) must not be baked anywhere. Point it at slot A so any
+# upstream consumer that still reads it lands on a real partition rather than a
+# label that no longer exists in our layout.
+QCOM_BOOTIMG_ROOTFS = "PARTLABEL=rootfsA"
+
+# No UEFI capsule work from our side: the board's own firmware owns the capsule
+# path (it pre-allocates /boot/Persisted_Capsules.bin), and we do not write
+# firmware partitions.
+WENDYOS_UPDATE_BOOTLOADER = "0"
+WENDYOS_EFI_DEBUG = "0"
+
+# NVIDIA-only stacks.
+WENDYOS_DEEPSTREAM = "0"
+
+# Two USB device controllers exist on this board (a400000.usb, a600000.usb), so
+# gadget networking is mechanically available. The Tegra-only gadget helper
+# recipes that wendyos-image.bb pairs with this knob are dropped in
+# conf/distro/include/qcom-image.inc, exactly as the RPi include does.
+WENDYOS_USB_GADGET = "1"
+
+
+# /data encryption stays off: the SoC exposes a TPM2 driver but the board has no
+# TPM firmware ("TPM2 Support: driver only, firmware unavailable" per bootctl),
+# so a first-boot enroll could never succeed here.
+WENDYOS_DATA_ENCRYPTED = "0"
+WENDYOS_ENABLE_TPM = "0"
+
+# Device tree the A/B GRUB config loads from each slot. meta-qcom's
+# KERNEL_DEVICETREE lists several for this SoC; this names the one this board
+# boots, and wendyos-grub-ab asserts it is one the kernel installs.
+WENDYOS_QCOM_DTB = "monaco-evk.dtb"
+
+# Stable board identity written to /etc/wendyos/device-type
+WENDYOS_BOARD_ID = "dragonwing-iq-8275"

--- a/conf/template/boards/dragonwing-iq8275/bblayers.conf
+++ b/conf/template/boards/dragonwing-iq8275/bblayers.conf
@@ -1,0 +1,4 @@
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/core.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/oe-common.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/qcom.inc
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/bblayers/wendyos.inc

--- a/conf/template/boards/dragonwing-iq8275/local.conf
+++ b/conf/template/boards/dragonwing-iq8275/local.conf
@@ -1,0 +1,18 @@
+# dragonwing-iq8275: Qualcomm Dragonwing IQ-8275 EVK (blacksail tree).
+#
+# QCS8275 / QCS8300 family, board codename "monaco", 128 GB UFS. The SoC's own
+# UEFI 2.70 chainloads GRUB from the ESP, which selects one of the two rootfs
+# slots (WENDYOS_OTA = "wendy"). Needs this layer's rawprogram0.xml, not the
+# stock single-rootfs one.
+
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/common.inc
+
+# Bridge LAYERSERIES_COMPAT for meta-oe/meta-virtualization, which oe-common.inc
+# layers and which have not declared blacksail upstream. Gated on
+# WENDYOS_LAYER_TREE == "blacksail", inert elsewhere. meta-qcom's own bridge is in
+# bblayers/qcom.inc -- it has to be, see the note in this file.
+require ${TOPDIR}/../${WENDYOS_META_REPO}/conf/template/include/local/blacksail-compat.inc
+
+DEVICE  = "dragonwing-iq-8275"
+STORAGE = "ufs"
+MACHINE = "iq-8275-evk-wendyos"

--- a/conf/template/boards/dragonwing-iq8275/repos.overrides
+++ b/conf/template/boards/dragonwing-iq8275/repos.overrides
@@ -1,0 +1,10 @@
+# Per-board repo overrides for dragonwing-iq8275 (blacksail tree).
+#
+# Qualcomm Dragonwing IQ-8275 EVK -- QCS8275, QCS8300 SoC family, board
+# codename "monaco". Upstream MACHINE is iq-8275-evk in meta-qcom.
+#
+# No SRCREV overrides: every pin comes from the shared blacksail set in
+# scripts/upstream-repos.env, SRCREV_QCOM included. The meta-tegra*/meta-rpi/
+# meta-security pins in that set are irrelevant here -- bootstrap skips cloning
+# any layer this board's bblayers does not name.
+WENDYOS_LAYER_TREE="blacksail"

--- a/conf/template/include/bblayers/qcom.inc
+++ b/conf/template/include/bblayers/qcom.inc
@@ -1,0 +1,19 @@
+# Qualcomm layer set (Dragonwing / QCS SoCs), used by the dragonwing-* boards.
+#
+# meta-qcom alone: its LAYERDEPENDS is just "core", and the layers it only
+# RECOMMENDS (openembedded-layer, meta-arm) are either already present via
+# bblayers/oe-common.inc or needed only by the *-open-fw machine variants,
+# which add TF-A + OP-TEE and are not what we build.
+
+BBLAYERS += " \
+    ${TOPDIR}/../repos/${WENDYOS_LAYER_TREE}/meta-qcom \
+    ${TOPDIR}/../${WENDYOS_META_REPO}/meta-qcom-extensions \
+    "
+
+# LAYERSERIES_COMPAT guard for meta-qcom, which declares "wrynose" at the pinned
+# SRCREV_QCOM. That already intersects oe-core's LAYERSERIES_CORENAMES ("wrynose
+# blacksail"), so this is normally redundant -- it covers the pin being moved to
+# a commit that declares neither. Same situation, and same reason it MUST live in
+# a bblayers include rather than local.conf, as meta-raspberrypi: see the
+# cookerdata.py note in bblayers/rpi-blacksail.inc.
+LAYERSERIES_COMPAT_qcom:append = " blacksail"

--- a/meta-qcom-extensions/conf/layer.conf
+++ b/meta-qcom-extensions/conf/layer.conf
@@ -1,0 +1,17 @@
+BBPATH:prepend := "${LAYERDIR}:"
+
+BBFILES += " \
+    ${LAYERDIR}/recipes-*/*/*.bb \
+    ${LAYERDIR}/recipes-*/*/*.bbappend \
+    "
+
+BBFILE_COLLECTIONS += "wendyos-qcom"
+BBFILE_PATTERN_wendyos-qcom := "^${LAYERDIR}/"
+BBFILE_PRIORITY_wendyos-qcom = "51"
+
+# Only layered for the Dragonwing boards (see conf/template/include/bblayers/
+# qcom.inc), so its recipes and bbappends never reach other boards. The board
+# builds on blacksail; wrynose stays in the set as the fallback series.
+LAYERSERIES_COMPAT_wendyos-qcom = "wrynose blacksail"
+LAYERVERSION_wendyos-qcom = "1"
+LAYERDEPENDS_wendyos-qcom = "core wendyos"

--- a/meta-qcom-extensions/files/grub/grubAB-qcom.cfg
+++ b/meta-qcom-extensions/files/grub/grubAB-qcom.cfg
@@ -1,0 +1,140 @@
+# WendyOS Dragonwing A/B trial-boot GRUB config (wendyos-update OTA stack).
+#
+# Installed as EFI/BOOT/grub.cfg by wendyos-esp-image.bb. A port of
+# meta-x86-extensions' grubAB.cfg: the slot arithmetic is identical because
+# partitions.conf keeps WendyOS's partition order, so the slots land on p3/p4 here
+# exactly as on x86 and RPi.
+#
+# Env-var contract, shared with the U-Boot boards and the wendyos-update grubenv
+# connector:
+#   wendyos_boot_slot          0|1  slot to boot (0=rootfsA, 1=rootfsB)
+#   wendyos_upgrade_available  0|1  a trial boot is armed
+#   bootcount                  0|1  trial attempt counter (bootlimit is 1)
+#
+# Board-specific deviations from the x86 config:
+#   - No `serial` block. GRUB's serial driver cannot bind this SoC's GENI UART;
+#     output reaches the port through the firmware's ConOut instead.
+#   - `Image`, not `bzImage`, and console=ttyMSM0.
+#   - A `devicetree` line, which is NOT optional: with no DTB supplied the kernel
+#     inherits UEFI's vendor tree, which lacks the UFS regulator bindings this
+#     kernel expects, so the controller never probes and rootwait hangs forever.
+#
+# No initrd is needed: SCSI_UFSHCD, SCSI_UFS_QCOM, BLK_DEV_SD, EXT4_FS and
+# EFI_PARTITION are all built in, so the kernel mounts the ext4 slot and resolves
+# root=PARTLABEL= unaided.
+
+set timeout=3
+
+# Load the persistent A/B state from this ESP's grubenv (EFI/BOOT/grubenv). The
+# ESP image ships a pre-created 1024-byte grubenv so save_env always has a file to
+# write; a missing one would make the trial counter a silent no-op and rollback
+# would never fire.
+load_env
+
+# First-boot seed (idempotent). A fresh grubenv has none of our vars.
+if [ -z "${wendyos_boot_slot}" ]; then set wendyos_boot_slot=0; fi
+if [ -z "${wendyos_upgrade_available}" ]; then set wendyos_upgrade_available=0; fi
+if [ -z "${bootcount}" ]; then set bootcount=0; fi
+
+# Device-tree filename inside each slot's /boot. Not persisted in grubenv -- it is
+# a property of the image, not of the A/B state -- but defaulted the same way so a
+# grubenv override remains possible for bring-up.
+if [ -z "${wendyos_dtb}" ]; then set wendyos_dtb=@WENDYOS_QCOM_DTB@; fi
+
+# Give up on this slot: flip to the other one and abandon any armed trial, then
+# reboot. Used by the load-failure paths below -- the trial block only counts while
+# an update is armed, so a committed slot that cannot load would otherwise reboot
+# into itself forever and never reach the known-good slot.
+function wendyos_fall_back_and_reboot {
+    if [ "${wendyos_boot_slot}" = "0" ]; then
+        set wendyos_boot_slot=1
+    else
+        set wendyos_boot_slot=0
+    fi
+    set wendyos_upgrade_available=0
+    set bootcount=0
+    save_env wendyos_boot_slot
+    save_env wendyos_upgrade_available
+    save_env bootcount
+    sleep 10
+    reboot
+}
+
+# Trial boot. Only while an update is armed (wendyos_upgrade_available=1, set by
+# `wendyos-update install`) do we count. bootlimit is 1, so bootcount is just a
+# {0,1} "have we already tried" flag and no arithmetic is needed. A healthy boot
+# is finalized by `wendyos-update commit`, which clears the flag from Linux. If a
+# later boot still finds the trial uncommitted, fall back to the other slot.
+if [ "${wendyos_upgrade_available}" = "1" ]; then
+    if [ "${bootcount}" = "0" ]; then
+        set bootcount=1
+        save_env bootcount
+    else
+        echo "wendyos: trial slot ${wendyos_boot_slot} did not commit, falling back"
+        if [ "${wendyos_boot_slot}" = "0" ]; then
+            set wendyos_boot_slot=1
+        else
+            set wendyos_boot_slot=0
+        fi
+        set wendyos_upgrade_available=0
+        set bootcount=0
+        save_env wendyos_boot_slot
+        save_env wendyos_upgrade_available
+        save_env bootcount
+    fi
+fi
+
+# Slot -> rootfs partition on the boot disk. Resolve by PARTITION NUMBER, never
+# the ext4 fs label: an OTA raw-writes the payload into the target slot, which
+# CLOBBERS that slot's fs label (the payload carries its own single label), so
+# `search --label rootfsA/B` breaks after the first update. The GPT partition
+# NUMBER survives (the partition table is never rewritten by an OTA), as does the
+# GPT PARTLABEL used by root=.
+#
+# $root is the ESP GRUB booted from (e.g. "hd0,gpt1"); derive its disk and address
+# the slot as a fixed partition on that SAME disk (partitions.conf order: p3
+# rootfsA, p4 rootfsB). Nothing here is pinned to a device name, so the same ESP
+# works whichever disk the firmware booted. GRUB has no `search --part-label` and
+# the omit-disk "(,gptN)" form is not supported here, hence the regexp approach.
+regexp -s 1:bootdisk '^([^,]+),' "${root}"
+
+if [ "${wendyos_boot_slot}" = "1" ]; then
+    set slotdev="(${bootdisk},gpt4)"
+    set slot_partlabel=rootfsB
+else
+    set slotdev="(${bootdisk},gpt3)"
+    set slot_partlabel=rootfsA
+fi
+
+echo "wendyos: booting slot ${wendyos_boot_slot} (${slot_partlabel} = ${slotdev})"
+
+set default=0
+menuentry "WendyOS (slot ${wendyos_boot_slot})" {
+    # If the slot's kernel or DTB cannot be LOADED (missing/corrupt), switch slots
+    # and reboot -- the equivalent of the U-Boot boards' `reset` on ext4load
+    # failure. A failed `linux` otherwise leaves GRUB hung at the interactive menu
+    # on a headless device. `||` is not supported in GRUB script, hence `if ! ...`.
+    if ! devicetree ${slotdev}/boot/${wendyos_dtb} ; then
+        echo "wendyos: slot ${wendyos_boot_slot} device tree failed to load; switching slots"
+        wendyos_fall_back_and_reboot
+    fi
+    if ! linux ${slotdev}/boot/Image root=PARTLABEL=${slot_partlabel} rw rootwait console=ttyMSM0,115200 ; then
+        echo "wendyos: slot ${wendyos_boot_slot} kernel failed to load; switching slots"
+        wendyos_fall_back_and_reboot
+    fi
+}
+
+# Manual slot overrides, handy from the console (press a key to stop the timeout).
+# Plain linux (no reboot-on-failure): a human picking a slot wants to SEE the
+# error, not have it reboot out from under them.
+menuentry "WendyOS slot A (rootfsA)" {
+    regexp -s 1:d '^([^,]+),' "${root}"
+    devicetree (${d},gpt3)/boot/${wendyos_dtb}
+    linux (${d},gpt3)/boot/Image root=PARTLABEL=rootfsA rw rootwait console=ttyMSM0,115200
+}
+
+menuentry "WendyOS slot B (rootfsB)" {
+    regexp -s 1:d '^([^,]+),' "${root}"
+    devicetree (${d},gpt4)/boot/${wendyos_dtb}
+    linux (${d},gpt4)/boot/Image root=PARTLABEL=rootfsB rw rootwait console=ttyMSM0,115200
+}

--- a/meta-qcom-extensions/files/grub/grubAB-qcom.test.sh
+++ b/meta-qcom-extensions/files/grub/grubAB-qcom.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Static checks on the Dragonwing A/B GRUB config.
+#
+# The config runs before any userspace exists, so a mistake in it is only
+# observable as a device that will not boot -- and its two failure paths (trial
+# fall-back, kernel-load failure) are exactly the ones that are hardest to
+# exercise by hand. These assertions are cheap and catch the drift that review
+# tends to miss.
+#
+# Run: bash meta-qcom-extensions/files/grub/grubAB-qcom.test.sh
+
+set -uo pipefail
+
+CFG="$(dirname "$0")/grubAB-qcom.cfg"
+fails=0
+
+check() {
+    if [ "$1" = "0" ]; then
+        printf '  ok    %s\n' "$2"
+    else
+        printf '  FAIL  %s\n' "$2"
+        fails=$((fails + 1))
+    fi
+}
+
+[ -f "$CFG" ] || { printf 'grubAB-qcom.cfg not found at %s\n' "$CFG" >&2; exit 1; }
+printf 'Checking %s\n' "$CFG"
+
+# Strip comments once: prose mentions variable names and partition numbers, and
+# a comment must never satisfy (or break) an assertion.
+BODY="$(grep -vE '^[[:space:]]*#' "$CFG")"
+
+# --- 1. every persisted variable has a first-boot default -------------------
+# A fresh device's grubenv is an empty block: every variable reads back as "".
+# The config must therefore default each one it relies on, or the very first
+# boot evaluates an empty slot number. Deriving the list from save_env means a
+# newly persisted variable cannot be added without also being guarded.
+saved="$(printf '%s\n' "$BODY" | grep -oE '^[[:space:]]*save_env .*' \
+    | sed 's/^[[:space:]]*save_env //' | tr ' ' '\n' | sort -u | grep -v '^$')"
+[ -n "$saved" ] || { printf '  FAIL  no save_env statements found (config gutted?)\n'; fails=$((fails + 1)); }
+
+for v in $saved; do
+    printf '%s\n' "$BODY" | grep -qF "if [ -z \"\${$v}\" ]"
+    check $? "persisted variable '$v' has a -z first-boot default"
+done
+
+# --- 2. the connector contract is intact ------------------------------------
+# These three names are the shared contract with the wendyos-update grubenv
+# connector (internal/connector/grubenv/grubenv.go) and with the U-Boot boards'
+# boot script. Renaming one here silently breaks OTA on this board only.
+for v in wendyos_boot_slot wendyos_upgrade_available bootcount; do
+    printf '%s\n' "$BODY" | grep -qF "if [ -z \"\${$v}\" ]"
+    check $? "contract variable '$v' is defaulted"
+done
+
+printf '%s\n' "$BODY" | grep -qE '^[[:space:]]*load_env'
+check $? "load_env is called (otherwise persisted state is never read)"
+
+# --- 3. slot -> partition mapping matches partitions.conf -------------------
+# The GPT order in meta-qcom-extensions/recipes-bsp/partition/files/
+# partitions.conf is efi, config, rootfsA, rootfsB, data => slots are p3 and p4.
+# GRUB addresses them by NUMBER because an OTA raw-write clobbers a slot's
+# filesystem label, so these two must move together.
+printf '%s\n' "$BODY" | grep -qF 'gpt3' && printf '%s\n' "$BODY" | grep -qF 'gpt4'
+check $? "slots addressed as gpt3/gpt4"
+
+PCONF="$(dirname "$0")/../../recipes-bsp/partition/files/partitions.conf"
+if [ -f "$PCONF" ]; then
+    order="$(grep -oE '^--partition .*--name=[a-zA-Z]+' "$PCONF" \
+        | sed 's/.*--name=//' | tr '\n' ' ')"
+    rc=0
+    test "$order" = "efi config rootfsA rootfsB data " || rc=1
+    check "$rc" "partitions.conf order is 'efi config rootfsA rootfsB data' (got: $order)"
+else
+    printf '  skip  partitions.conf not found next to the config\n'
+fi
+
+# --- 4. no x86 leftovers ----------------------------------------------------
+# This config is a port of meta-x86-extensions' grubAB.cfg. Both x86-isms boot
+# nothing on aarch64: bzImage does not exist, and ttyS0 is not this SoC's UART.
+! printf '%s\n' "$BODY" | grep -qF 'bzImage'
+check $? "no bzImage reference (aarch64 kernel is 'Image')"
+
+printf '%s\n' "$BODY" | grep -qF '/boot/Image'
+check $? "loads /boot/Image from inside the rootfs slot"
+
+! printf '%s\n' "$BODY" | grep -qF 'ttyS0'
+check $? "no ttyS0 reference (this board's console is ttyMSM0)"
+
+printf '%s\n' "$BODY" | grep -qF 'ttyMSM0'
+check $? "console is ttyMSM0"
+
+# --- 4b. the kernel must be given OUR device tree ---------------------------
+# With no `devicetree` command the kernel inherits the DTB UEFI installed from the
+# dtb_a partition -- the vendor tree for Qualcomm Linux's 6.6 kernel. Against this
+# mainline 7.2 kernel it lacks the UFS regulator bindings, so ufshcd-qcom never
+# probes, no disk appears, and rootwait hangs silently. Cost us a flash cycle to
+# find on hardware, so assert it rather than trusting review.
+printf '%s\n' "$BODY" | grep -qE '(^|[[:space:]])devicetree[[:space:]]'
+check $? "config loads a device tree with the 'devicetree' command"
+
+# One devicetree per linux. A whole-file count, not per-menuentry pairing, but
+# enough to catch a dropped devicetree line.
+n_linux=$(printf '%s\n' "$BODY" | grep -cE '(^|[[:space:]])linux[[:space:]]')
+n_dtb=$(printf '%s\n' "$BODY" | grep -cE '(^|[[:space:]])devicetree[[:space:]]')
+rc=0
+test "$n_dtb" -ge "$n_linux" || rc=1
+check "$rc" "a 'devicetree' for every 'linux' (linux=$n_linux devicetree=$n_dtb)"
+
+# A failed devicetree load must not fall through to `linux`: the kernel would boot
+# the vendor DTB, ufshcd-qcom would never probe, and rootwait would hang forever.
+printf '%s\n' "$BODY" | awk '/if ! devicetree/,/^[[:space:]]*fi/' \
+    | grep -q 'wendyos_fall_back_and_reboot'
+check $? "a failed 'devicetree' load calls the slot fallback"
+
+# ...and the fallback must SWITCH slots, not just reboot. The trial block only
+# counts while an update is armed, so a bare reboot on a committed slot would
+# retry the same broken slot forever and never reach the known-good one.
+FALLBACK="$(printf '%s\n' "$BODY" | awk '/^function wendyos_fall_back_and_reboot/,/^}/')"
+printf '%s\n' "$FALLBACK" | grep -q 'set wendyos_boot_slot=1' \
+    && printf '%s\n' "$FALLBACK" | grep -q 'set wendyos_boot_slot=0' \
+    && printf '%s\n' "$FALLBACK" | grep -q 'save_env wendyos_boot_slot' \
+    && printf '%s\n' "$FALLBACK" | grep -q 'set wendyos_upgrade_available=0'
+check $? "the fallback flips the slot, persists it, and abandons the trial"
+
+# The DTB name must come from WENDYOS_QCOM_DTB, not a second hardcoded copy that
+# can drift from the machine's KERNEL_DEVICETREE.
+printf '%s\n' "$BODY" | grep -q 'wendyos_dtb=@WENDYOS_QCOM_DTB@'
+check $? "the DTB filename is substituted from WENDYOS_QCOM_DTB"
+! printf '%s\n' "$BODY" | grep -qE 'wendyos_dtb=[a-z0-9-]+\.dtb'
+check $? "no hardcoded .dtb filename in the config"
+
+# The DTB must come from the SLOT, not the shared ESP: dtb+kernel+rootfs have to
+# travel together or an OTA can boot a new rootfs against a stale device tree.
+! printf '%s\n' "$BODY" | grep -E '(^|[[:space:]])devicetree[[:space:]]' | grep -qvE '\$\{slotdev\}|\(\$\{d\},gpt[34]\)'
+check $? "device tree is loaded from the rootfs slot, not the ESP"
+
+# --- 5. commands used must be built into the GRUB image ---------------------
+# grub-mkimage bakes a fixed module set into bootaa64.efi and the ESP carries no
+# module directory, so a command that is not built in is simply absent at boot.
+# This was found on hardware: 'echo' was missing and every message silently
+# failed. Keep this list in step with GRUB_BUILDIN in
+# meta-qcom-extensions/recipes-bsp/grub/grub-efi_%.bbappend plus oe-core's
+# default set.
+BBAPPEND="$(dirname "$0")/../../recipes-bsp/grub/grub-efi_%.bbappend"
+OECORE_DEFAULT="boot linux ext2 fat serial part_msdos part_gpt normal efi_gop iso9660 configfile search loadenv test"
+if [ -f "$BBAPPEND" ]; then
+    added="$(grep -oE 'GRUB_BUILDIN:append *= *"[^"]*"' "$BBAPPEND" \
+        | sed 's/.*= *"//; s/"$//')"
+    available=" $OECORE_DEFAULT $added "
+    # loadenv provides load_env/save_env; test provides '['.
+    for cmd in echo regexp reboot sleep linux devicetree; do
+        printf '%s\n' "$BODY" | grep -qE "(^|[[:space:]])${cmd}([[:space:]]|$)" || continue
+        mod="$cmd"
+        # `devicetree` is provided by the fdt module; loadenv provides load_env.
+        [ "$cmd" = "devicetree" ] && mod="fdt"
+        printf '%s' "$available" | grep -qE "[[:space:]]${mod}[[:space:]]"
+        check $? "command '$cmd' (module '$mod') is built into GRUB"
+    done
+    printf '%s\n' "$BODY" | grep -qE '(^|[[:space:]])(load_env|save_env)([[:space:]]|$)' && {
+        printf '%s' "$available" | grep -qE '[[:space:]]loadenv[[:space:]]'
+        check $? "loadenv module present for load_env/save_env"
+    }
+else
+    printf '  skip  grub-efi bbappend not found\n'
+fi
+
+printf '\n'
+if [ "$fails" -eq 0 ]; then
+    printf 'All checks passed.\n'
+    exit 0
+fi
+printf '%d check(s) FAILED.\n' "$fails"
+exit 1

--- a/meta-qcom-extensions/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-qcom-extensions/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,0 +1,12 @@
+# Modules the A/B grub.cfg needs that stock GRUB_BUILDIN omits. grub-mkimage bakes
+# the module set into bootaa64.efi and the ESP carries no module directory, so a
+# command that is not built in is simply absent -- `echo` was missing on the first
+# hardware test and every message vanished silently.
+#   regexp - derive the boot disk from $root; an OTA clobbers a slot's fs LABEL, so
+#            the boot chain keys off GPT partition numbers instead.
+#   reboot - a slot whose kernel will not load must reboot so the bootcount logic
+#            falls back, rather than hang at the menu on a headless board.
+#   sleep  - paces that reboot loop when BOTH slots are unbootable.
+#   fdt    - provides `devicetree`; without our DTB the kernel inherits UEFI's
+#            vendor one, which lacks the UFS bindings this kernel needs.
+GRUB_BUILDIN:append = " regexp reboot sleep echo fdt"

--- a/meta-qcom-extensions/recipes-bsp/partition/files/partitions.conf
+++ b/meta-qcom-extensions/recipes-bsp/partition/files/partitions.conf
@@ -1,0 +1,46 @@
+# WendyOS A/B partition layout for the Dragonwing IQ-8275 EVK -- LUN 0 only.
+#
+# Declares ONLY the HLOS LUN. That is deliberate and doubles as a safety
+# property: ptool then emits gpt_main0/rawprogram0/patch0 alone, so flashing this
+# package physically cannot rewrite the XBL / UEFI / TZ / DTB firmware LUNs
+# (upstream's LUNs 1-5). The board therefore stays recoverable by construction,
+# and upstream's firmware layout is inherited rather than copied -- meta-qcom is
+# a young, fast-moving BSP and duplicating its 100+ firmware partitions here
+# would only drift.
+#
+# Partition ORDER is load-bearing and matches meta-rpi-extensions/files/wic/
+# rpi-wendy-ab.wks and meta-x86-extensions/files/wic/genericx86-ab.wks exactly,
+# which is what lets the ported grubAB cfg reuse their slot arithmetic unchanged:
+#   p1 efi     (FAT)  ESP: GRUB bootaa64.efi + grub.cfg + the A/B grubenv.
+#                     Shared, never written by an OTA. The kernel is NOT here --
+#                     GRUB loads it from the selected slot's own /boot (A/B-safe).
+#   p2 config  (FAT)  first-boot provisioning seed (label "config").
+#   p3 rootfsA (ext4) slot 0  --| both flashed with the SAME rootfs.img so the
+#   p4 rootfsB (ext4) slot 1  --| device is bootable+recoverable from the factory
+#                                and A->B->A is testable immediately.
+#   p5 data    (ext4) persistent /data -- LAST, so the flash tool grows it to fill
+#                     the real disk (patch0.xml patches the last partition's end
+#                     LBA from NUM_DISK_SECTORS). On the 114.4 GiB LUN 0 of this
+#                     board that yields ~89.6 GiB after the 24.75 GiB above.
+#
+# Type GUIDs follow the x86 board's convention: only the ESP is typed explicitly.
+# The slots deliberately do NOT carry the Discoverable Partitions Spec arm64-root
+# GUID (b921b045-...) that upstream's single rootfs uses -- two partitions
+# claiming to be "the" root would give systemd-gpt-auto-generator a choice to get
+# wrong, and WendyOS passes root= explicitly from the boot script anyway.
+#
+# --disk --size is upstream's value for this board, not the measured LUN size: it
+# only has to exceed the fixed partitions above, because p5 is grown at flash time
+# from the device's actual geometry.
+#
+# rootfsA/rootfsB --size MUST equal WENDYOS_ROOTFS_SIZE_KB
+# (conf/distro/include/wendyos-rootfs-size.inc): image == slot == .wendy payload,
+# enforced by that file's floor==ceiling pin and again at pack time.
+
+--disk --type=ufs --size=76841669632 --write-protect-boundary=0 --sector-size-in-bytes=4096 --grow-last-partition
+
+--partition --lun=0 --name=efi     --size=524288KB   --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
+--partition --lun=0 --name=config  --size=262144KB   --type-guid=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7 --readonly=false
+--partition --lun=0 --name=rootfsA --size=12582912KB --type-guid=0FC63DAF-8483-4772-8E79-3D69D8477DE4 --filename=rootfs.img --readonly=false
+--partition --lun=0 --name=rootfsB --size=12582912KB --type-guid=0FC63DAF-8483-4772-8E79-3D69D8477DE4 --filename=rootfs.img --readonly=false
+--partition --lun=0 --name=data    --size=524288KB   --type-guid=0FC63DAF-8483-4772-8E79-3D69D8477DE4 --readonly=false

--- a/meta-qcom-extensions/recipes-bsp/partition/wendyos-partition-conf.bb
+++ b/meta-qcom-extensions/recipes-bsp/partition/wendyos-partition-conf.bb
@@ -1,0 +1,73 @@
+SUMMARY = "WendyOS A/B partition tables for Qualcomm Dragonwing"
+DESCRIPTION = "Generates the GPT binaries and QDL flashing scripts for the WendyOS \
+A/B layout (efi + config + rootfsA + rootfsB + data) from files/partitions.conf, \
+using meta-qcom's qcom-ptool. Replaces upstream qcom-partition-conf, which ships a \
+pre-generated single-rootfs layout; select it with \
+QCOM_PARTITION_CONF = \"wendyos-partition-conf\" in the machine conf."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://partitions.conf"
+S = "${UNPACKDIR}"
+
+DEPENDS = "qcom-ptool-native"
+
+inherit deploy
+
+COMPATIBLE_MACHINE = "iq-8275-evk-wendyos"
+
+# The GPT is machine-specific: slot sizes come from WENDYOS_ROOTFS_SIZE_KB and it
+# deploys under ${MACHINE}. Not allarch, or one machine's layout would be reused
+# from another's sstate.
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install[noexec] = "1"
+
+# Must match where image_types_qcom looks for these files, or the flash package
+# ships without a GPT.
+WENDYOS_PARTITION_SUBDIR ?= "${QCOM_PARTITION_FILES_SUBDIR}"
+
+# Fail loudly at build time if the declared slot size and the pinned rootfs size
+# ever drift apart. Silent drift would produce an image that does not fit its slot
+# and would only surface as a corrupt device after flashing.
+do_compile[vardeps] += "WENDYOS_ROOTFS_SIZE_KB"
+do_compile() {
+    conf="${UNPACKDIR}/partitions.conf"
+
+    for slot in rootfsA rootfsB; do
+        declared=$(sed -n "s/.*--name=${slot} --size=\([0-9]*\)KB.*/\1/p" "${conf}")
+        if [ -z "${declared}" ]; then
+            bbfatal "wendyos-partition-conf: no --size found for ${slot} in partitions.conf"
+        fi
+        if [ "${declared}" != "${WENDYOS_ROOTFS_SIZE_KB}" ]; then
+            bbfatal "wendyos-partition-conf: ${slot} is ${declared}KB but WENDYOS_ROOTFS_SIZE_KB is ${WENDYOS_ROOTFS_SIZE_KB}KB; the A/B slot must equal the pinned rootfs image size exactly"
+        fi
+    done
+
+    install -d ${B}/out
+    cd ${B}/out
+    cp "${conf}" .
+    qcom-ptool gen_partition -i partitions.conf -o partitions.xml
+    qcom-ptool ptool -x partitions.xml
+}
+
+do_deploy() {
+    install -d ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}
+    # image_types_qcom's deploy_partition_files() globs only gpt_{main,backup,both}*.bin,
+    # zeros_*.bin, rawprogram[0-9].xml and patch*.xml, so the empty-GPT and wipe
+    # helpers below reach DEPLOY_DIR_IMAGE for manual qdl recovery but not the tarball.
+    # LUN 0 exists here by design (see partitions.conf), so nothing can write the
+    # firmware LUNs.
+    install -m 0644 ${B}/out/gpt_main0.bin      ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}/
+    install -m 0644 ${B}/out/gpt_backup0.bin    ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}/
+    install -m 0644 ${B}/out/gpt_both0.bin      ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}/
+    install -m 0644 ${B}/out/gpt_empty0.bin     ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}/
+    install -m 0644 ${B}/out/rawprogram0.xml    ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}/
+    install -m 0644 ${B}/out/patch0.xml         ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}/
+    install -m 0644 ${B}/out/zeros_*.bin        ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}/
+    # Recovery/erase helpers ptool emits alongside the main scripts.
+    install -m 0644 ${B}/out/rawprogram0_BLANK_GPT.xml       ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}/
+    install -m 0644 ${B}/out/rawprogram0_WIPE_PARTITIONS.xml ${DEPLOYDIR}/${WENDYOS_PARTITION_SUBDIR}/
+}
+
+addtask deploy after do_compile before do_build

--- a/meta-qcom-extensions/recipes-bsp/wendyos-grub-ab/wendyos-grub-ab_1.0.bb
+++ b/meta-qcom-extensions/recipes-bsp/wendyos-grub-ab/wendyos-grub-ab_1.0.bb
@@ -1,0 +1,60 @@
+SUMMARY = "WendyOS A/B GRUB config and grubenv for the Dragonwing ESP"
+DESCRIPTION = "Installs the A/B trial-boot grub.cfg plus a pre-created GRUB \
+environment block into the EFI System Partition tree. Packaged separately from \
+wendyos-esp-image so the ESP image stays a plain package composition, matching how \
+wendyos-update-config ships its file."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/../../files/grub:"
+SRC_URI = "file://grubAB-qcom.cfg"
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "iq-8275-evk-wendyos"
+
+# Machine-scoped, not allarch: the config hardcodes this board's console
+# (ttyMSM0) and its slot partition numbers.
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# Take over oe-core's virtual for the ESP grub.cfg. grub-efi RDEPENDS on
+# "virtual-grub-bootconf", not on grub-bootconf directly, precisely so a machine
+# can substitute its own config ("Grub might require different configuration file
+# for different machines" -- grub-bootconf's own DESCRIPTION). Providing the
+# virtual, plus PREFERRED_RPROVIDER_virtual-grub-bootconf in the machine conf,
+# keeps grub-bootconf out of the image entirely. Without it both packages ship
+# ${EFI_FILES_PATH}/grub.cfg and dnf fails the transaction on a file conflict.
+RPROVIDES:${PN} += "virtual-grub-bootconf"
+
+# EFI_FILES_PATH / EFI_BOOT_IMAGE live in oe-core's conf/image-uefi.conf, which is
+# NOT globally included -- only systemd-boot.bbclass, grub-efi.bbclass, uki.bbclass
+# and barebox.bbclass pull it in. Without this the paths below expand empty and
+# grub.cfg lands in the rootfs root. Same require line grub-efi.bbclass uses.
+require conf/image-uefi.conf
+
+do_install() {
+    install -d ${D}${EFI_FILES_PATH}
+    install -m 0644 ${UNPACKDIR}/grubAB-qcom.cfg ${D}${EFI_FILES_PATH}/grub.cfg
+
+    # The bootloader must name a DTB the kernel actually installs; a mismatch
+    # surfaces only as a boot hang, and the ESP is not rewritten by an OTA.
+    case " ${KERNEL_DEVICETREE} " in
+        *"/${WENDYOS_QCOM_DTB} "*|*" ${WENDYOS_QCOM_DTB} "*) : ;;
+        *) bbfatal "WENDYOS_QCOM_DTB '${WENDYOS_QCOM_DTB}' is not in KERNEL_DEVICETREE" ;;
+    esac
+    sed -i -e "s|@WENDYOS_QCOM_DTB@|${WENDYOS_QCOM_DTB}|" ${D}${EFI_FILES_PATH}/grub.cfg
+
+    # Pre-create the GRUB environment block. GRUB requires it to be EXACTLY 1024
+    # bytes: a 25-byte header line then '#' padding. Shipping it matters -- with no
+    # grubenv on a fresh flash, the `save_env bootcount` in grub.cfg silently does
+    # nothing, so an armed trial never increments its counter and the automatic
+    # rollback never fires. grub-editenv on the device rewrites this in place.
+    printf '# GRUB Environment Block\n' > ${WORKDIR}/grubenv
+    head -c 999 /dev/zero | tr '\0' '#' >> ${WORKDIR}/grubenv
+    actual=$(stat -c %s ${WORKDIR}/grubenv)
+    if [ "${actual}" != "1024" ]; then
+        bbfatal "wendyos-grub-ab: grubenv is ${actual} bytes, GRUB requires exactly 1024"
+    fi
+    install -m 0644 ${WORKDIR}/grubenv ${D}${EFI_FILES_PATH}/grubenv
+}
+
+FILES:${PN} = "${EFI_FILES_PATH}/grub.cfg ${EFI_FILES_PATH}/grubenv"

--- a/meta-qcom-extensions/recipes-core/images/wendyos-esp-image.bb
+++ b/meta-qcom-extensions/recipes-core/images/wendyos-esp-image.bb
@@ -1,0 +1,68 @@
+DESCRIPTION = "WendyOS EFI System Partition image for Qualcomm Dragonwing (GRUB A/B)"
+LICENSE = "MIT"
+
+# GRUB instead of systemd-boot. systemd-boot can only load from the ESP or
+# XBOOTLDR (both FAT), so it cannot reach the kernel that ships INSIDE each ext4
+# rootfs slot -- after an OTA the new rootfs would boot the stale ESP kernel
+# unless the OTA also rewrote the ESP. GRUB's ext2 module reads ext4, so it loads
+# /boot/Image out of the selected slot and the kernel travels with the rootfs,
+# keeping an OTA a single raw partition write.
+PACKAGE_INSTALL = " \
+    grub-efi \
+    wendyos-grub-ab \
+"
+
+inherit image features_check
+
+# vfat, 512 MiB pinned floor==ceiling, and the UFS-compatible sector size. Reused
+# from meta-qcom rather than restated; the path is layer-root-relative because
+# BBPATH carries every layer root (same idiom as the require lines in
+# conf/distro/wendyos.conf).
+require recipes-kernel/images/esp-qcom-common.inc
+
+# EFI_BOOT_IMAGE / EFI_FILES_PATH come from oe-core's conf/image-uefi.conf, which
+# is not globally included (only the systemd-boot/grub-efi/uki/barebox classes
+# require it). Without this the checks below compare against empty strings and the
+# fatal fires on every build. Same require line grub-efi.bbclass uses.
+require conf/image-uefi.conf
+
+# Matches the 512 MiB "efi" partition in
+# meta-qcom-extensions/recipes-bsp/partition/files/partitions.conf.
+REQUIRED_MACHINE_FEATURES = "efi"
+COMPATIBLE_MACHINE = "iq-8275-evk-wendyos"
+
+# FAT volume label "boot". Not cosmetic: qcom-wendy-fstab mounts the ESP as
+# LABEL=boot, and the wendyos-update grubenv connector REFUSES to write A/B state
+# unless /boot is a real mountpoint (assertEnvWritable, guarding against writing a
+# shadow grubenv the bootloader never reads). Without the label the ESP never
+# mounts and every OTA declines to arm a trial. Observed on hardware: blkid
+# reported TYPE="vfat" PARTLABEL="efi" but no LABEL, and /boot was unmounted.
+# `-n` is passed straight to mkfs.vfat (IMAGE_CMD:vfat = "oe_mkvfatfs
+# ${EXTRA_IMAGECMD}"); upstream's include already appends -S for the sector size.
+EXTRA_IMAGECMD:vfat += " -n boot"
+
+# grub-efi packages its loader under ${EFI_FILES_PATH} (= /boot/EFI/BOOT), because
+# EFI_PREFIX defaults to /boot for a package installed into a rootfs. The ESP
+# image IS the partition, so /boot/EFI has to become /EFI at its root. Mirrors
+# esp-qcom-image.bb's setup_efi_folder, and the trailing prune drops the rest of
+# the package's rootfs (docs, /usr/lib/grub modules) that has no business on a
+# 512 MiB boot partition -- the modules grub.cfg needs are built into
+# bootaa64.efi (see the grub-efi bbappend).
+setup_efi_folder() {
+    if [ -d ${IMAGE_ROOTFS}/boot/EFI ]; then
+        install -d ${IMAGE_ROOTFS}/EFI
+        cp -a ${IMAGE_ROOTFS}/boot/EFI/. ${IMAGE_ROOTFS}/EFI/
+    fi
+
+    if [ ! -f ${IMAGE_ROOTFS}/EFI/BOOT/${EFI_BOOT_IMAGE} ]; then
+        bbfatal "wendyos-esp-image: ${EFI_BOOT_IMAGE} missing from the ESP tree. grub-efi only names its loader ${EFI_BOOT_IMAGE} when EFI_PROVIDER = \"grub-efi\"; the machine conf must set that (upstream qcom-common.inc defaults it to systemd-boot, which makes grub build as grub-efi-${EFI_BOOT_IMAGE} instead)."
+    fi
+    for f in grub.cfg grubenv; do
+        if [ ! -f ${IMAGE_ROOTFS}/EFI/BOOT/${f} ]; then
+            bbfatal "wendyos-esp-image: EFI/BOOT/${f} missing from the ESP tree (expected from wendyos-grub-ab)"
+        fi
+    done
+
+    find ${IMAGE_ROOTFS} -mindepth 1 ! -path "${IMAGE_ROOTFS}/EFI*" -exec rm -rf {} +
+}
+IMAGE_PREPROCESS_COMMAND:append = " setup_efi_folder"

--- a/meta-qcom-extensions/recipes-core/packagegroups/packagegroup-wendyos-qcom.bb
+++ b/meta-qcom-extensions/recipes-core/packagegroups/packagegroup-wendyos-qcom.bb
@@ -53,4 +53,23 @@ RDEPENDS:${PN} = " \
 # is the only thing keeping the clock sane across a reboot or an OTA swap.
 RDEPENDS:${PN} += " systemd-mount-timesync"
 
+# Qualcomm AI stack, gated on WENDYOS_QCOM_NPU (see the machine conf for why it is
+# off by default). The kernel half already ships: fastrpc is loaded, the cDSP boots
+# from linux-firmware, and qairt-sdk-hexagon-v75 supplies the DSP-side skels. What
+# these add is the host-side runtime plus the board's DSP blobs.
+#
+# The -config package is what makes offload work: it drops a conf.d yaml keyed on
+# the DT model ("Qualcomm Technologies, Inc. Monaco EVK") that tells fastrpc's
+# config parser where the skels live, and the -evk-{adsp,cdsp,gdsp} packages are
+# symlinks creating exactly that path. Without it DSP_LIBRARY_PATH is never set and
+# every offload call fails.
+WENDYOS_QCOM_NPU_INSTALL = " \
+    qairt-sdk \
+    hexagon-dsp-binaries-qualcomm-iq8275-evk-config \
+    hexagon-dsp-binaries-qcom-iq8275-evk-adsp \
+    hexagon-dsp-binaries-qcom-iq8275-evk-cdsp \
+    hexagon-dsp-binaries-qcom-iq8275-evk-gdsp \
+    "
+RDEPENDS:${PN} += "${@d.getVar('WENDYOS_QCOM_NPU_INSTALL') if d.getVar('WENDYOS_QCOM_NPU') == '1' else ''}"
+
 COMPATIBLE_MACHINE = "iq-8275-evk-wendyos"

--- a/meta-qcom-extensions/recipes-core/packagegroups/packagegroup-wendyos-qcom.bb
+++ b/meta-qcom-extensions/recipes-core/packagegroups/packagegroup-wendyos-qcom.bb
@@ -1,0 +1,56 @@
+SUMMARY = "WendyOS Dragonwing-specific packages"
+LICENSE = "MIT"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+inherit packagegroup
+
+# Drivers meta-qcom's kernel builds but installs nothing of. Each absence is
+# silent -- the interface simply never appears -- hence RDEPENDS, not RRECOMMENDS:
+# a kernel bump that stops emitting one must break the build rather than ship a
+# board with no networking. Found by sweeping for devices that have a modalias but
+# no driver bound; worth repeating after a kernel uprev.
+#
+#  pwrseq-pcie-m2      powers the M.2 Key-E slot (/connector-3). Without it
+#                      pci@1c00000 waits on its pwrseq provider forever, PCIe
+#                      domain 0000 never enumerates and there is no wlan0.
+#  at24                ethernet@23040000 takes its MAC from the I2C EEPROM at 0x50
+#                      as an nvmem supplier; without it stmmac never leaves
+#                      deferred probe and eth0 is absent entirely.
+#  qca808x, qcom-phy-lib  the QCA8081 2.5G PHY (id 0x004dd101). Without them the
+#                      generic PHY binds and rejects the DT's 2500base-x mode.
+#  lontium-lt8713sx    the DP bridge at i2c 0x4f. Without it
+#                      displayport-controller@af54000 defers, msm never binds,
+#                      there is no DRM card and the GPU never initialises.
+#  snd-soc-*, pinctrl-*-lpass-lpi  the codecs qcs8275-sndcard expects and the LPI
+#                      pins it routes over; the machine driver alone reports
+#                      "codec dai not found" and yields no /dev/snd. The sm8450
+#                      pinctrl variant cannot load without its core module.
+#  tpm-tis-*           the board really does carry a TPM 2.0 on spi0.0. Installing
+#                      the driver does not enable /data encryption --
+#                      WENDYOS_DATA_ENCRYPTED stays 0 -- it just stops the
+#                      hardware being invisible.
+#
+# qcom-refgen-regulator is deliberately absent, though the hardware wants it: it
+# lets 8906000.phy probe, which brings up a400000.usb as a SECOND UDC, and
+# gadget-setup.sh picks its controller with `ls /sys/class/udc | head -n1`. That
+# selects a400000.usb, the gadget binds to a port with no cable, and usb0 goes down
+# -- taking away the board's only host link. Install it once that script selects
+# its UDC explicitly rather than by sort order.
+RDEPENDS:${PN} = " \
+    kernel-module-pwrseq-pcie-m2 \
+    kernel-module-at24 \
+    kernel-module-qca808x \
+    kernel-module-qcom-phy-lib \
+    kernel-module-lontium-lt8713sx \
+    kernel-module-snd-soc-max98357a \
+    kernel-module-snd-soc-dmic \
+    kernel-module-pinctrl-lpass-lpi \
+    kernel-module-pinctrl-sm8450-lpass-lpi \
+    kernel-module-tpm-tis-core \
+    kernel-module-tpm-tis-spi \
+    "
+
+# The PMIC RTC is read-only and volatile, so timesyncd's saved timestamp on /data
+# is the only thing keeping the clock sane across a reboot or an OTA swap.
+RDEPENDS:${PN} += " systemd-mount-timesync"
+
+COMPATIBLE_MACHINE = "iq-8275-evk-wendyos"

--- a/meta-qcom-extensions/recipes-core/wendyos-config-setup/files/config.mount
+++ b/meta-qcom-extensions/recipes-core/wendyos-config-setup/files/config.mount
@@ -1,0 +1,17 @@
+[Unit]
+Description=WendyOS config partition (/config)
+# Format on first boot must complete before we mount. Mounting by PARTLABEL --
+# the identifier the formatter waits on -- not by LABEL: the filesystem label
+# does not exist until mkfs has run, so an fstab LABEL= entry races the format
+# and, being nofail, fails silently on exactly the first boot that matters.
+Requires=wendyos-config-init.service
+After=wendyos-config-init.service
+
+[Mount]
+What=/dev/disk/by-partlabel/config
+Where=/config
+Type=vfat
+Options=defaults,nofail
+
+[Install]
+WantedBy=local-fs.target

--- a/meta-qcom-extensions/recipes-core/wendyos-config-setup/files/wendyos-config-init.service
+++ b/meta-qcom-extensions/recipes-core/wendyos-config-setup/files/wendyos-config-init.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=WendyOS /config partition first-boot setup
+DefaultDependencies=no
+# A device dependency, not systemd-udev-settle (deprecated, and After= alone
+# never pulls it in): a condition or bare ordering races udev's coldplug of the
+# UFS disk, and losing that race skips the format -- the same failure the /data
+# initialiser documents.
+Wants=dev-disk-by\x2dpartlabel-config.device
+After=systemd-udevd.service dev-disk-by\x2dpartlabel-config.device
+Before=config.mount local-fs.target shutdown.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/wendyos-config-init.sh
+
+[Install]
+WantedBy=local-fs.target

--- a/meta-qcom-extensions/recipes-core/wendyos-config-setup/files/wendyos-config-init.sh
+++ b/meta-qcom-extensions/recipes-core/wendyos-config-setup/files/wendyos-config-init.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# First-boot creation of the FAT32 /config provisioning partition.
+#
+# qcom-ptool ALLOCATES the config partition but a partitions.conf entry with no
+# --filename is left raw, so unlike the wic boards nothing puts a filesystem on
+# it. /data has wendyos-data-setup for exactly this reason; this is its
+# counterpart for /config.
+#
+# Idempotency keys on the FILESYSTEM, never a stamp file: the rootfs is A/B and
+# swapped by OTA, so a per-slot stamp would be absent on the other slot and could
+# trigger a re-format that wipes provisioning data.
+set -eu
+
+BYLABEL=/dev/disk/by-partlabel/config
+log() { printf '[wendyos-config-init] %s\n' "$*"; }
+
+# Wait briefly for udev to publish the by-partlabel link.
+i=0
+while [ ! -e "$BYLABEL" ] && [ $i -lt 10 ]; do
+    udevadm settle 2>/dev/null || true
+    sleep 1
+    i=$((i + 1))
+done
+if [ ! -e "$BYLABEL" ]; then
+    log "no $BYLABEL after ${i}s; nothing to do"
+    exit 0
+fi
+
+DEV=$(readlink -f "$BYLABEL")
+
+# Already a FAT filesystem labelled "config"? Then leave it entirely alone -- it
+# may hold a provisioning seed written by `wendy os install`.
+TYPE=$(blkid -o value -s TYPE "$DEV" 2>/dev/null || true)
+LABEL=$(blkid -o value -s LABEL "$DEV" 2>/dev/null || true)
+if [ "$TYPE" = "vfat" ] && [ "$LABEL" = "config" ]; then
+    log "$DEV already vfat/config; leaving untouched"
+    exit 0
+fi
+
+# Anything else -- unformatted, or a stale filesystem left at the same LBA by a
+# previous layout (this board ships with Qualcomm Linux, whose 'persist'
+# partition starts at the same sector) -- gets a fresh FAT32.
+log "formatting $DEV as FAT32 label=config (was TYPE='${TYPE:-none}' LABEL='${LABEL:-none}')"
+mkfs.vfat -F 32 -n config "$DEV"
+log "done"

--- a/meta-qcom-extensions/recipes-core/wendyos-config-setup/wendyos-config-setup_1.0.bb
+++ b/meta-qcom-extensions/recipes-core/wendyos-config-setup/wendyos-config-setup_1.0.bb
@@ -1,0 +1,27 @@
+SUMMARY = "First-boot FAT32 setup for the Dragonwing /config partition"
+DESCRIPTION = "qcom-ptool allocates the config partition but leaves it raw (no \
+--filename in partitions.conf), so unlike the wic-built boards nothing creates a \
+filesystem on it. This is the /config counterpart to wendyos-data-setup, which \
+does the same job for /data on the allocate-empty platforms."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://wendyos-config-init.sh file://wendyos-config-init.service \
+           file://config.mount"
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "iq-8275-evk-wendyos"
+
+inherit systemd
+SYSTEMD_SERVICE:${PN} = "wendyos-config-init.service config.mount"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+RDEPENDS:${PN} = "coreutils dosfstools util-linux-blkid"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${UNPACKDIR}/wendyos-config-init.sh ${D}${bindir}/
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/wendyos-config-init.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${UNPACKDIR}/config.mount ${D}${systemd_system_unitdir}/
+}

--- a/meta-qcom-extensions/recipes-core/wendyos-update-config/files/config.json
+++ b/meta-qcom-extensions/recipes-core/wendyos-update-config/files/config.json
@@ -1,0 +1,3 @@
+{
+  "connector": "grubenv"
+}

--- a/meta-qcom-extensions/recipes-core/wendyos-update-config/wendyos-update-config.bb
+++ b/meta-qcom-extensions/recipes-core/wendyos-update-config/wendyos-update-config.bb
@@ -1,0 +1,23 @@
+SUMMARY = "wendyos-update connector config for Qualcomm Dragonwing (grubenv)"
+DESCRIPTION = "Installs /etc/wendyos-update/config.json pinning the wendyos-update \
+OTA client to the grubenv connector. Auto-detect would also pick it (grub-editenv \
+present + our env layout), but a build-time pin is one less runtime failure mode. \
+Same connector the generic x86-64 board uses -- this board reaches GRUB via the \
+SoC's own UEFI rather than via a PC BIOS, but the A/B state lives in the same \
+EFI/BOOT/grubenv, so the connector is unchanged."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://config.json"
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "iq-8275-evk-wendyos"
+
+do_install() {
+    install -d ${D}${sysconfdir}/wendyos-update
+    install -m 0644 ${UNPACKDIR}/config.json ${D}${sysconfdir}/wendyos-update/config.json
+}
+
+# The config dir is also created by the wendyos-update recipe (the <phase>.d
+# hook dirs); allow both to ship it.
+FILES:${PN} = "${sysconfdir}/wendyos-update/config.json"

--- a/meta-qcom-extensions/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-qcom-extensions/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,18 @@
+# Drop a meta-qcom backport patch that cannot apply against the pinned oe-core.
+#
+# meta-qcom's own linux-firmware bbappend adds
+# 0001-qcom-sa8775p-update-signature-on-cdsp1-firmware.patch, authored against
+# linux-firmware 20260810. SRCREV_OECORE pins a tree that still ships 20260622,
+# whose qcom/sa8775p/cdsp1.mbn is a third, unrelated blob. A git *delta* binary
+# patch cannot apply without its exact preimage, and GNU patch is GitApplyTree's
+# last fallback -- so the real cause surfaces as the misleading
+# "git binary diffs are not supported".
+#
+# Safe here, not merely expedient: this board's firmware lives in qcom/qcs8300/
+# as real files (cdsp0.mbn, adsp.mbn, MONACO-EVK-tplg.bin) with no cdsp1.mbn and
+# no symlink into sa8775p/, so the patched file is never loaded.
+#
+# Unconditional because this layer is only in BBLAYERS for the Dragonwing boards
+# (conf/template/include/bblayers/qcom.inc). Delete this file once SRCREV_OECORE
+# moves past linux-firmware 20260810.
+SRC_URI:remove = "file://0001-qcom-sa8775p-update-signature-on-cdsp1-firmware.patch"

--- a/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next/usb-gadget.cfg
+++ b/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next/usb-gadget.cfg
@@ -1,0 +1,45 @@
+# USB gadget support for the Dragonwing IQ-8275 EVK.
+#
+# The defconfig builds every one of these as a MODULE, and none of the resulting
+# kernel-module-* packages is pulled into the image, so on a flashed device:
+#   - dwc3-qcom never binds       -> /sys/class/udc is EMPTY, no UDC at all
+#   - libcomposite never loads    -> /sys/kernel/config/usb_gadget does not exist
+# gadget-setup.sh then fails with "No specific USB controller detected" followed
+# by "mkdir: cannot create '/sys/kernel/config/usb_gadget': Operation not
+# permitted". Both symptoms, one cause. Observed on hardware.
+#
+# Building them in rather than packaging the modules matches what the RPi board
+# does (meta-rpi-extensions/.../usb-gadget.cfg) and removes the load-order
+# question entirely: the UDC exists before gadget-setup.service runs.
+#
+# The device tree already cooperates -- usb@a600000 declares dr_mode=peripheral
+# in monaco-evk.dtb -- so only the driver side was missing.
+
+# Qualcomm dwc3 glue (the core CONFIG_USB_DWC3 is already =y).
+#
+# USB_QCOM_EUD must be =y as well, not merely present: USB_DWC3_QCOM carries
+#   depends on USB_QCOM_EUD || !USB_QCOM_EUD
+# which is Kconfig's idiom for "if EUD is enabled I cannot be built-in unless it
+# is too". With the defconfig's EUD=m, a bare USB_DWC3_QCOM=y is SILENTLY
+# downgraded back to m -- no warning, and the module then has to be packaged and
+# loaded, which is the failure this fragment exists to avoid. EUD is the Embedded
+# USB Debugger the SoC really has (XBL logs qusb_ldr_eud_init), so building it in
+# keeps the feature rather than disabling it to dodge the dependency.
+CONFIG_USB_QCOM_EUD=y
+CONFIG_USB_DWC3_QCOM=y
+
+# Gadget framework and configfs interface.
+CONFIG_CONFIGFS_FS=y
+CONFIG_USB_GADGET=y
+CONFIG_USB_LIBCOMPOSITE=y
+CONFIG_USB_CONFIGFS=y
+CONFIG_USB_CONFIGFS_SERIAL=y
+CONFIG_USB_CONFIGFS_ACM=y
+CONFIG_USB_CONFIGFS_NCM=y
+CONFIG_USB_CONFIGFS_ECM=y
+
+# Function drivers for the NCM+ACM composite gadget-setup.sh builds.
+CONFIG_USB_F_SERIAL=y
+CONFIG_USB_F_ACM=y
+CONFIG_USB_F_NCM=y
+CONFIG_USB_F_ECM=y

--- a/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next_%.bbappend
+++ b/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next_%.bbappend
@@ -1,0 +1,10 @@
+# WendyOS kernel deltas for the Dragonwing boards.
+#
+# Only the USB gadget stack so far. Everything else WendyOS needs is already in
+# meta-qcom's defconfig: the container prerequisites (namespaces, cgroups,
+# overlayfs, veth, bridge, netfilter masquerade, seccomp, BPF) are all present,
+# and root-mount critical drivers (SCSI_UFSHCD, SCSI_UFS_QCOM, BLK_DEV_SD,
+# EXT4_FS, EFI_PARTITION) are built in, so no fragment is needed for those.
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = "${@' file://usb-gadget.cfg' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"

--- a/meta-qcom-extensions/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/meta-qcom-extensions/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,0 +1,24 @@
+# Drop the two meta-qcom format-table patches that no longer apply to oe-core's
+# gstreamer, and keep the five that do.
+#
+# 0001 (QC08C) and 0010 (QC10C) each insert one row into gst_v4l2_formats[] in
+# sys/v4l2/gstv4l2object.c. Their context lines all carry
+# "GST_V4L2_RAW | GST_V4L2_MPLANE", but gstreamer 1.28.5 removed the MPLANE flag
+# from exactly those rows, so neither hunk can anchor. Verified by dry-run: only
+# these two fail; 0002/0004/0006/0007/0008 apply cleanly and are left in place,
+# so the V4L2 encoder/decoder fixes (colorimetry, aligned allocation, empty
+# bytesused buffers, GAP handling) are retained.
+#
+# Cost of dropping them: the v4l2 elements do not advertise Qualcomm's compressed
+# UBWC formats, so hardware decode/encode falls back to plain NV12 rather than the
+# bandwidth-efficient compressed path. Video still works; multi-stream bandwidth
+# headroom is lower.
+#
+# Not fixable by waiting for upstream: both patches are Upstream-Status: Denied
+# (freedesktop rejected NV12_Q08C), so meta-qcom carries them permanently and has
+# to rebase them for 1.28.5. Re-test on every SRCREV_QCOM or oe-core gstreamer
+# bump and delete this file once they apply again.
+SRC_URI:remove = " \
+    file://0001-v4l2-Add-support-for-V4L2_PIX_FMT_QC08C-format.patch \
+    file://0010-v4l2-Add-support-for-V4L2_PIX_FMT_QC10C-format.patch \
+    "

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -49,3 +49,6 @@ require ${@'x86-base-files.inc' if 'x86-wendyos' in d.getVar('MACHINEOVERRIDES')
 
 # VM A/B fstab — isolated so other boards are unaffected
 require ${@'vm-base-files.inc' if 'vm-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
+
+# Dragonwing A/B fstab — isolated so other boards are unaffected
+require ${@'qcom-base-files.inc' if 'qcom-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}

--- a/recipes-core/base-files/files/qcom-wendy-fstab
+++ b/recipes-core/base-files/files/qcom-wendy-fstab
@@ -1,0 +1,23 @@
+# WendyOS Dragonwing A/B fstab (wendyos-update OTA stack).
+#
+# Deliberately NO "/" entry: the rootfs slot is A/B and is mounted by the kernel
+# from the root= that grub.cfg sets per slot (root=PARTLABEL=rootfsA|rootfsB, see
+# meta-qcom-extensions/files/grub/grubAB-qcom.cfg), so a fixed root device here
+# would be wrong on the other slot. GRUB mounts "/" read-write via `rw` on the
+# kernel cmdline, matching the RPi and x86 A/B fstabs.
+#
+# /var/volatile tmpfs: shipped by stock oe-core base-files (our custom fstab
+# replaces that file, so carry it). Keeps churny /var data in RAM.
+#
+# /boot is the shared EFI System Partition (GRUB + grub.cfg + grubenv). It must
+# stay mounted: the wendyos-update grubenv connector edits /boot/EFI/BOOT/grubenv
+# via grub-editenv to flip slots and arm a trial. Referenced by LABEL, not a
+# per-build PARTUUID, since an OTA writes only the rootfs slot and never
+# re-partitions.
+#
+# /data is grown to fill the disk by the FLASH tool, not on first boot: it is the
+# last partition and patch0.xml patches its end LBA from the device's real
+# NUM_DISK_SECTORS. /config is the FAT provisioning partition. All by LABEL, all
+# nofail.
+tmpfs                   /var/volatile  tmpfs  defaults                 0 0
+LABEL=boot              /boot          vfat   defaults,nofail          0 2

--- a/recipes-core/base-files/qcom-base-files.inc
+++ b/recipes-core/base-files/qcom-base-files.inc
@@ -1,0 +1,18 @@
+# Qualcomm Dragonwing base-files extensions.
+# Included conditionally from base-files_%.bbappend — safe for other machines.
+
+SRC_URI:append = " \
+    file://qcom-wendy-fstab \
+    "
+
+# Dragonwing uses the wendyos-update A/B layout (two rootfs slots), so the stock
+# oe-core fstab is wrong twice over: it carries a "/" entry (the slot device
+# varies) and no /boot entry (the grubenv connector needs the ESP mounted). Install
+# the A/B fstab instead — no "/", everything by LABEL.
+#
+# Installed unconditionally for this board rather than gated on WENDYOS_OTA: the
+# entries are all `nofail`, so the file is also correct during bring-up when the
+# config and data partitions do not exist yet.
+do_install:append() {
+    install -m 0644 ${UNPACKDIR}/qcom-wendy-fstab ${D}${sysconfdir}/fstab
+}

--- a/recipes-core/images/wendyos-image.bb
+++ b/recipes-core/images/wendyos-image.bb
@@ -209,6 +209,7 @@ require ${@'conf/distro/include/tegra-image.inc' if 'tegra' in d.getVar('MACHINE
 require ${@'conf/distro/include/rpi-image.inc' if 'rpi' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 require ${@'conf/distro/include/x86-image.inc' if 'x86-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 require ${@'conf/distro/include/vm-image.inc' if 'vm-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
+require ${@'conf/distro/include/qcom-image.inc' if 'qcom-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 
 # Config sanity check. Encrypting /data needs a TPM at runtime -- data-enroll seals
 # the LUKS2 keyslot to it -- so WENDYOS_DATA_ENCRYPTED turns WENDYOS_ENABLE_TPM on

--- a/recipes-core/systemd-mount-timesync/files/var-lib-systemd-timesync.mount
+++ b/recipes-core/systemd-mount-timesync/files/var-lib-systemd-timesync.mount
@@ -1,0 +1,29 @@
+[Unit]
+Description=Bind mount /var/lib/systemd/timesync (last-known-good clock) from data partition
+Documentation=man:systemd.mount(5)
+
+# This board has no usable RTC: the PMIC RTC is read-only (its DT node has no
+# allow-set-time, so RTC_SET_TIME returns ENODEV) and loses everything on power
+# loss, so the only thing keeping time sane across a boot is the timestamp
+# systemd-timesyncd saves here. On the A/B rootfs that file dies at every OTA
+# swap; on /data it survives both reboots and slot switches.
+
+RequiresMountsFor=/data
+After=data.mount
+
+# systemd-timesyncd is DefaultDependencies=no, so it does NOT wait for
+# local-fs.target -- without this edge it can start first, write the clock file
+# to the rootfs, and then have the bind hide it.
+Before=systemd-timesyncd.service
+DefaultDependencies=no
+
+[Mount]
+What=/data/systemd-timesync
+Where=/var/lib/systemd/timesync
+Type=none
+# x-systemd.mkdir creates both ends; timesyncd's StateDirectory=systemd/timesync
+# then chowns through the bind to the systemd-timesync user.
+Options=bind,nosuid,nodev,x-systemd.mkdir
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/systemd-mount-timesync/systemd-mount-timesync_1.0.bb
+++ b/recipes-core/systemd-mount-timesync/systemd-mount-timesync_1.0.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Bind mount the systemd-timesyncd clock state from /data"
+DESCRIPTION = "Keeps systemd-timesyncd's last-known-good timestamp on the /data \
+partition instead of the A/B rootfs, so the system clock stays monotonic across \
+reboots and OTA slot switches on a board with no writable, battery-backed RTC."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit systemd
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = "file://var-lib-systemd-timesync.mount"
+S = "${UNPACKDIR}"
+
+SYSTEMD_SERVICE:${PN} = "var-lib-systemd-timesync.mount"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/var-lib-systemd-timesync.mount \
+        ${D}${systemd_system_unitdir}/var-lib-systemd-timesync.mount
+}
+
+FILES:${PN} += "${systemd_system_unitdir}/var-lib-systemd-timesync.mount"
+RDEPENDS:${PN} = "systemd"

--- a/recipes-core/wendyos-data-setup/wendyos-data-setup_1.0.bb
+++ b/recipes-core/wendyos-data-setup/wendyos-data-setup_1.0.bb
@@ -38,4 +38,7 @@ FILES:${PN} += " \
 SYSTEMD_SERVICE:${PN} = "wendyos-data-init.service data.mount"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
-RDEPENDS:${PN} = "bash coreutils util-linux parted e2fsprogs-mke2fs gptfdisk"
+# e2fsprogs-dumpe2fs is what makes the "already initialised?" probe work: if
+# dumpe2fs is absent the guard cannot read the superblock, and the script falls
+# through to mkfs.ext4 -F, wiping /data on EVERY boot.
+RDEPENDS:${PN} = "bash coreutils util-linux parted e2fsprogs-mke2fs e2fsprogs-dumpe2fs gptfdisk"

--- a/scripts/check-repo-pins.sh
+++ b/scripts/check-repo-pins.sh
@@ -71,6 +71,7 @@ meta-tegra-community:SRCREV_TEGRA_COMM
 meta-virtualization:SRCREV_VIRT
 meta-raspberrypi:SRCREV_RPI
 meta-security:SRCREV_SECURITY
+meta-qcom:SRCREV_QCOM
 "
 
 MATRIX="$(mktemp)"

--- a/scripts/resolve-artifacts.sh
+++ b/scripts/resolve-artifacts.sh
@@ -24,7 +24,7 @@
 # Output: KEY=VALUE lines on stdout, safe to `eval` in a step or append to
 # $GITHUB_ENV. Diagnostics and errors go to stderr.
 #   IMAGE_KIND         generated-nvme-img | generated-sd-img | tegraflash-bundle |
-#                      sdimg-gz-with-wic-fallback | wic-disk
+#                      qcomflash-bundle | sdimg-gz-with-wic-fallback | wic-disk
 #   IMAGE_FILE         primary artifact path. For generated-*-img this is the
 #                      MACHINE-scoped target path the "Generate flashable image"
 #                      step writes (it does NOT exist at Yocto deploy time, so it
@@ -103,6 +103,18 @@ if [[ "$RECOVERY_EXPECTED" == "true" || "$IMAGE_KIND" == "tegraflash-bundle" ]];
     -print -quit 2>/dev/null || true)
 fi
 
+# Prefer Yocto's stable symlink; fall back to the timestamped name.
+QCOMFLASH_BUNDLE=""
+if [[ "$IMAGE_KIND" == "qcomflash-bundle" ]]; then
+  stable="$DEPLOY_DIR/wendyos-image-${MACHINE}.rootfs.qcomflash.tar.gz"
+  if [[ -e "$stable" ]]; then
+    QCOMFLASH_BUNDLE="$stable"
+  else
+    QCOMFLASH_BUNDLE=$(find "$DEPLOY_DIR" -maxdepth 1 \
+      -name "wendyos-image-${MACHINE}*.qcomflash.tar.gz" -print -quit 2>/dev/null || true)
+  fi
+fi
+
 RPI_NEEDS_GZIP=false
 case "$IMAGE_KIND" in
   tegraflash-bundle)
@@ -112,6 +124,14 @@ case "$IMAGE_KIND" in
       fail "no tegraflash bundle for $KEY ($MACHINE): expected wendyos-image-${MACHINE}.tegraflash-tar or .tegraflash-tar.zst in $DEPLOY_DIR (map entry image_kind=tegraflash-bundle)"
     fi
     IMAGE_FILE="$TEGRAFLASH_BUNDLE"
+    ;;
+  qcomflash-bundle)
+    # EDL flashing produces no disk image: the qcomflash tarball IS the artifact,
+    # carrying the partition images and the rawprogram/patch XML that drives qdl.
+    if [[ -z "$QCOMFLASH_BUNDLE" || ! -e "$QCOMFLASH_BUNDLE" ]]; then
+      fail "no qcomflash bundle for $KEY ($MACHINE): expected wendyos-image-${MACHINE}.rootfs.qcomflash.tar.gz in $DEPLOY_DIR (map entry image_kind=qcomflash-bundle)"
+    fi
+    IMAGE_FILE="$QCOMFLASH_BUNDLE"
     ;;
   generated-nvme-img)
     # The offline NVMe image is produced by build.yml's "Generate flashable

--- a/scripts/resolve-artifacts.test.sh
+++ b/scripts/resolve-artifacts.test.sh
@@ -93,6 +93,43 @@ test_thor() {
   rm -rf "$d"
 }
 
+# Dragonwing: UFS is flashed over EDL, so the qcomflash tarball is the artifact.
+test_dragonwing_qcomflash() {
+  local d M; d=$(newdir); M=iq-8275-evk-wendyos
+  : >"$d/wendyos-image-$M.rootfs.qcomflash.tar.gz"
+  local out; out=$(run_resolver dragonwing-iq-8275 ufs "$M" "$d"); local rc=$?
+  assert_eq "dragonwing: exits 0" 0 "$rc"
+  assert_eq "dragonwing: kind"         qcomflash-bundle "$(field IMAGE_KIND <<<"$out")"
+  assert_eq "dragonwing: image"        "$d/wendyos-image-$M.rootfs.qcomflash.tar.gz" "$(field IMAGE_FILE <<<"$out")"
+  assert_eq "dragonwing: bmap"         false "$(field BMAP_REQUIRED <<<"$out")"
+  assert_eq "dragonwing: flashpack"    false "$(field FLASHPACK_REQUIRED <<<"$out")"
+  assert_eq "dragonwing: recovery"     false "$(field RECOVERY_EXPECTED <<<"$out")"
+  assert_eq "dragonwing: pass_storage" false "$(field PASS_STORAGE <<<"$out")"
+  rm -rf "$d"
+}
+
+# A build that deployed no stable symlink still resolves via the versioned name.
+test_dragonwing_versioned_fallback() {
+  local d M; d=$(newdir); M=iq-8275-evk-wendyos
+  : >"$d/wendyos-image-$M.rootfs-20260907185415.qcomflash.tar.gz"
+  local out; out=$(run_resolver dragonwing-iq-8275 ufs "$M" "$d"); local rc=$?
+  assert_eq "dragonwing versioned: exits 0" 0 "$rc"
+  assert_eq "dragonwing versioned: image" \
+    "$d/wendyos-image-$M.rootfs-20260907185415.qcomflash.tar.gz" "$(field IMAGE_FILE <<<"$out")"
+  rm -rf "$d"
+}
+
+# A missing bundle must be fatal, not a silent empty upload.
+test_missing_qcomflash_fatal() {
+  local d M; d=$(newdir); M=iq-8275-evk-wendyos
+  local out; out=$(run_resolver dragonwing-iq-8275 ufs "$M" "$d" 2>&1); local rc=$?
+  if [[ "$rc" -ne 0 ]]; then ok "missing qcomflash: non-zero exit"
+  else bad "missing qcomflash: expected non-zero exit"; fi
+  if grep -q "no qcomflash bundle" <<<"$out"; then ok "missing qcomflash: names the artifact"
+  else bad "missing qcomflash: error did not name the artifact"; fi
+  rm -rf "$d"
+}
+
 # tegraflash .zst variant resolves too (JP7 / r38.4.x compressed bundle).
 test_tegraflash_zst() {
   local d M; d=$(newdir); M=jetson-orin-nano-devkit-nvme-wendyos
@@ -262,8 +299,9 @@ test_generated_nvme_bundle_absent() {
 }
 
 # ---------------------------------------------------------------------------
-# (c) Every device+storage combo in build.yml's matrix has a map entry.
-# Hardcoded from build.yml's ALL_MATRIX — keep in sync if the matrix changes.
+# (c) Every device+storage combo in build.yml's matrix has a map entry, and every
+# map entry belongs to one. Hardcoded from build.yml's ALL_MATRIX — keep in sync
+# if the matrix changes.
 # ---------------------------------------------------------------------------
 test_matrix_coverage() {
   local combos=(
@@ -279,6 +317,7 @@ test_matrix_coverage() {
     generic-x86-64/disk
     vm-arm64/disk
     vm-x86-64/disk
+    dragonwing-iq-8275/ufs
   )
   local c
   for c in "${combos[@]}"; do
@@ -302,6 +341,9 @@ test_jetson_nvme
 test_jetson_emmc
 test_thor
 test_tegraflash_zst
+test_dragonwing_qcomflash
+test_dragonwing_versioned_fallback
+test_missing_qcomflash_fatal
 test_jetson_nano_sd
 test_rpi_sdimg
 test_rpi_wic

--- a/scripts/upstream-repos.env
+++ b/scripts/upstream-repos.env
@@ -28,6 +28,7 @@ URL_TEGRA="https://github.com/OE4T/meta-tegra.git"
 URL_TEGRA_COMM="https://github.com/OE4T/meta-tegra-community"
 URL_VIRT="https://git.yoctoproject.org/meta-virtualization.git"
 URL_RPI="https://github.com/agherzan/meta-raspberrypi.git"
+URL_QCOM="https://github.com/qualcomm-linux/meta-qcom.git"
 URL_SECURITY="https://git.yoctoproject.org/meta-security"
 
 # ---------------------------------------------------------------------------
@@ -108,3 +109,8 @@ SRCREV_RPI="a0ebcf5639b391690b27381cc65c56c157a0981b"
 # blacksail branch yet, which is why the bblayers includes bridge
 # LAYERSERIES_COMPAT_tpm-layer.
 SRCREV_SECURITY="226839ac408223f8041cde1b1d8b762d6fbc8050"
+
+# meta-qcom master, layered only by the dragonwing boards. Upstream has no
+# blacksail branch; master is the right pin because meta-qcom's own CI builds it
+# against oe-core and bitbake master, which is what the blacksail tree pins.
+SRCREV_QCOM="fcadf0c38a91fc77c4583d6defdf522fc9deb9da"


### PR DESCRIPTION
Adds the `iq-8275-evk-wendyos` machine on top of meta-qcom: A/B rootfs on UFS with wendyos-update, GRUB A/B boot, Wi-Fi and Ethernet, and CI that builds and publishes the qcomflash bundle so the board can be flashed over EDL with qdl.

Validated on hardware end to end, including an OTA install, slot switch and auto-commit.

 Refs: WDY-2846