### PR TITLE
 dragonwing: enable the USB2 host port

### DIFF
--- a/conf/machine/iq-8275-evk-wendyos.conf
+++ b/conf/machine/iq-8275-evk-wendyos.conf
@@ -65,8 +65,8 @@ WENDYOS_EFI_DEBUG = "0"
 # NVIDIA-only stacks.
 WENDYOS_DEEPSTREAM = "0"
 
-# Two USB device controllers exist on this board (a400000.usb, a600000.usb), so
-# gadget networking is mechanically available. The Tegra-only gadget helper
+# The gadget rides a600000.usb, whose socket is chosen by the board's USB
+# switches; a400000.usb is the host port. The Tegra-only gadget helper
 # recipes that wendyos-image.bb pairs with this knob are dropped in
 # conf/distro/include/qcom-image.inc, exactly as the RPi include does.
 WENDYOS_USB_GADGET = "1"

--- a/meta-qcom-extensions/recipes-core/packagegroups/packagegroup-wendyos-qcom.bb
+++ b/meta-qcom-extensions/recipes-core/packagegroups/packagegroup-wendyos-qcom.bb
@@ -28,13 +28,8 @@ inherit packagegroup
 #                      the driver does not enable /data encryption --
 #                      WENDYOS_DATA_ENCRYPTED stays 0 -- it just stops the
 #                      hardware being invisible.
-#
-# qcom-refgen-regulator is deliberately absent, though the hardware wants it: it
-# lets 8906000.phy probe, which brings up a400000.usb as a SECOND UDC, and
-# gadget-setup.sh picks its controller with `ls /sys/class/udc | head -n1`. That
-# selects a400000.usb, the gadget binds to a port with no cable, and usb0 goes down
-# -- taking away the board's only host link. Install it once that script selects
-# its UDC explicitly rather than by sort order.
+#  uvcvideo            USB webcams on the host port. The rest of the V4L2 stack
+#                      already ships for the on-SoC camera path.
 RDEPENDS:${PN} = " \
     kernel-module-pwrseq-pcie-m2 \
     kernel-module-at24 \
@@ -47,6 +42,7 @@ RDEPENDS:${PN} = " \
     kernel-module-pinctrl-sm8450-lpass-lpi \
     kernel-module-tpm-tis-core \
     kernel-module-tpm-tis-spi \
+    kernel-module-uvcvideo \
     "
 
 # The PMIC RTC is read-only and volatile, so timesyncd's saved timestamp on /data

