### PR TITLE
identity: source the shared helpers under their installed name

### DIFF
--- a/recipes-connectivity/avahi/files/generate-hostname.sh
+++ b/recipes-connectivity/avahi/files/generate-hostname.sh
@@ -23,7 +23,7 @@ log() {
 }
 
 # Shared identity helpers, one source of truth with update-mdns-uuid.sh.
-IDENTITY_LIB="${IDENTITY_LIB:-/usr/share/wendyos/identity-lib.sh}"
+IDENTITY_LIB="${IDENTITY_LIB:-/usr/share/wendyos/wendyos-identity-lib.sh}"
 # shellcheck source=/dev/null
 . "$IDENTITY_LIB" || { echo "Cannot source identity helpers: $IDENTITY_LIB" >&2; exit 1; }
 

--- a/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
+++ b/recipes-core/wendyos-identity/files/update-mdns-uuid.sh
@@ -18,7 +18,7 @@ AVAHI_RELOAD_CMD="${AVAHI_RELOAD_CMD:-systemctl}"
 IDENTITY_WAIT_SECS="${IDENTITY_WAIT_SECS:-10}"
 
 # Shared identity helpers, one source of truth with generate-hostname.sh.
-IDENTITY_LIB="${IDENTITY_LIB:-/usr/share/wendyos/identity-lib.sh}"
+IDENTITY_LIB="${IDENTITY_LIB:-/usr/share/wendyos/wendyos-identity-lib.sh}"
 # shellcheck source=/dev/null
 . "$IDENTITY_LIB" || { echo "Cannot source identity helpers: $IDENTITY_LIB" >&2; exit 1; }
 


### PR DESCRIPTION
update-mdns-uuid.sh and generate-hostname.sh defaulted to identity-lib.sh while the recipe installs wendyos-identity-lib.sh, so both failed and mDNS was unset.

Refs: WDY-2843