### PR TITLE
 enable the Hexagon NPU on the Dragonwing IQ-8275

### DIFF
--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -21,6 +21,13 @@ on:
       - 'meta-qcom-extensions/recipes-bsp/grub/*'
       - 'meta-qcom-extensions/recipes-bsp/partition/files/*'
       - 'meta-qcom-extensions/recipes-core/wendyos-config-setup/files/*'
+      - 'meta-qcom-extensions/recipes-core/packagegroups/*'
+      - 'meta-qcom-extensions/recipes-bsp/hexagon-dsp-binaries/*'
+      - 'conf/machine/iq-8275-evk-wendyos.conf'
+      - 'conf/distro/wendyos.conf'
+      - 'conf/distro/include/qcom-distro.inc'
+      - 'scripts/upstream-repos.env'
+      - 'scripts/qcom-npu.test.sh'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
   push:
@@ -42,6 +49,13 @@ on:
       - 'meta-qcom-extensions/recipes-bsp/grub/*'
       - 'meta-qcom-extensions/recipes-bsp/partition/files/*'
       - 'meta-qcom-extensions/recipes-core/wendyos-config-setup/files/*'
+      - 'meta-qcom-extensions/recipes-core/packagegroups/*'
+      - 'meta-qcom-extensions/recipes-bsp/hexagon-dsp-binaries/*'
+      - 'conf/machine/iq-8275-evk-wendyos.conf'
+      - 'conf/distro/wendyos.conf'
+      - 'conf/distro/include/qcom-distro.inc'
+      - 'scripts/upstream-repos.env'
+      - 'scripts/qcom-npu.test.sh'
       - '.github/device-artifacts.json'
       - '.github/workflows/scripts-ci.yml'
 
@@ -67,6 +81,7 @@ jobs:
                      recipes-core/wendyos-sysext-apply/files/wendyos-sysext-apply.sh \
                      recipes-kernel/wendyos-kernel-devkit/files/setup.sh \
                      meta-qcom-extensions/files/grub/grubAB-qcom.test.sh \
+                     scripts/qcom-npu.test.sh \
                      meta-qcom-extensions/recipes-core/wendyos-config-setup/files/wendyos-config-init.sh
           shellcheck recipes-core/wendyos-identity/files/wendyos-identity-lib.sh \
                      recipes-core/wendyos-identity/files/update-mdns-uuid.sh \
@@ -99,6 +114,9 @@ jobs:
       # partitions.conf, the grub-efi bbappend and the grubenv connector.
       - name: Run Dragonwing GRUB A/B config checks
         run: bash meta-qcom-extensions/files/grub/grubAB-qcom.test.sh
+
+      - name: Run Dragonwing NPU stack checks
+        run: bash scripts/qcom-npu.test.sh
 
       - name: Run T234 flashpack manifest tests
         run: python3 -m unittest scripts/t234_flashpack_manifest_test.py

--- a/conf/distro/include/qcom-distro.inc
+++ b/conf/distro/include/qcom-distro.inc
@@ -1,0 +1,18 @@
+# Qualcomm-specific distro configuration, shared by every qcom board.
+
+# Hexagon DSP userspace selection. The signed DSP firmware authorises each Hexagon binary
+# by ELF segment hash, so this must name the build the shipped linux-firmware admits.
+# hexagon-dsp-binaries carries several; verify a change with its scripts/check.py.
+#
+# hexagon-dsp-binaries is allarch, so the three pins below must hold one value across all
+# qcom machines; overriding any of them per machine gives one sstate object two
+# signatures.
+WENDYOS_QCOM_DSP_BUILD ?= "DSP.AT.1.0.1-00201-LEMANS-2"
+
+# SoC directories to retarget. Only boards this repo builds, so an upstream change to an
+# unused SoC cannot fail the build.
+WENDYOS_QCOM_DSP_SOCS ?= "qcs8300"
+
+# The linux-firmware version oe-core ships. A bump must fail the build until the DSP
+# build above has been re-checked against it.
+WENDYOS_QCOM_DSP_FW_PV ?= "20260622"