--- a/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next/0001-arm64-dts-monaco-evk-host-mode-on-usb2.patch
+++ b/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next/0001-arm64-dts-monaco-evk-host-mode-on-usb2.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benjamin Kelenyi <benjamin@wendy.sh>
+Date: Thu, 11 Sep 2026 10:00:00 +0300
+Subject: [PATCH] arm64: dts: monaco-evk: USB2 as host, USB1 dual-role
+
+Board switches S19 and S20 route either Type-C socket to usb_1, so only one
+is ever live and EDL needs USB0; usb_2 reaches the micro-AB socket alone.
+Making usb_2 the host therefore leaves both the PC link and EDL undisturbed.
+
+usb_2 needs usb2_vbus held on to source 5V: CONFIG_USB_CONN_GPIO is not set,
+so connector-2 binds no driver and nothing else enables the rail. The 5V is
+then permanent -- do not attach a host to USB2.
+
+usb_1 becomes otg so dwc3 registers a userspace-controllable role switch; an
+unset role-switch-default-mode still boots it as the gadget. Writing "host"
+turns the selected Type-C socket into a SuperSpeed host, at the cost of the
+PC link, and the gadget needs rebinding afterwards.
+
+refgen is held on because hardware voting for the USB2 HS PHY is broken and
+qcom_snps_hsphy_exit() would otherwise drop it; monaco-monza-som.dtsi
+carries the same override. Only reachable now that the driver is built in.
+
+Signed-off-by: Benjamin Kelenyi <benjamin@wendy.sh>
+Upstream-Status: Inappropriate [WendyOS board policy]
+---
+ arch/arm64/boot/dts/qcom/monaco-evk-common.dtsi | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/qcom/monaco-evk-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/monaco-evk-common.dtsi
+@@ -84,6 +84,7 @@
+ 		regulator-min-microvolt = <5000000>;
+ 		regulator-max-microvolt = <5000000>;
+ 		enable-active-high;
++		regulator-always-on;
+ 	};
+ 
+ 	sound {
+@@ -666,6 +667,13 @@
+ 	status = "okay";
+ };
+ 
++/* HW/FW issue prevents REFGEN hardware voting for the USB2 HS PHY, so the PHY
++ * would drop it on exit once a driver is bound. Hold it on, as the Monza SOM does.
++ */
++&refgen {
++	regulator-always-on;
++};
++
+ &remoteproc_adsp {
+ 	firmware-name = "qcom/qcs8300/adsp.mbn";
+ 
+@@ -867,7 +875,7 @@
+ };
+ 
+ &usb_1 {
+-	dr_mode = "peripheral";
++	dr_mode = "otg";
+ 
+ 	status = "okay";
+ };
+@@ -888,6 +896,8 @@
+ };
+ 
+ &usb_2 {
++	dr_mode = "host";
++
+ 	status = "okay";
+ };
+ 
+--
+2.43.0

--- a/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next/usb-gadget.cfg
+++ b/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next/usb-gadget.cfg
@@ -12,8 +12,8 @@
 # does (meta-rpi-extensions/.../usb-gadget.cfg) and removes the load-order
 # question entirely: the UDC exists before gadget-setup.service runs.
 #
-# The device tree already cooperates -- usb@a600000 declares dr_mode=peripheral
-# in monaco-evk.dtb -- so only the driver side was missing.
+# usb@a600000 is dual-role, so the UDC appears from dwc3's drd work rather than
+# inline in probe; gadget-setup.service waits for it.
 
 # Qualcomm dwc3 glue (the core CONFIG_USB_DWC3 is already =y).
 #

--- a/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next/usb-host.cfg
+++ b/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next/usb-host.cfg
@@ -1,0 +1,5 @@
+# Reference regulator for usb_2_hsphy's PLL rail. Its DT node has always been
+# there, but as a module nothing installs it, so the PHY defers forever on a
+# supply with no driver and a400000.usb -- the host port -- never probes.
+# Built in so it cannot lose a race with udev.
+CONFIG_REGULATOR_QCOM_REFGEN=y

--- a/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next_%.bbappend
+++ b/meta-qcom-extensions/recipes-kernel/linux/linux-qcom-next_%.bbappend
@@ -8,3 +8,13 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append = "${@' file://usb-gadget.cfg' if d.getVar('WENDYOS_USB_GADGET') == '1' else ''}"
+
+# The host port and its board wiring. Ungated: refgen and the USB roles have
+# nothing to do with the gadget knob. Scoped to the machine because the patch
+# rewrites monaco-evk's board dtsi.
+SRC_URI:append:iq-8275-evk = " file://usb-host.cfg \
+                               file://0001-arm64-dts-monaco-evk-host-mode-on-usb2.patch"
+
+# quilt leaves .pc/ in the shared kernel tree, which CONFIG_LOCALVERSION_AUTO
+# then reports as -dirty in the release string and every module package name.
+PATCHTOOL = "git"


### PR DESCRIPTION
USB support for IQ-8275

* enable the micro-USB port as a host by fixing the missing refgen dependency
* keep refgen enabled to prevent the USB2 HS PHY from losing its PLL rail
* make a600000 dual-role, allowing the selected Type-C port to switch to SuperSpeed (S19/S20 switches)
* keep the PC gadget link and EDL path unchanged