--- a/conf/distro/wendyos.conf
+++ b/conf/distro/wendyos.conf
@@ -169,6 +169,7 @@ require ${@'conf/distro/include/qemu-distro.inc' if 'qemuall' in d.getVar('MACHI
 require ${@'conf/distro/include/rpi-distro.inc'  if 'rpi'     in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 require ${@'conf/distro/include/x86-distro.inc'  if 'x86-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 require ${@'conf/distro/include/vm-distro.inc'   if 'vm-wendyos'  in d.getVar('MACHINEOVERRIDES').split(':') else ''}
+require ${@'conf/distro/include/qcom-distro.inc' if 'qcom-wendyos' in d.getVar('MACHINEOVERRIDES').split(':') else ''}
 
 # Driver add-ons (systemd-sysext): systemd's sysext support, the boot-time merge
 # service and the kernel devkit. Gated on WENDYOS_DRIVER_EXTENSIONS, so it must

--- a/conf/machine/iq-8275-evk-wendyos.conf
+++ b/conf/machine/iq-8275-evk-wendyos.conf
@@ -83,10 +83,12 @@ WENDYOS_ENABLE_TPM = "0"
 # boots, and wendyos-grub-ab asserts it is one the kernel installs.
 WENDYOS_QCOM_DTB = "monaco-evk.dtb"
 
-# Stable board identity written to /etc/wendyos/device-type
-# Qualcomm AI stack for the on-SoC Hexagon NPU (QAIRT/QNN runtime + the DSP
-# blobs). Off by default: it adds ~500 MB to every rootfs slot, roughly triples
-# the OTA payload, and pulls in proprietary redistributables.
-WENDYOS_QCOM_NPU ?= "0"
+# Qualcomm AI stack for the on-SoC Hexagon NPU, installed into the image. The device has
+# no package manager, so it cannot be added afterwards.
+#
+# "0" drops only qairt-sdk and fastrpc-tests: meta-qcom recommends the DSP userspace and
+# the HTP skels regardless, and the skels are a qairt-sdk subpackage.
+WENDYOS_QCOM_NPU ?= "1"
 
+# Stable board identity written to /etc/wendyos/device-type
 WENDYOS_BOARD_ID = "dragonwing-iq-8275"

--- a/meta-qcom-extensions/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_%.bbappend
+++ b/meta-qcom-extensions/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_%.bbappend
@@ -1,0 +1,44 @@
+# Retarget the DSP userspace to the build our firmware authorises, and correct the
+# version pin that expresses that pairing. See WENDYOS_QCOM_DSP_BUILD in qcom-distro.inc.
+
+# Edited in place rather than by overriding do_install, so upstream's install target
+# keeps working. The sed is idempotent.
+do_install:prepend() {
+    for soc in ${WENDYOS_QCOM_DSP_SOCS}; do
+        sed -i -E "/^Install:[[:space:]]+$soc\//s/DSP\.AT\.[0-9.]+-[0-9.]+-LEMANS-[0-9]+/${WENDYOS_QCOM_DSP_BUILD}/" \
+            "${S}/config.txt"
+
+        # A sed that matched nothing leaves a selection the firmware refuses at
+        # runtime, with a green build.
+        if ! grep -q "^Install:[[:space:]]\+$soc/.*${WENDYOS_QCOM_DSP_BUILD}" "${S}/config.txt"; then
+            bbfatal "no Install: line for $soc names ${WENDYOS_QCOM_DSP_BUILD}; upstream's \
+config.txt format changed or it no longer ships that build"
+        fi
+    done
+}
+
+# Upstream derives these pins from its own PV, which the shipped firmware does not
+# satisfy. Rewritten, not dropped: the pin is what makes a future skew a build failure.
+#
+# Only where the firmware named belongs to a retargeted SoC; elsewhere the pairing was
+# never checked. Matched on the firmware package, since the package name does not
+# identify the SoC.
+python () {
+    import re
+    fwpv = d.getVar('WENDYOS_QCOM_DSP_FW_PV')
+    if not fwpv:
+        bb.fatal("WENDYOS_QCOM_DSP_FW_PV is unset; it must name the linux-firmware "
+                 "version oe-core ships")
+    socs = (d.getVar('WENDYOS_QCOM_DSP_SOCS') or '').split()
+    if not socs:
+        bb.fatal("WENDYOS_QCOM_DSP_SOCS is unset; nothing would be retargeted")
+    pin = re.compile(r'(linux-firmware-qcom-(?:%s)-[a-z]+ \(= 1:)%s\b'
+                     % ('|'.join(map(re.escape, socs)), re.escape(d.getVar('PV'))))
+    for pkg in (d.getVar('PACKAGES') or '').split():
+        var = 'RDEPENDS:' + pkg
+        cur = d.getVar(var)
+        if cur:
+            new = pin.sub(r'\g<1>' + fwpv, cur)
+            if new != cur:
+                d.setVar(var, new)
+}

--- a/meta-qcom-extensions/recipes-core/packagegroups/packagegroup-wendyos-qcom.bb
+++ b/meta-qcom-extensions/recipes-core/packagegroups/packagegroup-wendyos-qcom.bb
@@ -53,22 +53,22 @@ RDEPENDS:${PN} = " \
 # is the only thing keeping the clock sane across a reboot or an OTA swap.
 RDEPENDS:${PN} += " systemd-mount-timesync"
 
-# Qualcomm AI stack, gated on WENDYOS_QCOM_NPU (see the machine conf for why it is
-# off by default). The kernel half already ships: fastrpc is loaded, the cDSP boots
-# from linux-firmware, and qairt-sdk-hexagon-v75 supplies the DSP-side skels. What
-# these add is the host-side runtime plus the board's DSP blobs.
+# Qualcomm AI stack for the on-SoC Hexagon NPU, gated on WENDYOS_QCOM_NPU. fastrpc and
+# the DSP firmware already ship with the kernel.
 #
-# The -config package is what makes offload work: it drops a conf.d yaml keyed on
-# the DT model ("Qualcomm Technologies, Inc. Monaco EVK") that tells fastrpc's
-# config parser where the skels live, and the -evk-{adsp,cdsp,gdsp} packages are
-# symlinks creating exactly that path. Without it DSP_LIBRARY_PATH is never set and
-# every offload call fails.
+# RDEPENDS, not RRECOMMENDS: meta-qcom reaches these through
+# MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS, where an unsatisfiable entry is dropped silently.
+#
+# The -evk-* packages are symlinks onto the -ride-* payload; -evk-config supplies the
+# DT-model to DSP_LIBRARY_PATH mapping that offload needs.
 WENDYOS_QCOM_NPU_INSTALL = " \
-    qairt-sdk \
     hexagon-dsp-binaries-qualcomm-iq8275-evk-config \
     hexagon-dsp-binaries-qcom-iq8275-evk-adsp \
     hexagon-dsp-binaries-qcom-iq8275-evk-cdsp \
     hexagon-dsp-binaries-qcom-iq8275-evk-gdsp \
+    qairt-sdk \
+    qairt-sdk-hexagon-v75 \
+    fastrpc-tests \
     "
 RDEPENDS:${PN} += "${@d.getVar('WENDYOS_QCOM_NPU_INSTALL') if d.getVar('WENDYOS_QCOM_NPU') == '1' else ''}"
 

--- a/meta-qcom-extensions/recipes-ml/qairt/qairt-sdk_%.bbappend
+++ b/meta-qcom-extensions/recipes-ml/qairt/qairt-sdk_%.bbappend
@@ -1,0 +1,14 @@
+# Upstream recommends a skel package for every Hexagon version. The SoC fixes which one
+# is usable and the packagegroup names it, so drop the skels by shape: a named list would
+# either admit a version added later or remove the one another board needs.
+python () {
+    import re
+    pn = d.getVar('PN')
+    skel = re.compile(r'^%s-hexagon-v\d+$' % re.escape(pn))
+    var = 'RRECOMMENDS:' + pn
+    deps = bb.utils.explode_dep_versions2(d.getVar(var) or '')
+    for pkg in list(deps):
+        if skel.match(pkg):
+            del deps[pkg]
+    d.setVar(var, bb.utils.join_deps(deps, commasep=False))
+}

--- a/scripts/qcom-npu.test.sh
+++ b/scripts/qcom-npu.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Static checks on the Dragonwing NPU stack.
+#
+# Two failure modes here are invisible to a build: the DSP firmware refuses a userspace
+# it does not authorise, and an unsatisfiable RRECOMMENDS drops a package silently.
+#
+# Run: bash scripts/qcom-npu.test.sh
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PG="$ROOT/meta-qcom-extensions/recipes-core/packagegroups/packagegroup-wendyos-qcom.bb"
+BBA="$ROOT/meta-qcom-extensions/recipes-bsp/hexagon-dsp-binaries/hexagon-dsp-binaries_%.bbappend"
+MACH="$ROOT/conf/machine/iq-8275-evk-wendyos.conf"
+DISTRO="$ROOT/conf/distro/include/qcom-distro.inc"
+REPOSENV="$ROOT/scripts/upstream-repos.env"
+OECORE="$ROOT/../repos/blacksail/openembedded-core"
+fails=0
+
+check() {
+    if [ "$1" = "0" ]; then
+        printf '  ok    %s\n' "$2"
+    else
+        printf '  FAIL  %s\n' "$2"
+        fails=$((fails + 1))
+    fi
+}
+
+for f in "$PG" "$BBA" "$MACH" "$DISTRO" "$REPOSENV"; do
+    [ -f "$f" ] || { printf 'missing input: %s\n' "$f" >&2; exit 1; }
+done
+printf 'Checking the Dragonwing NPU stack\n'
+
+# A comment must never satisfy an assertion.
+strip() { grep -vE '^[[:space:]]*#' "$1"; }
+PGBODY="$(strip "$PG")"
+BBABODY="$(strip "$BBA")"
+MACHBODY="$(strip "$MACH")"
+DISTROBODY="$(strip "$DISTRO")"
+
+# --- 1. the stack is complete -----------------------------------------------
+# Read from the recipe: a restated list cannot notice a deletion.
+INSTALL="$(printf '%s\n' "$PGBODY" \
+    | sed -n '/^WENDYOS_QCOM_NPU_INSTALL/,/^[[:space:]]*"/p' \
+    | awk '$1 ~ /^[a-z0-9]/ { print $1 }')"
+n=$(printf '%s\n' "$INSTALL" | grep -c .)
+if [ "$n" -ge 7 ]; then check 0 "the install list parses ($n packages)"
+else check 1 "the install list parses (got $n packages, expected at least 7)"; fi
+
+# Anchored to a whole entry: a substring match would be satisfied by a longer name.
+has() { printf '%s\n' "$INSTALL" | grep -qx "$1"; }
+for p in \
+    qairt-sdk \
+    qairt-sdk-hexagon-v75 \
+    fastrpc-tests \
+    hexagon-dsp-binaries-qualcomm-iq8275-evk-config \
+    hexagon-dsp-binaries-qcom-iq8275-evk-adsp \
+    hexagon-dsp-binaries-qcom-iq8275-evk-cdsp \
+    hexagon-dsp-binaries-qcom-iq8275-evk-gdsp
+do
+    has "$p"
+    check $? "the stack names $p"
+done
+
+# --- 2. hard dependencies, not recommendations ------------------------------
+# Joined into one logical line first: the recipe's own idiom is a backslash-continued
+# list, so a line-at-a-time match cannot see a multi-line RRECOMMENDS.
+printf '%s\n' "$PGBODY" | grep -qE 'RDEPENDS:\$\{PN\}[[:space:]]*\+=.*NPU_INSTALL'
+check $? "the stack is installed via RDEPENDS"
+# Comments are stripped, so any occurrence left is a real declaration.
+printf '%s\n' "$PGBODY" | grep -qF 'RRECOMMENDS'
+check $((1 - $?)) "and the recipe declares no RRECOMMENDS at all"
+
+# --- 3. it is in the image, not an extension --------------------------------
+printf '%s\n' "$MACHBODY" | grep -qE '^WENDYOS_QCOM_NPU[[:space:]]*\??=[[:space:]]*"1"'
+check $? "the NPU is on by default for this board"
+printf '%s\n' "$PGBODY" | grep -qF "d.getVar('WENDYOS_QCOM_NPU') == '1'"
+check $? "the install list is still gated on the knob"
+
+# --- 4. the firmware pairing ------------------------------------------------
+# The pin must name the version oe-core ships, or do_rootfs cannot resolve it.
+printf '%s\n' "$DISTROBODY" | grep -qE '^WENDYOS_QCOM_DSP_BUILD[[:space:]]*\??='
+check $? "the DSP build is pinned distro-wide"
+FWPV="$(printf '%s\n' "$DISTROBODY" | sed -nE 's/^WENDYOS_QCOM_DSP_FW_PV[[:space:]]*\??=[[:space:]]*"([^"]+)".*/\1/p')"
+if [ -n "$FWPV" ]; then check 0 "the firmware version it is matched to is pinned"
+else check 1 "WENDYOS_QCOM_DSP_FW_PV is not pinned"; fi
+
+# An oe-core bump can move linux-firmware, and with it which binaries the signed firmware
+# admits. Comparing the two revisions needs no checkout, so unlike the check below it also
+# runs in CI.
+pin() { sed -nE "s/^$1=\"([^\"]+)\".*/\1/p" "$REPOSENV"; }
+OEREV="$(pin SRCREV_OECORE)"
+OEVERIFIED="$(pin SRCREV_OECORE_DSP_VERIFIED)"
+if [ -n "$OEREV" ] && [ "$OEREV" = "$OEVERIFIED" ]; then
+    check 0 "the DSP pairing was verified against the pinned oe-core"
+else
+    check 1 "oe-core is at ${OEREV:-unset}, pairing verified at ${OEVERIFIED:-unset}; \
+re-check the pairing and update SRCREV_OECORE_DSP_VERIFIED"
+fi
+
+if [ -d "$OECORE" ]; then
+    OEPV="$(find "$OECORE/meta/recipes-kernel/linux-firmware" -maxdepth 1 \
+        -name 'linux-firmware_*.bb' -printf '%f\n' 2>/dev/null \
+        | sed -nE 's/^linux-firmware_(.+)\.bb$/\1/p' | head -1)"
+    if [ -n "$OEPV" ] && [ "$FWPV" = "$OEPV" ]; then
+        check 0 "the pin ($FWPV) matches oe-core's linux-firmware ($OEPV)"
+    else
+        check 1 "the pin ($FWPV) does not match oe-core's linux-firmware (${OEPV:-unknown})"
+    fi
+else
+    printf '  skip  oe-core not checked out; the revision check above stands in\n'
+fi
+
+# --- 5. the retarget cannot silently no-op ----------------------------------
+# A no-op retarget ships a userspace the firmware refuses, with a green build.
+printf '%s\n' "$BBABODY" | grep -qF 'bbfatal'
+check $? "the bbappend asserts the retarget substituted"
+printf '%s\n' "$BBABODY" | grep -qE "do_install:(prepend|append)"
+check $? "and hooks upstream's do_install rather than replacing it"
+
+printf '\n%s\n' "$([ "$fails" -eq 0 ] && echo 'all checks passed' || echo "$fails check(s) failed")"
+exit $((fails > 0))

--- a/scripts/upstream-repos.env
+++ b/scripts/upstream-repos.env
@@ -59,6 +59,11 @@ SRCREV_BITBAKE="c870f5bd96ad02efc02c58133c27bdae3a300e3e"
 SRCREV_OECORE="2faf8e366df74aded7898904b72317521a08e2f6"
 SRCREV_METAYOCTO="9c6cf36c3511b94957aba04002d98bec665e9f1e"
 
+# The oe-core revision the Dragonwing DSP firmware pairing was verified against. Moving
+# SRCREV_OECORE can change which Hexagon binaries the signed firmware admits, so CI fails
+# until the pairing is re-checked and this is updated with WENDYOS_QCOM_DSP_FW_PV.
+SRCREV_OECORE_DSP_VERIFIED="2faf8e366df74aded7898904b72317521a08e2f6"
+
 # meta-openembedded and meta-virtualization master HEAD. Neither declares
 # blacksail yet — meta-oe says LAYERSERIES_COMPAT = "whinlatter wrynose",
 # meta-virtualization says "wrynose" only. Both are bridged by


### PR DESCRIPTION
Installs the Qualcomm AI stack into the image: the Hexagon DSP userspace +  the QAIRT/QNN